### PR TITLE
fix: 修复邮件通知配置修改时没有反显授权码导致必输校验无法通过的问题

### DIFF
--- a/app/api/notification.py
+++ b/app/api/notification.py
@@ -513,7 +513,12 @@ async def update_email(
             config.set(section_name, "smtp_port", str(email_data.smtp_port))
         if email_data.smtp_username is not None:
             config.set(section_name, "smtp_username", email_data.smtp_username)
-        if email_data.smtp_password is not None:
+        # 只有当密码不为空且不是掩码时才更新密码
+        if (
+            email_data.smtp_password is not None
+            and email_data.smtp_password.strip()
+            and email_data.smtp_password != "******"
+        ):
             config.set(section_name, "smtp_password", email_data.smtp_password)
         if email_data.smtp_use_tls is not None:
             config.set(section_name, "smtp_use_tls", str(email_data.smtp_use_tls))

--- a/templates/config.html
+++ b/templates/config.html
@@ -2324,12 +2324,11 @@ async function testWebhook(webhookId) {
                             </div>
                             <div class="col-md-6">
                                 <label for="email-smtp-password-input" class="form-label fw-semibold">
-                                    <i class="bi bi-key me-1"></i>SMTP 密码/授权码 <span class="text-danger">*</span>
+                                    <i class="bi bi-key me-1"></i>SMTP 密码/授权码 <span class="text-danger" id="email-password-required">*</span>
                                 </label>
                                 <input type="password"
                                        class="form-control"
                                        id="email-smtp-password-input"
-                                       required
                                        placeholder="授权码或密码">
                             </div>
                         </div>
@@ -2618,11 +2617,15 @@ function showAddEmailModal() {
     document.getElementById('email-smtp-port-input').value = '465';
     document.getElementById('email-smtp-username-input').value = '';
     document.getElementById('email-smtp-password-input').value = '';
+    document.getElementById('email-smtp-password-input').placeholder = '授权码或密码';
     document.getElementById('email-from-input').value = '';
     document.getElementById('email-to-input').value = '';
     document.getElementById('email-smtp-use-tls-input').checked = true;
     document.getElementById('email-subject-input').value = '';
     document.getElementById('email-template-file-input').value = '';
+    
+    // 新建时密码为必填
+    document.getElementById('email-password-required').style.display = 'inline';
 
     // 重置复选框
     const checkboxes = document.querySelectorAll('[id^="email-type-"]');
@@ -2650,7 +2653,12 @@ async function showEditEmailModal(emailId) {
                 document.getElementById('email-smtp-server-input').value = email.smtp_server;
                 document.getElementById('email-smtp-port-input').value = email.smtp_port;
                 document.getElementById('email-smtp-username-input').value = email.smtp_username;
-                document.getElementById('email-smtp-password-input').value = email.smtp_password === '******' ? '' : email.smtp_password;
+                // 保留密码掩码，用户可以选择修改或保持不变
+                document.getElementById('email-smtp-password-input').value = email.smtp_password || '';
+                // 编辑时提示用户可以不修改密码
+                document.getElementById('email-smtp-password-input').placeholder = '留空则保持原密码不变';
+                // 编辑时密码不是必填
+                document.getElementById('email-password-required').style.display = 'none';
                 document.getElementById('email-from-input').value = email.email_from;
                 document.getElementById('email-to-input').value = email.email_to;
                 document.getElementById('email-smtp-use-tls-input').checked = email.smtp_use_tls;
@@ -2680,12 +2688,13 @@ async function showEditEmailModal(emailId) {
 // 保存邮件配置
 async function saveEmailConfig() {
     const emailId = document.getElementById('email-id').value;
+    const passwordValue = document.getElementById('email-smtp-password-input').value;
+    
     const emailData = {
         enabled: document.getElementById('email-enabled-input').checked,
         smtp_server: document.getElementById('email-smtp-server-input').value,
         smtp_port: parseInt(document.getElementById('email-smtp-port-input').value),
         smtp_username: document.getElementById('email-smtp-username-input').value,
-        smtp_password: document.getElementById('email-smtp-password-input').value,
         email_from: document.getElementById('email-from-input').value,
         email_to: document.getElementById('email-to-input').value,
         smtp_use_tls: document.getElementById('email-smtp-use-tls-input').checked,
@@ -2693,10 +2702,21 @@ async function saveEmailConfig() {
         email_template_file: document.getElementById('email-template-file-input').value,
         types: Array.from(document.querySelectorAll('[id^="email-type-"]:checked')).map(cb => cb.value).join(',') || 'all'
     };
+    
+    // 只有当密码不是掩码且不为空时才添加到请求数据中
+    if (passwordValue && passwordValue !== '******') {
+        emailData.smtp_password = passwordValue;
+    }
 
     // 验证必填字段
-    if (!emailData.smtp_server || !emailData.smtp_username || !emailData.smtp_password || !emailData.email_to) {
+    if (!emailData.smtp_server || !emailData.smtp_username || !emailData.email_to) {
         showAlert('请填写所有必填字段', 'warning');
+        return;
+    }
+    
+    // 新建时必须填写密码
+    if (!emailId && !emailData.smtp_password) {
+        showAlert('请填写 SMTP 密码/授权码', 'warning');
         return;
     }
 


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
修复邮件通知配置修改时没有反显授权码导致必输校验无法通过的问题

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单

### 代码质量检查
<!-- 请在提交 PR 前完成以下检查 -->
- 已运行 `uv run ruff check .` 并修复所有问题
- 已运行 `uv run ruff format .` 格式化代码
- 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 功能测试
- 新功能已在本地测试通过
- 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
