### PR TITLE
doc: 修改jellyfin webhook 版本为 18.0.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ services:
 ### Jellyfin插件
 
 1. 运行Bangumi-syncer
-2. 打开Jellyfin控制台 -> `插件` -> `目录` -> 拉到最下面找到点进`Webhook` -> 选择`8.0.0.0`版本，点击`Install`安装此插件然后 **重启服务器**
+2. 打开Jellyfin控制台 -> `插件` -> `目录` -> 拉到最下面找到点进`Webhook` -> 选择`18.0.0.0`版本，点击`Install`安装此插件然后 **重启服务器**
 ![](https://p.sda1.dev/16/be346724555f34a98b5dc16c73df794f/1.jpg)
 3. 打开Jellyfin控制台 -> `插件` -> `我的插件` -> 点进`Webhook`。`Server Url`里输入你的Jellyfin地址，点击`Add Generic Destination`
 ![](https://p.sda1.dev/16/038568513c591f785d10ee745f254966/2.jpg)


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**填写PR内容：**
# 改动点
- 修改文档中的 jellyfin webhook 版本为 18.0.0.0

# 理由
实际在使用  jellyfin: 10.11.5 时,安装 8.0.0.0 版本的 webhook 后,不会激活,切换为 18.0.0.0 后可以正常发送 webhook

