### PR TITLE
Fix: Docker 向前兼容

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ARG PUID=1000
 ARG PGID=1000
 RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser --create-home appuser
 
-# 3. 安装 util-linux 用于用户切换（包含 setpriv）
-RUN apt-get update && apt-get install -y --no-install-recommends util-linux && rm -rf /var/lib/apt/lists/*
+# 3. 安装 gosu 用于用户切换（Docker社区标准工具）
+RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
 
 # 4. 预创建目录
 RUN mkdir -p /app/config /app/logs /app/data /app/config_backups && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,9 +31,9 @@ if [ "$(id -u)" = "0" ]; then
 
     # 切换到非root用户执行后续操作
     echo "切换到用户 appuser (UID=${PUID}, GID=${PGID}) 执行应用..."
-    exec setpriv --reuid=${PUID} --regid=${PGID} --init-groups "$0" "$@"
+    exec gosu appuser "$0" "$@"
     # 注意：上面的 exec 会替换当前进程，所以下面的代码只有在没有切换时才会执行
-    # 实际上，su-exec 会执行相同的脚本，但以 appuser 身份
+    # 实际上，gosu 会执行相同的脚本，但以 appuser 身份
 fi
 
 # ============================================================================


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**填写PR内容：**
# 主要内容
- #82  
- 修复了Dockerfile中由于使用USER导致的配置文件挂载问题。问题在于原来Dockerfile创建了非root用户appuser并直接切换，当挂载宿主机目录时，容器内的appuser用户可能没有写入权限。    

# 修复方案

**核心思路**：在容器启动时动态调整用户ID和目录权限，确保与宿主机用户匹配。

## 1. 修改的 Dockerfile 关键部分

```dockerfile
# 支持通过环境变量 PUID/PGID 指定用户ID
ARG PUID=1000
ARG PGID=1000
RUN groupadd -g ${PGID} appuser && useradd -u ${PUID} -g appuser --create-home appuser

# 3. 安装 gosu 用于用户切换（Docker社区标准工具）
RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
# 移除原来的 USER appuser 指令，改由 entrypoint.sh 处理
```

## 2. 修改的 entrypoint.sh 关键逻辑
```sh
    # 默认用户ID和组ID
    PUID=${PUID:-1000}
    PGID=${PGID:-1000}

    echo "配置用户权限: UID=${PUID}, GID=${PGID}"

    # 检查并修改用户组ID（如果PGID不等于默认值）
    if [ "$(id -g appuser)" != "${PGID}" ]; then
        echo "调整用户组ID为 ${PGID}..."
        groupmod -g ${PGID} appuser
    fi

    # 检查并修改用户ID（如果PUID不等于默认值）
    if [ "$(id -u appuser)" != "${PUID}" ]; then
        echo "调整用户ID为 ${PUID}..."
        usermod -u ${PUID} appuser
    fi

    # 确保挂载目录的所有权正确（以root身份运行，可以修改目录所有权）
    echo "设置目录所有权..."
    chown -R ${PUID}:${PGID} /app/config /app/logs /app/data /app/config_backups 2>/dev/null || true

    # 切换到非root用户执行后续操作
    echo "切换到用户 appuser (UID=${PUID}, GID=${PGID}) 执行应用..."
    exec gosu appuser "$0" "$@"
    # 注意：上面的 exec 会替换当前进程，所以下面的代码只有在没有切换时才会执行
    # 实际上，gosu 会执行相同的脚本，但以 appuser 身份
```

## 3. docker-compose.yml 保持不变
```yaml
environment:
  - PUID=1000
  - PGID=1000
  - TZ=Asia/Shanghai
```

# 测试结果
- ✅ Docker 镜像构建成功
- ✅ 容器能够以指定 UID/GID 运行（测试了 UID=1000 和 UID=1001）
- ✅ 配置文件自动创建且权限正确
- ✅ 应用正常启动，日志显示运行正常
- ✅ 挂载的宿主机目录可写入

# 使用方法
- 默认情况：使用 PUID=1000 PGID=1000（大多数 Linux 系统的第一个用户）
- 自定义用户：在 docker-compose.yml 中修改 PUID 和 PGID 环境变量为宿主机用户的 UID/GID
- 兼容性：保持与原 docker-compose 配置完全兼容
