### PR TITLE
feature: 支持配置Nginx子路径反向代理

### DIFF
--- a/app/api/pages.py
+++ b/app/api/pages.py
@@ -3,13 +3,13 @@
 """
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
 
+from ..core.public_url import redirect_public
+from ..core.web_templates import get_templates
 from .deps import get_current_user_from_cookie
 
-# 设置模板引擎
-templates = Jinja2Templates(directory="templates")
+templates = get_templates()
 
 # 创建页面路由
 router = APIRouter(tags=["pages"])
@@ -18,7 +18,7 @@ router = APIRouter(tags=["pages"])
 @router.get("/", response_class=HTMLResponse)
 async def root(request: Request):
     """根路径重定向到仪表板"""
-    return RedirectResponse(url="/dashboard", status_code=302)
+    return redirect_public("/dashboard")
 
 
 @router.get("/dashboard", response_class=HTMLResponse)
@@ -26,7 +26,7 @@ async def dashboard(request: Request):
     """仪表板页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse(
         "dashboard.html", {"request": request, "user": user}
@@ -39,7 +39,7 @@ async def login_page(request: Request):
     # 如果已经登录，直接跳转到主页
     user = get_current_user_from_cookie(request)
     if user:
-        return RedirectResponse(url="/dashboard", status_code=302)
+        return redirect_public("/dashboard")
 
     return templates.TemplateResponse("login.html", {"request": request})
 
@@ -49,7 +49,7 @@ async def config_page(request: Request):
     """配置管理页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse("config.html", {"request": request, "user": user})
 
@@ -59,7 +59,7 @@ async def records_page(request: Request):
     """同步记录页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse(
         "records.html", {"request": request, "user": user}
@@ -71,7 +71,7 @@ async def mappings_page(request: Request):
     """映射管理页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse(
         "mappings.html", {"request": request, "user": user}
@@ -83,7 +83,7 @@ async def debug_page(request: Request):
     """调试工具页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse("debug.html", {"request": request, "user": user})
 
@@ -93,7 +93,7 @@ async def logs_page(request: Request):
     """日志页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse("logs.html", {"request": request, "user": user})
 
@@ -103,7 +103,7 @@ async def trakt_config_page(request: Request):
     """Trakt 配置页面"""
     user = get_current_user_from_cookie(request)
     if not user:
-        return RedirectResponse(url="/login", status_code=302)
+        return redirect_public("/login")
 
     return templates.TemplateResponse(
         "trakt/config.html", {"request": request, "user": user}

--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -3,6 +3,7 @@ Trakt.tv API 路由
 """
 
 from typing import Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import RedirectResponse
@@ -11,6 +12,7 @@ from ..api import deps
 from ..core.config import config_manager
 from ..core.database import database_manager
 from ..core.logging import logger
+from ..core.public_url import redirect_public
 from ..models.trakt import (
     TraktApiConfigUpdateRequest,
     TraktAuthRequest,
@@ -65,30 +67,31 @@ async def trakt_auth_callback(
 ) -> RedirectResponse:
     """Trakt OAuth 回调处理"""
     try:
-        # 这里需要从会话或 state 中获取用户ID
-        # 简化处理：使用默认用户ID
-        if state is not None:
-            user_id = (
-                trakt_auth_service.extract_user_id_from_state(state) or "default_user"
+        if state is None:
+            return redirect_public(
+                "/trakt/auth?status=error&message=" + quote("缺少 state 参数", safe="")
             )
 
-            callback_request = TraktCallbackRequest(code=code, state=state or "")
-            callback_response = await trakt_auth_service.handle_callback(
-                callback_request, user_id
-            )
+        user_id = trakt_auth_service.extract_user_id_from_state(state) or "default_user"
 
-            if callback_response.success:
-                # 重定向到成功页面（不需要认证）
-                return RedirectResponse(url="/trakt/auth/success")
+        callback_request = TraktCallbackRequest(code=code, state=state or "")
+        callback_response = await trakt_auth_service.handle_callback(
+            callback_request, user_id
+        )
 
-        # 重定向到失败页面
-        return RedirectResponse(
-            url=f"/trakt/auth?status=error&message={callback_response.message}"
+        if callback_response.success:
+            return redirect_public("/trakt/auth/success")
+
+        return redirect_public(
+            "/trakt/auth?status=error&message="
+            + quote(str(callback_response.message), safe="")
         )
 
     except Exception as e:
         logger.error(f"处理 Trakt 回调失败: {e}")
-        return RedirectResponse(url=f"/trakt/auth?status=error&message={str(e)}")
+        return redirect_public(
+            "/trakt/auth?status=error&message=" + quote(str(e), safe="")
+        )
 
 
 @router.get("/config", response_model=TraktConfigResponse)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -93,6 +93,7 @@ class ConfigManager:
             ("bangumi", "private"): "BANGUMI_PRIVATE",
             ("dev", "script_proxy"): "HTTP_PROXY",
             ("dev", "debug"): "DEBUG_MODE",
+            ("web", "base_path"): "APPLICATION_ROOT",
         }
 
         for (section, option), env_var in env_overrides.items():

--- a/app/core/public_url.py
+++ b/app/core/public_url.py
@@ -1,0 +1,61 @@
+"""
+对外 URL 路径前缀（子路径反向代理）工具。
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi.responses import RedirectResponse
+
+
+def normalize_public_base_path(raw: str) -> str:
+    """规范化前缀：空、无尾斜杠、以 / 开头、URL 内统一为正斜杠。"""
+    s = (raw or "").strip()
+    if not s:
+        return ""
+    s = s.replace("\\", "/")
+    while len(s) > 1 and s.endswith("/"):
+        s = s[:-1]
+    if not s.startswith("/"):
+        s = "/" + s
+    return s
+
+
+def get_public_base_path() -> str:
+    """
+    当前对外路径前缀（不含尾斜杠）。
+    优先环境变量 APPLICATION_ROOT 或 BASE_PATH，其次 config.ini [web] base_path。
+    """
+    env_raw = (
+        os.environ.get("APPLICATION_ROOT") or os.environ.get("BASE_PATH") or ""
+    ).strip()
+    if env_raw:
+        return normalize_public_base_path(env_raw)
+    try:
+        from .config import config_manager
+
+        ini = config_manager.get("web", "base_path", fallback="") or ""
+        return normalize_public_base_path(str(ini).strip())
+    except Exception:
+        return ""
+
+
+def join_public(path: str) -> str:
+    """
+    将必须以 / 开头的站内路径（可含 query）拼到公开前缀之后。
+    """
+    if not path:
+        base = get_public_base_path()
+        return base if base else "/"
+    path = path.replace("\\", "/")
+    if not path.startswith("/"):
+        path = "/" + path
+    base = get_public_base_path()
+    if not base:
+        return path
+    return base + path
+
+
+def redirect_public(path: str, status_code: int = 302) -> RedirectResponse:
+    return RedirectResponse(url=join_public(path), status_code=status_code)

--- a/app/core/web_templates.py
+++ b/app/core/web_templates.py
@@ -1,0 +1,34 @@
+"""
+全局 Jinja2 配置：子路径过滤器 p、公开前缀注入等。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.templating import Jinja2Templates
+from markupsafe import Markup
+
+from .public_url import get_public_base_path, join_public
+
+_templates: Jinja2Templates | None = None
+
+
+def _templates_dir() -> str:
+    return str(Path(__file__).resolve().parent.parent.parent / "templates")
+
+
+def get_templates() -> Jinja2Templates:
+    global _templates
+    if _templates is None:
+        _templates = Jinja2Templates(directory=_templates_dir())
+        env = _templates.env
+        env.filters["p"] = join_public
+        env.globals["get_public_base_path"] = get_public_base_path
+
+        def public_base_path_json() -> Markup:
+            return Markup(json.dumps(get_public_base_path()))
+
+        env.globals["public_base_path_json"] = public_base_path_json
+    return _templates

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,6 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 
 from version import get_version, get_version_info, get_version_name
 
@@ -23,16 +22,21 @@ from .api.sync import root_router, router as sync_router
 from .api.trakt import router as trakt_router
 from .core.config import config_manager
 from .core.logging import logger
+from .core.public_url import get_public_base_path
 from .core.startup_info import startup_info
 from .services.mapping_service import mapping_service
 from .services.trakt.scheduler import trakt_scheduler
 
-# 创建FastAPI应用
-app = FastAPI(
-    title=get_version_name(),
-    description=get_version_info()["description"],
-    version=get_version(),
-)
+# 创建FastAPI应用（root_path 便于反代子路径下 OpenAPI 等）
+_app_kw: dict = {
+    "title": get_version_name(),
+    "description": get_version_info()["description"],
+    "version": get_version(),
+}
+_rp = get_public_base_path()
+if _rp:
+    _app_kw["root_path"] = _rp
+app = FastAPI(**_app_kw)
 
 
 # 创建静态文件和模板目录
@@ -41,9 +45,6 @@ os.makedirs("templates", exist_ok=True)
 
 # 挂载静态文件
 app.mount("/static", StaticFiles(directory="static"), name="static")
-
-# 设置模板引擎
-templates = Jinja2Templates(directory="templates")
 
 # 注册路由
 app.include_router(sync_router)

--- a/config.ini
+++ b/config.ini
@@ -201,6 +201,14 @@ webhook_auth_enabled = False
 # email_template_file = 
 # types = all
 
+##########################Web / 反向代理################################
+
+[web]
+
+# 对外 URL 路径前缀（子路径反代时与 Nginx location 一致，例如 /Bangumi）。根路径部署留空。
+# 也可用环境变量 APPLICATION_ROOT 或 BASE_PATH 覆盖。
+base_path =
+
 ##########################其他设置################################
 
 [dev]

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,18 @@
 // 通用JavaScript功能
 
+/**
+ * 子路径反向代理下的站内 URL（与后端 join_public / 模板 | p 一致）
+ */
+function appUrl(path) {
+    const base =
+        typeof window.__APP_BASE_PATH__ === 'string' ? window.__APP_BASE_PATH__ : '';
+    if (!path) {
+        return base || '/';
+    }
+    const p = path.startsWith('/') ? path : '/' + path;
+    return base + p;
+}
+
 // 显示提示消息
 function showAlert(message, type = 'info', duration = 5000) {
     // 创建Toast容器（如果不存在）
@@ -201,7 +214,7 @@ class ApiClient {
             // 处理认证失败
             if (response.status === 401) {
                 // 跳转到登录页面
-                window.location.href = '/login';
+                window.location.href = appUrl('/login');
                 return;
             }
             
@@ -246,7 +259,9 @@ class ApiClient {
     }
 }
 
-const api = new ApiClient();
+const api = new ApiClient(
+    typeof window.__APP_BASE_PATH__ === 'string' ? window.__APP_BASE_PATH__ : ''
+);
 
 // 表单验证
 class FormValidator {
@@ -401,7 +416,7 @@ document.addEventListener('DOMContentLoaded', function() {
 async function logout() {
     try {
         const result = await confirmAction('确定要登出吗？', async () => {
-            const response = await fetch('/api/logout', {
+            const response = await fetch(appUrl('/api/logout'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -412,7 +427,7 @@ async function logout() {
                 showAlert('登出成功', 'success', 2000);
                 // 延迟跳转到登录页面
                 setTimeout(() => {
-                    window.location.href = '/login';
+                    window.location.href = appUrl('/login');
                 }, 1000);
             } else {
                 throw new Error('登出失败');
@@ -440,7 +455,7 @@ async function confirmAction(message, callback) {
 // 检查认证状态
 async function checkAuthStatus() {
     try {
-        const response = await fetch('/api/auth/status');
+        const response = await fetch(appUrl('/api/auth/status'));
         const result = await response.json();
         
         if (result.status === 'success' && result.data) {
@@ -459,7 +474,7 @@ async function initAuth() {
     
     // 如果未认证且不在登录页面，跳转到登录页面
     if (!authStatus.authenticated && !window.location.pathname.includes('/login')) {
-        window.location.href = '/login';
+        window.location.href = appUrl('/login');
         return false;
     }
     
@@ -482,6 +497,7 @@ window.StorageManager = StorageManager;
 window.logout = logout;
 window.checkAuthStatus = checkAuthStatus;
 window.initAuth = initAuth;
+window.appUrl = appUrl;
 
 // ========== 登录页面专用功能 ==========
 
@@ -534,7 +550,7 @@ async function handleLoginSubmit(e) {
     };
     
     try {
-        const response = await fetch('/api/login', {
+        const response = await fetch(appUrl('/api/login'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -554,7 +570,7 @@ async function handleLoginSubmit(e) {
             
             // 延迟跳转以显示成功信息
             setTimeout(() => {
-                window.location.href = '/';
+                window.location.href = appUrl('/');
             }, 1000);
         } else {
             // 登录失败
@@ -615,7 +631,7 @@ async function retrySync(recordId) {
         showAlert('正在重试同步...', 'info', 0);
         
         // 调用重试API
-        const response = await fetch(`/api/records/${recordId}/retry`, {
+        const response = await fetch(appUrl(`/api/records/${recordId}/retry`), {
             method: 'POST',
             credentials: 'include',
             headers: {

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -192,7 +192,7 @@ class TraktConfigPage {
     async loadConfig() {
         try {
             this.showLoading('connection-status', '正在检查连接状态...');
-            const response = await fetch('/api/trakt/config');
+            const response = await fetch(appUrl('/api/trakt/config'));
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
@@ -281,7 +281,7 @@ class TraktConfigPage {
     async loadSyncStatus() {
         try {
             this.showLoading('sync-status', '正在检查同步状态...');
-            const response = await fetch('/api/trakt/sync/status');
+            const response = await fetch(appUrl('/api/trakt/sync/status'));
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
@@ -335,7 +335,7 @@ class TraktConfigPage {
         try {
             this.showLoading('sync-history-body', '正在加载同步历史...');
 
-            const response = await fetch(`/api/records?limit=${this.pageSize}&offset=${(this.currentPage - 1) * this.pageSize}`);
+            const response = await fetch(appUrl(`/api/records?limit=${this.pageSize}&offset=${(this.currentPage - 1) * this.pageSize}`));
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);
@@ -461,7 +461,7 @@ class TraktConfigPage {
         };
 
         try {
-            const response = await fetch('/api/trakt/config', {
+            const response = await fetch(appUrl('/api/trakt/config'), {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
@@ -497,7 +497,7 @@ class TraktConfigPage {
         };
 
         try {
-            const response = await fetch('/api/trakt/config/api', {
+            const response = await fetch(appUrl('/api/trakt/config/api'), {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
@@ -526,7 +526,7 @@ class TraktConfigPage {
     async triggerManualSync(fullSync = false) {
         try {
             // 获取用户ID（从配置中）
-            const configResponse = await fetch('/api/trakt/config');
+            const configResponse = await fetch(appUrl('/api/trakt/config'));
             if (!configResponse.ok) {
                 throw new Error('无法获取用户配置');
             }
@@ -534,7 +534,7 @@ class TraktConfigPage {
             const config = await configResponse.json();
             const user_id = config.user_id || 'default_user';
 
-            const response = await fetch('/api/trakt/sync/manual', {
+            const response = await fetch(appUrl('/api/trakt/sync/manual'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -573,7 +573,7 @@ class TraktConfigPage {
         }
 
         try {
-            const response = await fetch('/api/trakt/disconnect', {
+            const response = await fetch(appUrl('/api/trakt/disconnect'), {
                 method: 'DELETE'
             });
 
@@ -627,12 +627,12 @@ class TraktConfigPage {
             this.showAuthStep(2);
 
             // 获取用户ID（从配置中或使用默认）
-            const configResponse = await fetch('/api/trakt/config');
+            const configResponse = await fetch(appUrl('/api/trakt/config'));
             const config = await configResponse.json();
             const user_id = config.user_id || 'default_user';
 
             // 初始化授权
-            const response = await fetch('/api/trakt/auth/init', {
+            const response = await fetch(appUrl('/api/trakt/auth/init'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -804,7 +804,7 @@ class TraktConfigPage {
      */
     async checkAuthStatus() {
         try {
-            const response = await fetch('/api/trakt/config');
+            const response = await fetch(appUrl('/api/trakt/config'));
             if (!response.ok) {
                 return false;
             }

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,21 +2,22 @@
 <html lang="zh-CN">
     <head>
         <meta charset="UTF-8">
+        <script>window.__APP_BASE_PATH__ = {{ public_base_path_json() }};</script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>
             {% block title %}Bangumi Syncer{% endblock %}
         </title>
-        <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/static/css/bootstrap-icons.css" rel="stylesheet">
-        <link href="/static/css/style.css" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap.min.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap-icons.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/style.css' | p }}" rel="stylesheet">
         {% block head %}{% endblock %}
     </head>
     <body class="bg-light">
         <!-- 移动端顶部导航栏 -->
         <nav class="navbar navbar-expand-md navbar-light bg-white border-bottom d-md-none fixed-top">
             <div class="container-fluid">
-                <a class="navbar-brand d-flex align-items-center" href="/">
-                    <img src="/static/logo.png"
+                <a class="navbar-brand d-flex align-items-center" href="{{ '/' | p }}">
+                    <img src="{{ '/static/logo.png' | p }}"
                          alt="Bangumi-Syncer"
                          style="height: 32px;
                                 width: auto;
@@ -32,43 +33,43 @@
                     <ul class="navbar-nav me-auto">
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/' %}active{% endif %}"
-                               href="/">
+                               href="{{ '/' | p }}">
                                 <i class="bi bi-house-door me-2"></i>仪表板
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/config' %}active{% endif %}"
-                               href="/config">
+                               href="{{ '/config' | p }}">
                                 <i class="bi bi-gear me-2"></i>配置管理
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/records' %}active{% endif %}"
-                               href="/records">
+                               href="{{ '/records' | p }}">
                                 <i class="bi bi-journal-text me-2"></i>同步记录
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/mappings' %}active{% endif %}"
-                               href="/mappings">
+                               href="{{ '/mappings' | p }}">
                                 <i class="bi bi-diagram-3 me-2"></i>映射管理
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/debug' %}active{% endif %}"
-                               href="/debug">
+                               href="{{ '/debug' | p }}">
                                 <i class="bi bi-bug me-2"></i>调试工具
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/logs' %}active{% endif %}"
-                               href="/logs">
+                               href="{{ '/logs' | p }}">
                                 <i class="bi bi-file-text me-2"></i>日志管理
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link {% if request.url.path == '/trakt/config' %}active{% endif %}"
-                               href="/trakt/config">
+                               href="{{ '/trakt/config' | p }}">
                                 <i class="bi bi-tv me-2"></i>Trakt 同步
                             </a>
                         </li>
@@ -105,7 +106,7 @@
                 <nav class="col-md-3 col-lg-2 d-none d-md-block sidebar">
                     <div class="position-sticky pt-4">
                         <div class="text-center mb-4 px-3">
-                            <img src="/static/logo.png"
+                            <img src="{{ '/static/logo.png' | p }}"
                                  alt="Bangumi-Syncer"
                                  style="width: 175px;
                                         height: 100px;
@@ -114,49 +115,49 @@
                         <ul class="nav flex-column px-2">
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/' %}active{% endif %}"
-                                   href="/">
+                                   href="{{ '/' | p }}">
                                     <i class="bi bi-house-door me-2"></i>
                                     仪表板
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/config' %}active{% endif %}"
-                                   href="/config">
+                                   href="{{ '/config' | p }}">
                                     <i class="bi bi-gear me-2"></i>
                                     配置管理
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/records' %}active{% endif %}"
-                                   href="/records">
+                                   href="{{ '/records' | p }}">
                                     <i class="bi bi-journal-text me-2"></i>
                                     同步记录
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/mappings' %}active{% endif %}"
-                                   href="/mappings">
+                                   href="{{ '/mappings' | p }}">
                                     <i class="bi bi-diagram-3 me-2"></i>
                                     映射管理
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/debug' %}active{% endif %}"
-                                   href="/debug">
+                                   href="{{ '/debug' | p }}">
                                     <i class="bi bi-bug me-2"></i>
                                     调试工具
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/logs' %}active{% endif %}"
-                                   href="/logs">
+                                   href="{{ '/logs' | p }}">
                                     <i class="bi bi-file-text me-2"></i>
                                     日志管理
                                 </a>
                             </li>
                             <li class="nav-item mb-1">
                                 <a class="nav-link {% if request.url.path == '/trakt/config' %}active{% endif %}"
-                                   href="/trakt/config">
+                                   href="{{ '/trakt/config' | p }}">
                                     <i class="bi bi-tv me-2"></i>
                                     Trakt 同步
                                 </a>
@@ -199,9 +200,9 @@
         <div class="toast-container position-fixed top-0 end-0 p-3">
             <!-- Toast通知将在这里动态添加 -->
         </div>
-        <script src="/static/js/bootstrap.bundle.min.js"></script>
-        <script src="/static/js/chart.js"></script>
-        <script src="/static/js/app.js"></script>
+        <script src="{{ '/static/js/bootstrap.bundle.min.js' | p }}"></script>
+        <script src="{{ '/static/js/chart.js' | p }}"></script>
+        <script src="{{ '/static/js/app.js' | p }}"></script>
         {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/templates/config.html
+++ b/templates/config.html
@@ -233,6 +233,20 @@
                     <div class="card-body">
                         <div class="row g-3">
                             <div class="col-12">
+                                <label for="web-base-path" class="form-label fw-semibold">
+                                    <i class="bi bi-link-45deg me-1 text-primary"></i>Web 对外路径前缀（子路径反代）
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="部署在反向代理子路径下时才需要填写，例如 /Bangumi，须与 Nginx location 一致；根路径访问请留空。修改后需要重启服务才生效。"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="web-base-path"
+                                       name="web.base_path"
+                                       placeholder="除非你知道自己在做什么，否则留空，修改后需要重启服务才生效"
+                                       autocomplete="off">
+                            </div>
+                            <div class="col-12">
                                 <label for="script-proxy" class="form-label fw-semibold">
                                     <i class="bi bi-globe me-1 text-info"></i>HTTP代理
                                     <i class="bi bi-question-circle ms-1 text-muted"
@@ -730,7 +744,7 @@
                         <br>
                         提供更丰富的调试功能和更好的用户体验。
                     </p>
-                    <a href="/debug" class="btn btn-info px-4">
+                    <a href="{{ '/debug' | p }}" class="btn btn-info px-4">
                         <i class="bi bi-arrow-right-circle me-2"></i>前往调试工具
                     </a>
                 </div>
@@ -956,7 +970,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 async function loadConfig(showToast = true) {
     try {
-        const response = await fetch('/api/config', {
+        const response = await fetch(appUrl('/api/config'), {
             method: 'GET',
             credentials: 'include',  // 包含Cookie认证信息
             headers: {
@@ -966,7 +980,7 @@ async function loadConfig(showToast = true) {
         
         if (response.status === 401) {
             // 认证失败，跳转到登录页面
-            window.location.href = '/login';
+            window.location.href = appUrl('/login');
             return;
         }
         
@@ -1000,6 +1014,10 @@ function populateForm(config) {
     document.getElementById('single-username').value = config.sync.single_username || '';
     document.getElementById('blocked-keywords').value = config.sync.blocked_keywords || '';
     
+    const webBase = document.getElementById('web-base-path');
+    if (webBase) {
+        webBase.value = (config.web && config.web.base_path) ? String(config.web.base_path) : '';
+    }
     document.getElementById('script-proxy').value = config.dev.script_proxy || '';
     document.getElementById('ssl-verify').checked = Boolean(config.dev.ssl_verify);
     document.getElementById('debug-mode').checked = Boolean(config.dev.debug);
@@ -1160,6 +1178,9 @@ async function saveConfig() {
                 single_username: document.getElementById('single-username').value,
                 blocked_keywords: document.getElementById('blocked-keywords').value
             },
+            web: {
+                base_path: (document.getElementById('web-base-path') && document.getElementById('web-base-path').value.trim()) || ''
+            },
             dev: {
                 script_proxy: document.getElementById('script-proxy').value,
                 ssl_verify: document.getElementById('ssl-verify').checked,
@@ -1217,7 +1238,7 @@ async function saveConfig() {
             configData.multi_accounts = multiAccounts;
         }
         
-        const response = await fetch('/api/config', {
+        const response = await fetch(appUrl('/api/config'), {
             method: 'POST',
             credentials: 'include',  // 包含Cookie认证信息
             headers: {
@@ -1236,11 +1257,11 @@ async function saveConfig() {
                 setTimeout(() => {
                     if (confirm('您已修改了登录密码，需要重新登录。是否现在跳转到登录页面？')) {
                         // 先登出，然后跳转到登录页面
-                        fetch('/api/logout', {
+                        fetch(appUrl('/api/logout'), {
                             method: 'POST',
                             credentials: 'include'
                         }).then(() => {
-                            window.location.href = '/login';
+                            window.location.href = appUrl('/login');
                         });
                     }
                 }, 1000);
@@ -1258,7 +1279,7 @@ async function saveConfig() {
 // 备份配置
 async function backupConfig() {
     try {
-        const response = await fetch('/api/config/backup', {
+        const response = await fetch(appUrl('/api/config/backup'), {
             method: 'POST',
             credentials: 'include',  // 包含Cookie认证信息
             headers: {
@@ -1318,7 +1339,7 @@ async function showRestoreModal() {
 // 加载备份文件列表
 async function loadBackupFiles() {
     try {
-        const response = await fetch('/api/config/backups', {
+        const response = await fetch(appUrl('/api/config/backups'), {
             credentials: 'include'
         });
         const data = await response.json();
@@ -1377,7 +1398,7 @@ async function selectBackupFile(filename) {
     event.target.closest('.list-group-item').classList.add('active');
     
     // 找到对应的backup对象
-    const response = await fetch('/api/config/backups', {
+    const response = await fetch(appUrl('/api/config/backups'), {
         credentials: 'include'
     });
     const data = await response.json();
@@ -1388,7 +1409,7 @@ async function selectBackupFile(filename) {
     
     // 预览配置内容
     try {
-        const response = await fetch(`/api/config/backup/${filename}`, {
+        const response = await fetch(appUrl(`/api/config/backup/${filename}`), {
             credentials: 'include'
         });
         const data = await response.json();
@@ -1424,7 +1445,7 @@ async function deleteBackupFile(filename, event) {
     }
     
     try {
-        const response = await fetch(`/api/config/backup/${filename}`, {
+        const response = await fetch(appUrl(`/api/config/backup/${filename}`), {
             method: 'DELETE',
             credentials: 'include'
         });
@@ -1461,7 +1482,7 @@ async function confirmRestore() {
     }
     
     try {
-        const response = await fetch(`/api/config/restore/${selectedBackupFile.filename}`, {
+        const response = await fetch(appUrl(`/api/config/restore/${selectedBackupFile.filename}`), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -1601,7 +1622,7 @@ function detectPortFromInput(event) {
             `;
             
             try {
-                const response = await fetch('/api/proxy/test-host', {
+                const response = await fetch(appUrl('/api/proxy/test-host'), {
                     method: 'POST',
                     credentials: 'include',
                     headers: {
@@ -1734,7 +1755,7 @@ async function loadProxySuggestions() {
     
     try {
         // 获取代理建议
-        const response = await fetch(`/api/proxy/suggestions?port=${port}`, {
+        const response = await fetch(appUrl(`/api/proxy/suggestions?port=${port}`), {
             method: 'GET',
             credentials: 'include',
             headers: {
@@ -1851,7 +1872,7 @@ async function testProxy(address, event) {
     button.innerHTML = '<div class="spinner-border spinner-border-sm" role="status"></div>';
     
     try {
-        const response = await fetch('/api/proxy/test', {
+        const response = await fetch(appUrl('/api/proxy/test'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -1893,7 +1914,7 @@ async function confirmCleanup() {
     }
     
     try {
-        const response = await fetch('/api/config/backups/cleanup', {
+        const response = await fetch(appUrl('/api/config/backups/cleanup'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -1925,7 +1946,7 @@ async function confirmCleanup() {
 // 加载 Webhook 配置列表
 async function loadWebhookConfigs() {
     try {
-        const response = await fetch('/api/notification/webhooks', {
+        const response = await fetch(appUrl('/api/notification/webhooks'), {
             credentials: 'include'
         });
 
@@ -2023,7 +2044,7 @@ function showAddWebhookModal() {
 // 显示编辑 Webhook 模态框
 async function showEditWebhookModal(webhookId) {
     try {
-        const response = await fetch('/api/notification/webhooks', {
+        const response = await fetch(appUrl('/api/notification/webhooks'), {
             credentials: 'include'
         });
 
@@ -2073,7 +2094,7 @@ async function saveWebhookConfig() {
         let response;
         if (webhookId) {
             // 更新
-            response = await fetch(`/api/notification/webhooks/${webhookId}`, {
+            response = await fetch(appUrl(`/api/notification/webhooks/${webhookId}`), {
                 method: 'PUT',
                 credentials: 'include',
                 headers: {
@@ -2083,7 +2104,7 @@ async function saveWebhookConfig() {
             });
         } else {
             // 创建
-            response = await fetch('/api/notification/webhooks', {
+            response = await fetch(appUrl('/api/notification/webhooks'), {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
@@ -2114,7 +2135,7 @@ async function saveWebhookConfig() {
 // 切换 Webhook 启用状态
 async function toggleWebhookEnabled(webhookId, enabled) {
     try {
-        const response = await fetch(`/api/notification/webhooks/${webhookId}`, {
+        const response = await fetch(appUrl(`/api/notification/webhooks/${webhookId}`), {
             method: 'PUT',
             credentials: 'include',
             headers: {
@@ -2155,7 +2176,7 @@ async function deleteWebhookConfig() {
     const webhookId = document.getElementById('delete-webhook-id').value;
 
     try {
-        const response = await fetch(`/api/notification/webhooks/${webhookId}`, {
+        const response = await fetch(appUrl(`/api/notification/webhooks/${webhookId}`), {
             method: 'DELETE',
             credentials: 'include'
         });
@@ -2186,7 +2207,7 @@ async function testWebhook(webhookId) {
     button.innerHTML = '<i class="bi bi-hourglass-split"></i> 测试中...';
 
     try {
-        const response = await fetch(`/api/notification/webhooks/${webhookId}/test`, {
+        const response = await fetch(appUrl(`/api/notification/webhooks/${webhookId}/test`), {
             method: 'POST',
             credentials: 'include'
         });
@@ -2219,7 +2240,7 @@ async function refreshWebhookKey() {
     }
 
     try {
-        const response = await fetch('/api/config/auth/refresh-webhook-key', {
+        const response = await fetch(appUrl('/api/config/auth/refresh-webhook-key'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -2678,7 +2699,7 @@ function copyWebhookKey() {
 // 加载邮件配置列表
 async function loadEmailConfigs() {
     try {
-        const response = await fetch('/api/notification/emails', {
+        const response = await fetch(appUrl('/api/notification/emails'), {
             credentials: 'include'
         });
 
@@ -2791,7 +2812,7 @@ function showAddEmailModal() {
 // 显示编辑邮件配置模态框
 async function showEditEmailModal(emailId) {
     try {
-        const response = await fetch('/api/notification/emails', {
+        const response = await fetch(appUrl('/api/notification/emails'), {
             credentials: 'include'
         });
 
@@ -2876,14 +2897,14 @@ async function saveEmailConfig() {
     try {
         let response;
         if (emailId) {
-            response = await fetch(`/api/notification/emails/${emailId}`, {
+            response = await fetch(appUrl(`/api/notification/emails/${emailId}`), {
                 method: 'PUT',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(emailData)
             });
         } else {
-            response = await fetch('/api/notification/emails', {
+            response = await fetch(appUrl('/api/notification/emails'), {
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
@@ -2909,7 +2930,7 @@ async function saveEmailConfig() {
 // 切换邮件配置启用状态
 async function toggleEmailEnabled(emailId, enabled) {
     try {
-        const response = await fetch(`/api/notification/emails/${emailId}`, {
+        const response = await fetch(appUrl(`/api/notification/emails/${emailId}`), {
             method: 'PUT',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
@@ -2941,7 +2962,7 @@ async function deleteEmailConfig() {
     const emailId = document.getElementById('delete-email-id').value;
 
     try {
-        const response = await fetch(`/api/notification/emails/${emailId}`, {
+        const response = await fetch(appUrl(`/api/notification/emails/${emailId}`), {
             method: 'DELETE',
             credentials: 'include'
         });
@@ -2969,7 +2990,7 @@ async function testEmail(emailId) {
     button.innerHTML = '<i class="bi bi-hourglass-split"></i> 测试中...';
 
     try {
-        const response = await fetch(`/api/notification/emails/${emailId}/test`, {
+        const response = await fetch(appUrl(`/api/notification/emails/${emailId}/test`), {
             method: 'POST',
             credentials: 'include'
         });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
 async function loadDashboardData() {
     try {
         // 加载统计数据
-        const statsResponse = await fetch('/api/stats', {
+        const statsResponse = await fetch(appUrl('/api/stats'), {
             credentials: 'include'
         });
         const statsData = await statsResponse.json();
@@ -163,7 +163,7 @@ async function loadDashboardData() {
         }
         
         // 加载最近记录
-        const recordsResponse = await fetch('/api/records?limit=10', {
+        const recordsResponse = await fetch(appUrl('/api/records?limit=10'), {
             credentials: 'include'
         });
         const recordsData = await recordsResponse.json();

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -304,7 +304,7 @@ async function testSync() {
         
         const startTime = Date.now();
         
-        const response = await fetch('/api/test-sync?async_mode=false', {
+        const response = await fetch(appUrl('/api/test-sync?async_mode=false'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -451,7 +451,7 @@ async function diagnoseBangumiNetwork() {
     `;
     
     try {
-        const response = await fetch('/api/network/diagnose', {
+        const response = await fetch(appUrl('/api/network/diagnose'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -761,7 +761,7 @@ async function testHostConnectivity() {
     `;
     
     try {
-        const response = await fetch('/api/proxy/test-host', {
+        const response = await fetch(appUrl('/api/proxy/test-host'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -911,7 +911,7 @@ async function testProxy(address, event) {
     button.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>测试中';
     
     try {
-        const response = await fetch('/api/proxy/test', {
+        const response = await fetch(appUrl('/api/proxy/test'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -1010,7 +1010,7 @@ async function testNotificationByType(type, btnId, resultDivId) {
     `;
     
     try {
-        const response = await fetch('/api/notification/test', {
+        const response = await fetch(appUrl('/api/notification/test'), {
             method: 'POST',
             credentials: 'include',
             headers: {

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,11 +2,12 @@
 <html lang="zh-CN">
     <head>
         <meta charset="UTF-8">
+        <script>window.__APP_BASE_PATH__ = {{ public_base_path_json() }};</script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>登录 - Bangumi-Syncer</title>
-        <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/static/css/bootstrap-icons.css" rel="stylesheet">
-        <link href="/static/css/style.css" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap.min.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap-icons.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/style.css' | p }}" rel="stylesheet">
     </head>
     <body class="bg-light">
         <div class="container-fluid vh-100 d-flex align-items-center justify-content-center px-3">
@@ -16,7 +17,7 @@
                         <div class="card-body p-4">
                             <!-- Logo 和标题 -->
                             <div class="text-center mb-4">
-                                <img src="/static/logo.png"
+                                <img src="{{ '/static/logo.png' | p }}"
                                      alt="Bangumi-Syncer"
                                      class="login-logo mb-3 d-block mx-auto">
                                 <p class="text-muted mb-0">请登录以访问管理界面</p>
@@ -64,7 +65,7 @@
                 </div>
             </div>
         </div>
-        <script src="/static/js/bootstrap.bundle.min.js"></script>
-        <script src="/static/js/app.js"></script>
+        <script src="{{ '/static/js/bootstrap.bundle.min.js' | p }}"></script>
+        <script src="{{ '/static/js/app.js' | p }}"></script>
     </body>
 </html>

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -197,7 +197,7 @@ function stopAutoRefresh() {
 
 async function loadLogs() {
     try {
-        const response = await fetch('/api/logs', {
+        const response = await fetch(appUrl('/api/logs'), {
             credentials: 'include'
         });
         const data = await response.json();
@@ -251,7 +251,7 @@ async function applyLogFilter() {
             limit: limit
         });
         
-        const response = await fetch(`/api/logs?${params}`);
+        const response = await fetch(appUrl(`/api/logs?${params}`));
         const data = await response.json();
         
         if (data.status === 'success') {
@@ -273,7 +273,7 @@ async function confirmClearLogs() {
     const createBackup = document.getElementById('backup-before-clear').checked;
     
     try {
-        const response = await fetch('/api/logs/clear', {
+        const response = await fetch(appUrl('/api/logs/clear'), {
             method: 'POST',
             credentials: 'include',
             headers: {

--- a/templates/mappings.html
+++ b/templates/mappings.html
@@ -210,7 +210,7 @@ async function loadMappings() {
     showLoading(true);
     
     try {
-        const response = await fetch('/api/mappings', {
+        const response = await fetch(appUrl('/api/mappings'), {
             credentials: 'include'
         });
         const data = await response.json();
@@ -326,7 +326,7 @@ async function saveMapping() {
         
         newMappings[title] = id;
         
-        const response = await fetch('/api/mappings', {
+        const response = await fetch(appUrl('/api/mappings'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -362,7 +362,7 @@ async function confirmDelete() {
     const title = deleteModal._deleteTitle;
     
     try {
-        const response = await fetch(`/api/mappings/${encodeURIComponent(title)}`, {
+        const response = await fetch(appUrl(`/api/mappings/${encodeURIComponent(title)}`), {
             method: 'DELETE',
             credentials: 'include'
         });
@@ -419,7 +419,7 @@ async function importMappings() {
             newMappings[title] = id;
         }
         
-        const response = await fetch('/api/mappings', {
+        const response = await fetch(appUrl('/api/mappings'), {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -471,7 +471,7 @@ async function clearAllMappings() {
     }
     
     try {
-        const response = await fetch('/api/mappings', {
+        const response = await fetch(appUrl('/api/mappings'), {
             method: 'POST',
             credentials: 'include',
             headers: {

--- a/templates/records.html
+++ b/templates/records.html
@@ -151,7 +151,7 @@ async function loadRecords(page = 1, limit = 50) {
             ...currentFilters
         });
         
-        const response = await fetch(`/api/records?${params}`);
+        const response = await fetch(appUrl(`/api/records?${params}`));
         const data = await response.json();
         
         if (data.status === 'success') {
@@ -361,7 +361,7 @@ function clearFilters() {
 async function showRecordDetail(recordId) {
     try {
         // 从API获取完整的记录数据
-        const response = await fetch(`/api/records/${recordId}`, {
+        const response = await fetch(appUrl(`/api/records/${recordId}`), {
             method: 'GET',
             credentials: 'include'
         });

--- a/templates/trakt/auth_error.html
+++ b/templates/trakt/auth_error.html
@@ -2,10 +2,11 @@
 <html lang="zh-CN">
     <head>
         <meta charset="UTF-8">
+        <script>window.__APP_BASE_PATH__ = {{ public_base_path_json() }};</script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Trakt 授权失败 - Bangumi Syncer</title>
-        <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/static/css/bootstrap-icons.css" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap.min.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap-icons.css' | p }}" rel="stylesheet">
         <style>
         body {
             background-color: #f8f9fa;

--- a/templates/trakt/auth_success.html
+++ b/templates/trakt/auth_success.html
@@ -2,10 +2,11 @@
 <html lang="zh-CN">
     <head>
         <meta charset="UTF-8">
+        <script>window.__APP_BASE_PATH__ = {{ public_base_path_json() }};</script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Trakt 授权成功 - Bangumi Syncer</title>
-        <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/static/css/bootstrap-icons.css" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap.min.css' | p }}" rel="stylesheet">
+        <link href="{{ '/static/css/bootstrap-icons.css' | p }}" rel="stylesheet">
         <style>
         body {
             background-color: #f8f9fa;

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -308,5 +308,5 @@
 {% endblock %}
 {% block scripts %}
     {{ super() }}
-    <script src="/static/js/trakt/config.js"></script>
+    <script src="{{ '/static/js/trakt/config.js' | p }}"></script>
 {% endblock %}

--- a/tests/core/test_public_url.py
+++ b/tests/core/test_public_url.py
@@ -1,0 +1,35 @@
+"""public_url 子路径前缀工具测试"""
+
+from app.core import public_url as pu
+
+
+def test_normalize_public_base_path_empty():
+    assert pu.normalize_public_base_path("") == ""
+    assert pu.normalize_public_base_path("   ") == ""
+
+
+def test_normalize_public_base_path_slash_and_backslash():
+    assert pu.normalize_public_base_path("/Bangumi") == "/Bangumi"
+    assert pu.normalize_public_base_path("/Bangumi/") == "/Bangumi"
+    assert pu.normalize_public_base_path("Bangumi") == "/Bangumi"
+    assert pu.normalize_public_base_path("\\Bangumi\\") == "/Bangumi"
+
+
+def test_join_public_no_prefix(monkeypatch):
+    monkeypatch.setattr("app.core.public_url.get_public_base_path", lambda: "")
+    assert pu.join_public("/api/foo") == "/api/foo"
+    assert pu.join_public("/static/x.css") == "/static/x.css"
+
+
+def test_join_public_with_prefix(monkeypatch):
+    monkeypatch.setattr("app.core.public_url.get_public_base_path", lambda: "/Bangumi")
+    assert pu.join_public("/api/foo") == "/Bangumi/api/foo"
+    assert pu.join_public("/trakt/auth?a=b") == "/Bangumi/trakt/auth?a=b"
+
+
+def test_get_public_base_path_env_priority(monkeypatch):
+    monkeypatch.setenv("APPLICATION_ROOT", "/Proxy")
+    assert pu.get_public_base_path() == "/Proxy"
+    monkeypatch.delenv("APPLICATION_ROOT", raising=False)
+    monkeypatch.setenv("BASE_PATH", "/FromBase")
+    assert pu.get_public_base_path() == "/FromBase"


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
✨ 新功能 (feature)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
- **子路径反向代理**：新增 `get_public_base_path` / `join_public` / `redirect_public` 与 Jinja 过滤器 `p`，模板与静态资源、内联 `fetch`、JS 中统一使用带前缀 URL；`FastAPI(root_path=…)` 在配置了前缀时生效。
- **配置**：`config.ini` 增加 `[web] base_path`；支持环境变量 `APPLICATION_ROOT`（及 `BASE_PATH`）覆盖；配置页「高级配置」增加 Web 对外路径前缀输入并随 `POST /api/config` 保存。
- **测试**：补充 `public_url` 单测。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
Closes #107 

## 📋 提交前检查清单

### 代码质量检查
<!-- 请在提交 PR 前完成以下检查 -->
- 已运行 `uv run ruff check .` 并修复所有问题
- 已运行 `uv run ruff format .` 格式化代码
- 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 功能测试
- 新功能已在本地测试通过
- 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
