### PR TITLE
fix: plex webhooks originalTitle 字段缺失, fixes #73

### DIFF
--- a/app/utils/data_util.py
+++ b/app/utils/data_util.py
@@ -41,11 +41,13 @@ def extract_plex_data(plex_data):
     else:
         logger.debug(f'未找到originallyAvailableAt字段，将尝试从bangumi-data获取日期信息')
 
+    original_title = plex_data["Metadata"].get("originalTitle", " ")
+
     # 重新组装数据
     return CustomItem(
         media_type=plex_data["Metadata"]["type"],
         title=plex_data["Metadata"]["grandparentTitle"],
-        ori_title=plex_data["Metadata"]["originalTitle"],
+        ori_title=original_title,
         season=plex_data["Metadata"]["parentIndex"],
         episode=plex_data["Metadata"]["index"],
         release_date=release_date,


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

若 plex 请求体包含 originalTitle 则使用该值，否则使用空格

fixes #73 