### PR TITLE
fix(sync_service): 修复番剧ID匹配通知发送逻辑

### DIFF
--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -162,8 +162,6 @@ class SyncService:
                 )
                 return SyncResponse(status="error", message="未找到匹配的番剧")
 
-            send_notify("bangumi_id_found", item, actual_source, subject_id=subject_id)
-
             # 获取对应用户的bangumi API实例
             bgm = self._get_bangumi_api_for_user(item.user_name)
             if not bgm:
@@ -202,6 +200,9 @@ class SyncService:
                 f"bgm: 查询到 {item.title} (https://bgm.tv/subject/{bgm_se_id}) "
                 f"S{item.season:02d}E{item.episode:02d} (https://bgm.tv/ep/{bgm_ep_id})"
             )
+
+            # 发送匹配成功的通知，使用解析后的正确季度ID
+            send_notify("bangumi_id_found", item, actual_source, subject_id=bgm_se_id)
 
             # 标记为看过
             try:


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
- 修复 `bangumi_id_found` 在错误时机发送webhook; 导致如果标记的季度为2或以上时将始终收到的均为季度1

## 📋 提交前检查清单

### 代码质量检查
<!-- 请在提交 PR 前完成以下检查 -->
- 已运行 `uv run ruff check .` 并修复所有问题
- 已运行 `uv run ruff format .` 格式化代码
- 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 功能测试
- 新功能已在本地测试通过
- 现有功能未受影响

---
fix(sync_service): Fix Anime ID Matching Notification Sending Logic

问题修复：
- 移除了位于错误位置的通知发送代码
- 在正确的处理分支中添加了通知发送逻辑
- 确保通知能够携带解析后正确的季度ID（subject_id）参数

Bug Fix:
- Removed the notification sending code located at an incorrect position
- Added notification sending logic at the correct processing branch
- Ensures that the notification carries the correct, parsed season ID (subject_id) parameter