### PR TITLE
fix: 修复修改密码后不重启程序无法登录问题

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from ..core.config import config_manager
 from ..core.logging import logger
+from ..core.security import security_manager
 from .deps import get_current_user_flexible
 
 
@@ -92,6 +93,12 @@ async def update_config(request: Request, current_user: dict = Depends(get_curre
             # 将下划线转换为连字符，以匹配配置文件格式
             normalized_section = section.replace('_', '-')
             for key, value in items.items():
+                # 对密码进行加密再保存
+                if normalized_section == 'auth' and key == 'password':
+                    secret_key = config_manager.get('auth', 'secret_key')
+                    config_manager.set_config(normalized_section, key, security_manager.hash_password(value, secret_key))
+                    break
+
                 config_manager.set_config(normalized_section, key, value)
         
         # 处理多账号配置


### PR DESCRIPTION
- 修复修改并保存配置时,任使用原来明文保存密码的方式保存了密码,但在新版本中密码是加密的。这会导致程序如果不重启将无法使用密码登录和重启后程序误认为是版本升级触发与其相关的逻辑

修改文件:
- app/api/config.py

破坏性修改: 否
