### PR TITLE
feature: 支持飞牛影视定时同步

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [方式四：Emby通知](#Emby通知)
   - [方式五：Jellyfin Webhook插件](#Jellyfin插件)
   - [方式六：Trakt.tv定时同步](#trakttv定时同步)
+  - [方式七：飞牛影视](#飞牛影视)
 - [📖 计划](#-计划)
 - [😘 贡献](#-贡献)
 - [👏 鸣谢](#-鸣谢)
@@ -44,6 +45,7 @@
 - **全流程在线配置**：配置项均可通过WEBUI修改生效，无需手改配置文件。
 - **多播放源接入**：内置 Plex / Emby / Jellyfin 等常见接入方式，并支持自定义 Webhook，将「看完一集」自动转为 Bangumi 打格子。
 - **Trakt.tv 同步**：支持按计划从 Trakt 拉取观看记录并写回 Bangumi，便于跨平台补全进度。
+- **飞牛影视同步**（可选）：只读读取飞牛 NAS 上 `trimmedia.db` 的观看进度，达到「已看完」或设定进度阈值后，走与 Webhook 相同的 Bangumi 匹配与打格逻辑；默认关闭，在「配置管理」中开启。
 - **多用户支持**：可按媒体服务器用户名路由到不同 Bangumi 账号；仪表板可按用户维度查看同步分布。
 - **映射与排障**：支持自定义指定id以处理自动匹配困难的条目；内置调试工具和日志管理便于定位失败原因与审计历史。
 - **安全与告警**：可选 Web 登录与会话、失败锁定等策略；同步时支持 Webhook / 邮件通知以适应各种场景。
@@ -92,6 +94,8 @@ services:
       - /docker/bangumi-syncer/config:/app/config
       - /docker/bangumi-syncer/logs:/app/logs
       - /docker/bangumi-syncer/data:/app/data
+      # 以下可选：仅在使用「飞牛影视」同步时挂载飞牛 trimmedia.db（只读）。不用飞牛则不要加。
+      # - /usr/local/apps/@appdata/trim.media/database:/app/data/feiniu-db:ro
     restart: unless-stopped
     environment:
       - PUID=1000
@@ -365,6 +369,28 @@ services:
 - 目前仅支持剧集（Episode）类型的观看历史，电影记录会被跳过
 - 增量同步基于最后同步时间，只获取新记录
 
+### 飞牛影视
+
+通过定时任务**只读**挂载其 SQLite 库，按配置间隔扫描「已看完」或达到进度阈值的单集，并提交到 Bangumi 同步。
+
+1. **准备**
+   - 在飞牛 NAS 上定位数据库文件，常见路径为：`/usr/local/apps/@appdata/trim.media/database/trimmedia.db`（以实际系统为准）。
+   - **Docker Compose**：飞牛卷挂载**仅在你启用飞牛同步时才需要**；不使用时不必挂载。请将目录或单个库文件**只读**映射进容器，并在「配置管理」里填写容器内路径（示例见上文 `docker-compose` 注释）。推荐挂到 `/app/data/feiniu-db:ro`。
+
+2. **在 WebUI「配置管理」中设置**
+   - 在 **通知配置** 区块下方找到 **飞牛影视**。
+   - 勾选 **启用飞牛同步** 并保存后，会以**保存时刻**为同步起点：只处理此后在飞牛库中有更新的观看记录，**不会**把启用前的历史存量一次性推到 Bangumi。再次关闭飞牛并保存会清除该起点；再次启用会重新从当前时刻起算。
+   - 填写 **数据库路径**（容器内路径，例如 `/app/data/feiniu-db/trimmedia.db`）。
+   - **视为看完的最低进度**：默认 85%，与飞牛「标记看完」类似，进度达到该百分比即参与同步。
+   - **飞牛用户**：填 `all` 或某一用户的 `guid`（可在已登录 Web 的情况下请求 `/api/feiniu/users` 查看列表）。
+   - **时间范围**：在起点水位之上，可再限制只处理最近一段时间内的播放更新。
+   - **定时 Cron**：默认每 15 分钟 `*/15 * * * *`。
+   - 保存配置后，飞牛定时任务会随配置热更新。
+
+3. **在 WebUI「调试工具」中手动同步测试（可选）**
+   - 在 **调试工具** 中找到 **飞牛同步测试**。
+   - 在飞牛端播放完成一集新的番剧，点击 **立即触发飞牛同步**。
+
 ## 📖 计划
 ✅ 支持自定义Webhook同步标记
 
@@ -377,8 +403,6 @@ services:
 ✅ 适配Emby通知
 
 ✅ 适配Jellyfin（需要jellyfin-plugin-webhook插件）
-
-✅ 支持Trakt.tv定时同步
 
 ✅ 支持通过 bangumi-data 匹配番剧 ID，减少 API 请求
 
@@ -396,7 +420,11 @@ services:
 
 ✅ 配置备份和恢复
 
-✅ 同步错误通知（Webhook/邮件）
+✅ 同步触发通知（Webhook/邮件）
+
+✅ 支持Trakt.tv定时同步
+
+✅ 支持飞牛影视定时同步
 
 ⬜️ ……
 
@@ -410,6 +438,7 @@ services:
 
 - [kjtsune/embyToLocalPlayer](https://github.com/kjtsune/embyToLocalPlayer)
 - [bangumi-data/bangumi-data](https://github.com/bangumi-data/bangumi-data)
+- [wabisabi525/fn-bangumi-sync](https://github.com/wabisabi525/fn-bangumi-sync)
 
 ## 📄 许可
 

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -11,6 +11,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..core.config import config_manager
+from ..core.database import database_manager
 from ..core.logging import logger
 from ..core.security import security_manager
 from .deps import get_current_user_flexible
@@ -108,6 +109,10 @@ async def update_config(
     try:
         data = await request.json()
 
+        old_feiniu_enabled = bool(
+            config_manager.get_feiniu_config().get("enabled", False)
+        )
+
         # 处理多账号配置
         multi_accounts = data.pop("multi_accounts", None)
 
@@ -149,6 +154,24 @@ async def update_config(
 
         # 保存配置
         config_manager.save_config()
+
+        new_feiniu_enabled = bool(
+            config_manager.get_feiniu_config().get("enabled", False)
+        )
+        if old_feiniu_enabled != new_feiniu_enabled:
+            if new_feiniu_enabled:
+                database_manager.set_feiniu_min_update_watermark_now()
+                logger.info("飞牛已启用：同步起点已设为当前时刻（不追溯历史观看记录）")
+            else:
+                database_manager.clear_feiniu_min_update_watermark()
+                logger.info("飞牛已关闭：已清除同步起点水位")
+
+        try:
+            from ..services.feiniu.scheduler import feiniu_scheduler
+
+            await feiniu_scheduler.apply_config_after_save()
+        except Exception as ex:
+            logger.debug("飞牛调度器随配置更新: %s", ex)
 
         # 如果密码被更新，需要重新初始化安全管理器以确保运行时状态一致
         if password_updated:

--- a/app/api/feiniu.py
+++ b/app/api/feiniu.py
@@ -1,0 +1,91 @@
+"""飞牛影视 trimmedia 同步 API"""
+
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..core.config import config_manager
+from ..core.logging import logger
+from ..services.feiniu.reader import list_feiniu_users
+from ..services.feiniu.sync_service import FeiniuSyncResult, feiniu_sync_service
+from .deps import get_current_user_flexible
+
+router = APIRouter(prefix="/api/feiniu", tags=["feiniu"])
+
+
+@router.get("/status")
+async def feiniu_status(
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    cfg = config_manager.get_feiniu_config()
+    dbp = (cfg.get("db_path") or "").strip()
+    db_ok = bool(dbp) and Path(dbp).is_file()
+    return {
+        "status": "success",
+        "data": {
+            "enabled": bool(cfg.get("enabled")),
+            "db_path": dbp,
+            "db_ok": db_ok,
+            "user_filter": cfg.get("user_filter"),
+            "time_range": cfg.get("time_range"),
+            "sync_interval": cfg.get("sync_interval"),
+            "min_percent": cfg.get("min_percent"),
+            "limit": cfg.get("limit"),
+        },
+    }
+
+
+@router.get("/users")
+async def feiniu_users(
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    cfg = config_manager.get_feiniu_config()
+    dbp = (cfg.get("db_path") or "").strip()
+    if not dbp or not Path(dbp).is_file():
+        return {
+            "status": "success",
+            "data": {"users": [], "message": "数据库未配置或不存在"},
+        }
+    users = list_feiniu_users(dbp)
+    return {
+        "status": "success",
+        "data": {
+            "users": [{"id": u.guid, "name": u.username} for u in users],
+        },
+    }
+
+
+@router.post("/sync/manual")
+async def feiniu_manual_sync(
+    user: Optional[str] = Query(
+        default=None,
+        description="飞牛用户 guid；不传则使用配置中的 user_filter",
+    ),
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    cfg = config_manager.get_feiniu_config()
+    if not cfg.get("enabled"):
+        raise HTTPException(status_code=400, detail="飞牛同步未启用，请在配置中开启")
+    dbp = (cfg.get("db_path") or "").strip()
+    if not dbp or not Path(dbp).is_file():
+        raise HTTPException(status_code=400, detail="数据库路径无效或文件不存在")
+
+    uf = user
+    try:
+        result: FeiniuSyncResult = await feiniu_sync_service.run_sync(
+            user_filter=uf,
+            ignore_enabled=False,
+        )
+        return {
+            "status": "success" if result.success else "error",
+            "message": result.message,
+            "data": {
+                "synced_count": result.synced_count,
+                "skipped_count": result.skipped_count,
+                "error_count": result.error_count,
+            },
+        }
+    except Exception as e:
+        logger.error(f"飞牛手动同步失败: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -94,6 +94,7 @@ class ConfigManager:
             ("dev", "script_proxy"): "HTTP_PROXY",
             ("dev", "debug"): "DEBUG_MODE",
             ("web", "base_path"): "APPLICATION_ROOT",
+            ("feiniu", "db_path"): "FEINIU_DB_PATH",
         }
 
         for (section, option), env_var in env_overrides.items():
@@ -297,6 +298,43 @@ class ConfigManager:
                     result_config[key] = default_value
 
         return result_config
+
+    def get_feiniu_config(self) -> dict[str, Any]:
+        """飞牛 trimmedia 同步配置（默认关闭）"""
+        defaults: dict[str, Any] = {
+            "enabled": False,
+            "db_path": "",
+            "min_percent": 85,
+            "user_filter": "all",
+            "time_range": "all",
+            "sync_interval": "*/15 * * * *",
+            "limit": 100,
+        }
+        raw = self.get_section("feiniu", {})
+        out: dict[str, Any] = {**defaults, **raw}
+        ev = out.get("enabled", False)
+        if isinstance(ev, str):
+            out["enabled"] = ev.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            out["enabled"] = bool(ev)
+
+        try:
+            out["min_percent"] = int(out.get("min_percent", 85))
+        except (TypeError, ValueError):
+            out["min_percent"] = 85
+        try:
+            out["limit"] = int(out.get("limit", 100))
+        except (TypeError, ValueError):
+            out["limit"] = 100
+
+        out["db_path"] = str(out.get("db_path") or "").strip()
+        out["user_filter"] = str(out.get("user_filter") or "all").strip() or "all"
+        out["time_range"] = str(out.get("time_range") or "all").strip() or "all"
+        out["sync_interval"] = str(
+            out.get("sync_interval") or defaults["sync_interval"]
+        ).strip()
+
+        return out
 
     def get_all_config(self) -> dict[str, dict[str, Any]]:
         """获取所有配置"""

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -5,11 +5,15 @@
 import os
 import shutil
 import sqlite3
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
 from .logging import logger
+
+# 飞牛「启用后不同步历史」水位键（sync_records.db / feiniu_meta）
+FEINIU_MIN_UPDATE_WATERMARK_META_KEY = "min_update_watermark_ms"
 
 
 def _env_flag(name: str) -> bool:
@@ -87,6 +91,25 @@ class DatabaseManager:
                 watched_at INTEGER NOT NULL,
                 synced_at INTEGER NOT NULL,
                 UNIQUE(user_id, trakt_item_id, watched_at)
+            )
+        """)
+
+        # 飞牛影视 trimmedia 同步去重表
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS feiniu_sync_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                fn_user_guid TEXT NOT NULL,
+                item_guid TEXT NOT NULL,
+                synced_at INTEGER NOT NULL,
+                update_time_snapshot INTEGER,
+                UNIQUE(fn_user_guid, item_guid)
+            )
+        """)
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS feiniu_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
             )
         """)
 
@@ -611,6 +634,127 @@ class DatabaseManager:
         except Exception as e:
             logger.error(f"获取启用同步的 Trakt 配置失败: {e}")
             return []
+
+    # ===== 飞牛同步历史 =====
+
+    def save_feiniu_sync_history(
+        self,
+        fn_user_guid: str,
+        item_guid: str,
+        update_time_snapshot: Optional[int] = None,
+    ) -> bool:
+        """记录已提交的飞牛条目同步（去重用）"""
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO feiniu_sync_history
+                (fn_user_guid, item_guid, synced_at, update_time_snapshot)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    fn_user_guid,
+                    item_guid,
+                    int(datetime.now().timestamp()),
+                    update_time_snapshot,
+                ),
+            )
+            conn.commit()
+            conn.close()
+            return True
+        except Exception as e:
+            logger.error(f"保存飞牛同步历史失败: {e}")
+            return False
+
+    def is_feiniu_item_synced(self, fn_user_guid: str, item_guid: str) -> bool:
+        """是否已为该飞牛用户与条目提交过同步"""
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT 1 FROM feiniu_sync_history
+                WHERE fn_user_guid = ? AND item_guid = ?
+                LIMIT 1
+                """,
+                (fn_user_guid, item_guid),
+            )
+            row = cursor.fetchone()
+            conn.close()
+            return row is not None
+        except Exception as e:
+            logger.warning(f"查询飞牛同步历史失败: {e}")
+            return False
+
+    def get_feiniu_meta(self, key: str) -> Optional[str]:
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT value FROM feiniu_meta WHERE key = ? LIMIT 1", (key,)
+            )
+            row = cursor.fetchone()
+            conn.close()
+            return str(row[0]) if row else None
+        except Exception as e:
+            logger.warning(f"读取飞牛 meta 失败: {e}")
+            return None
+
+    def set_feiniu_meta(self, key: str, value: str) -> bool:
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO feiniu_meta (key, value) VALUES (?, ?)
+                """,
+                (key, value),
+            )
+            conn.commit()
+            conn.close()
+            return True
+        except Exception as e:
+            logger.error(f"写入飞牛 meta 失败: {e}")
+            return False
+
+    def delete_feiniu_meta(self, key: str) -> bool:
+        try:
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM feiniu_meta WHERE key = ?", (key,))
+            conn.commit()
+            conn.close()
+            return True
+        except Exception as e:
+            logger.error(f"删除飞牛 meta 失败: {e}")
+            return False
+
+    def clear_feiniu_min_update_watermark(self) -> None:
+        """清除「启用后仅同步新进度」水位（飞牛关闭时调用）"""
+        self.delete_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY)
+
+    def set_feiniu_min_update_watermark_now(self) -> int:
+        """将同步起点设为当前时刻（Web 勾选启用并保存时调用，不追溯历史）"""
+        now_ms = int(time.time() * 1000)
+        self.set_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY, str(now_ms))
+        logger.info("飞牛：同步起点水位已设为当前时刻（仅此后库内更新的记录参与同步）")
+        return now_ms
+
+    def get_or_create_feiniu_min_update_watermark_ms(self) -> int:
+        """返回飞牛库 update_time 下限（毫秒）。首次调用时写入当前时刻，不追溯历史。"""
+        existing = self.get_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY)
+        if existing is not None:
+            try:
+                return int(existing)
+            except ValueError:
+                pass
+        now_ms = int(time.time() * 1000)
+        self.set_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY, str(now_ms))
+        logger.info(
+            "飞牛：已建立同步起点水位（仅此后在库中更新的观看记录会参与同步，不追溯启用前的存量）"
+        )
+        return now_ms
 
 
 # 全局数据库实例

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from version import get_version, get_version_info, get_version_name
 
 from .api.auth import router as auth_router
 from .api.config import router as config_router
+from .api.feiniu import router as feiniu_router
 from .api.health import router as health_router
 from .api.logs import router as logs_router
 from .api.mappings import router as mappings_router
@@ -24,6 +25,8 @@ from .core.config import config_manager
 from .core.logging import logger
 from .core.public_url import get_public_base_path
 from .core.startup_info import startup_info
+from .services.feiniu.scheduler import feiniu_scheduler
+from .services.feiniu.sync_service import ensure_feiniu_startup_watermark
 from .services.mapping_service import mapping_service
 from .services.trakt.scheduler import trakt_scheduler
 
@@ -58,6 +61,7 @@ app.include_router(health_router)
 app.include_router(proxy_router)
 app.include_router(notification_router)
 app.include_router(trakt_router)
+app.include_router(feiniu_router)
 
 
 # 启动事件
@@ -84,6 +88,11 @@ async def startup_event():
 
     startup_info.print_separator()
 
+    try:
+        ensure_feiniu_startup_watermark()
+    except Exception as e:
+        logger.debug("飞牛启动水位检查: %s", e)
+
     # 启动 Trakt 调度器（延迟启动）
     try:
         scheduler_config = config_manager.get_scheduler_config()
@@ -101,6 +110,13 @@ async def startup_event():
                 logger.info("Trakt 调度器启动成功")
             else:
                 logger.error("Trakt 调度器启动失败")
+            fn_ok = await feiniu_scheduler.start()
+            if fn_ok:
+                logger.info(
+                    "飞牛定时同步：延迟启动阶段结束（未启用或无有效 db 时不会注册定时任务）"
+                )
+            else:
+                logger.error("飞牛调度器启动失败")
 
         asyncio.create_task(delayed_scheduler_start())
 
@@ -122,6 +138,12 @@ async def shutdown_event():
         logger.info("Trakt 调度器已停止")
     except Exception as e:
         logger.error(f"停止 Trakt 调度器失败: {e}")
+
+    try:
+        await feiniu_scheduler.stop()
+        logger.info("飞牛调度器已停止")
+    except Exception as e:
+        logger.error(f"停止飞牛调度器失败: {e}")
 
 
 if __name__ == "__main__":

--- a/app/services/feiniu/__init__.py
+++ b/app/services/feiniu/__init__.py
@@ -1,0 +1,5 @@
+"""飞牛影视 trimmedia.db 只读同步"""
+
+from .sync_service import feiniu_sync_service
+
+__all__ = ["feiniu_sync_service"]

--- a/app/services/feiniu/models.py
+++ b/app/services/feiniu/models.py
@@ -1,0 +1,25 @@
+"""飞牛观看记录行模型"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class FeiniuUser:
+    guid: str
+    username: str
+
+
+@dataclass(frozen=True)
+class FeiniuWatchRecord:
+    """单条可同步的观看记录（已满足「看完」条件）"""
+
+    item_guid: str
+    user_guid: str
+    username: str
+    display_title: str
+    original_title: Optional[str]
+    season: int
+    episode: int
+    release_date: str
+    update_time_ms: int

--- a/app/services/feiniu/reader.py
+++ b/app/services/feiniu/reader.py
@@ -1,0 +1,258 @@
+"""
+只读读取飞牛影视 trimmedia.db（item_user_play + item）。
+逻辑参考社区常见挂载方式，表结构随飞牛版本可能变化，故做列探测与降级。
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from ...core.logging import logger
+from .models import FeiniuUser, FeiniuWatchRecord
+
+_EPISODE_TITLE_RE = re.compile(r"(?:第|E|ep)\s*0*(\d+)(?:集|话|話)?", re.IGNORECASE)
+
+
+def _sqlite_ro_uri(db_path: str) -> str:
+    p = Path(db_path).expanduser().resolve()
+    base = p.as_uri()
+    return f"{base}?mode=ro"
+
+
+def _table_columns(cursor: sqlite3.Cursor, table: str) -> set[str]:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return {str(row[1]).lower() for row in cursor.fetchall()}
+
+
+def _pick_episode_sql_column(cols: set[str]) -> str:
+    for name in ("episode_number", "index_number", "episode_index", "sort_index"):
+        if name in cols:
+            return f"i.{name}"
+    return "NULL"
+
+
+def _pick_season_value(row: sqlite3.Row, cols: set[str]) -> int:
+    for key in ("season_number", "parent_index_number", "season_index"):
+        if key in cols:
+            try:
+                v = row[key]
+                if v is not None:
+                    return max(1, int(v))
+            except (TypeError, ValueError):
+                pass
+    return 1
+
+
+def list_feiniu_users(db_path: str) -> list[FeiniuUser]:
+    if not db_path or not Path(db_path).is_file():
+        return []
+    try:
+        conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT guid, username FROM user
+            WHERE status = 1 AND guid != 'default-user-template'
+            ORDER BY username
+            """
+        )
+        users = [
+            FeiniuUser(
+                guid=str(r["guid"]), username=str(r["username"] or r["guid"][:8])
+            )
+            for r in cur.fetchall()
+        ]
+        conn.close()
+        return users
+    except Exception as e:
+        logger.warning(f"读取飞牛用户列表失败: {e}")
+        return []
+
+
+def _time_range_cutoff_ms(time_range: str) -> int | None:
+    now = datetime.now()
+    if time_range == "1day":
+        delta = timedelta(days=1)
+    elif time_range == "1week":
+        delta = timedelta(days=7)
+    elif time_range == "1month":
+        delta = timedelta(days=30)
+    else:
+        return None
+    return int((now - delta).timestamp() * 1000)
+
+
+def _normalize_to_epoch_seconds(ts: Any) -> float:
+    """飞牛时间戳多为毫秒；小数值按秒处理。"""
+    if ts is None:
+        return 0.0
+    try:
+        v = float(ts)
+    except (TypeError, ValueError):
+        return 0.0
+    if v > 1_000_000_000_000:
+        return v / 1000.0
+    return v
+
+
+def _real_series_title(row: sqlite3.Row, item_guid: str) -> str:
+    base = (row["media_title"] or row["media_original_title"] or "") or ""
+    p1 = row["p1_title"] or ""
+    p2 = row["p2_title"] or ""
+    real = base
+    if p2 and p1:
+        real = p1 if p2.lower() in p1.lower() else f"{p2} {p1}"
+    elif p2:
+        real = p2
+    elif p1:
+        real = p1
+    if not real:
+        real = f"视频-{str(item_guid)[:8]}"
+    return str(real)
+
+
+def fetch_completed_watch_records(
+    db_path: str,
+    *,
+    user_guid: str = "all",
+    time_range: str = "all",
+    limit: int = 100,
+    min_percent: int = 80,
+    min_update_time_ms: int | None = None,
+) -> list[FeiniuWatchRecord]:
+    """
+    返回按 update_time 倒序的观看行，且满足：
+    - visible = 1
+    - watched = 1 或 播放进度 >= min_percent
+    """
+    if not db_path or not Path(db_path).is_file():
+        return []
+
+    try:
+        conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        item_cols = _table_columns(cur, "item")
+        ep_col = _pick_episode_sql_column(item_cols)
+        season_fragments: list[str] = []
+        for c in ("season_number", "parent_index_number", "season_index"):
+            if c in item_cols:
+                season_fragments.append(f"i.{c} AS {c}")
+        season_sql = (
+            (",\n               " + ",\n               ".join(season_fragments))
+            if season_fragments
+            else ""
+        )
+
+        query = f"""
+        SELECT p.item_guid, p.user_guid, p.watched, p.ts, p.create_time, p.update_time,
+               i.title AS media_title, i.original_title AS media_original_title,
+               i.runtime AS runtime_mins,
+               p1.title AS p1_title, p2.title AS p2_title,
+               p1.runtime AS p1_runtime, p2.runtime AS p2_runtime,
+               {ep_col} AS ep_number,
+               COALESCE(NULLIF(TRIM(u.username), ''), substr(p.user_guid, 1, 8)) AS feiniu_username
+               {season_sql}
+        FROM item_user_play p
+        LEFT JOIN item i ON p.item_guid = i.guid
+        LEFT JOIN item p1 ON i.parent_guid = p1.guid
+        LEFT JOIN item p2 ON p1.parent_guid = p2.guid
+        LEFT JOIN user u ON p.user_guid = u.guid
+        WHERE p.visible = 1
+        """
+        params: list[Any] = []
+
+        if user_guid and user_guid != "all":
+            query += " AND p.user_guid = ?"
+            params.append(user_guid)
+
+        cutoffs: list[int] = []
+        tr_cutoff = _time_range_cutoff_ms(time_range)
+        if tr_cutoff is not None:
+            cutoffs.append(int(tr_cutoff))
+        if min_update_time_ms is not None:
+            cutoffs.append(int(min_update_time_ms))
+        if cutoffs:
+            query += " AND p.update_time >= ?"
+            params.append(max(cutoffs))
+
+        query += " ORDER BY p.update_time DESC LIMIT ?"
+        params.append(limit)
+
+        cur.execute(query, params)
+        rows_out: list[FeiniuWatchRecord] = []
+
+        for r in cur.fetchall():
+            ts_raw = r["update_time"] or r["create_time"] or 0
+            wall_sec = _normalize_to_epoch_seconds(ts_raw)
+            play_sec = int(r["ts"] or 0)
+            watched = int(r["watched"] or 0) == 1
+
+            runtime_mins = r["runtime_mins"]
+            if not runtime_mins:
+                runtime_mins = r["p1_runtime"]
+            if not runtime_mins:
+                runtime_mins = r["p2_runtime"]
+            runtime_mins = int(runtime_mins or 24)
+            total_sec = max(runtime_mins * 60, 1)
+
+            if watched:
+                percent = 100.0
+            else:
+                percent = round(max(0.0, min(100.0, (play_sec / total_sec) * 100.0)), 1)
+
+            finished = watched or percent >= float(min_percent)
+            if not finished:
+                continue
+
+            base_name = (r["media_title"] or r["media_original_title"] or "") or ""
+            ep_num = 1
+            en = r["ep_number"]
+            if en is not None:
+                try:
+                    ep_num = max(1, int(en))
+                except (TypeError, ValueError):
+                    ep_num = 1
+            else:
+                m = _EPISODE_TITLE_RE.search(base_name)
+                if m:
+                    ep_num = max(1, int(m.group(1)))
+
+            real_name = _real_series_title(r, str(r["item_guid"]))
+            season = _pick_season_value(r, item_cols)
+
+            if wall_sec > 0:
+                release_date = datetime.fromtimestamp(wall_sec).strftime("%Y-%m-%d")
+            else:
+                release_date = datetime.now().strftime("%Y-%m-%d")
+
+            ug = str(r["user_guid"])
+            uname = str(r["feiniu_username"] or (ug[:8] if ug else "unknown"))
+
+            ori = r["media_original_title"]
+            ori_s = str(ori) if ori else None
+
+            rows_out.append(
+                FeiniuWatchRecord(
+                    item_guid=str(r["item_guid"]),
+                    user_guid=ug,
+                    username=uname,
+                    display_title=real_name,
+                    original_title=ori_s,
+                    season=season,
+                    episode=ep_num,
+                    release_date=release_date,
+                    update_time_ms=int(ts_raw) if ts_raw else 0,
+                )
+            )
+
+        conn.close()
+        return rows_out
+    except Exception as e:
+        logger.error(f"读取飞牛观看记录失败: {e}")
+        return []

--- a/app/services/feiniu/scheduler.py
+++ b/app/services/feiniu/scheduler.py
@@ -1,0 +1,157 @@
+"""飞牛 trimmedia 定时同步（单任务，Cron 来自 config.ini [feiniu]）"""
+
+from __future__ import annotations
+
+import asyncio
+
+from apscheduler.executors.asyncio import AsyncIOExecutor
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from ...core.config import config_manager
+from ...core.logging import logger
+from .sync_service import feiniu_sync_service
+
+
+class FeiniuScheduler:
+    JOB_ID = "feiniu_trimmedia_sync"
+
+    def __init__(self) -> None:
+        self.scheduler: AsyncIOScheduler | None = None
+        self._scheduler_config = config_manager.get_scheduler_config()
+
+    def _feiniu_enabled_with_db(self) -> bool:
+        cfg = config_manager.get_feiniu_config()
+        if not cfg.get("enabled"):
+            return False
+        dbp = (cfg.get("db_path") or "").strip()
+        if not dbp:
+            return False
+        from pathlib import Path
+
+        return Path(dbp).is_file()
+
+    async def start(self) -> bool:
+        try:
+            if self.scheduler and self.scheduler.running:
+                if self._feiniu_enabled_with_db():
+                    self._schedule_or_refresh_job()
+                else:
+                    try:
+                        self.scheduler.remove_job(self.JOB_ID)
+                    except Exception:
+                        pass
+                return True
+
+            if not self._feiniu_enabled_with_db():
+                logger.info(
+                    "飞牛同步未启用或数据库路径无效，本次不注册飞牛定时任务（APScheduler 未创建）"
+                )
+                return True
+
+            jobstores = {"default": MemoryJobStore()}
+            executors = {"default": AsyncIOExecutor()}
+            job_defaults = {
+                "coalesce": True,
+                "max_instances": 1,
+                "misfire_grace_time": 60,
+            }
+            self.scheduler = AsyncIOScheduler(
+                jobstores=jobstores,
+                executors=executors,
+                job_defaults=job_defaults,
+                timezone="Asia/Shanghai",
+            )
+            self.scheduler.start()
+            self._schedule_or_refresh_job()
+            logger.info("飞牛调度器启动成功")
+            return True
+        except Exception as e:
+            logger.error(f"启动飞牛调度器失败: {e}")
+            return False
+
+    async def stop(self) -> bool:
+        try:
+            if self.scheduler and self.scheduler.running:
+                self.scheduler.shutdown()
+                self.scheduler = None
+                logger.info("飞牛调度器已停止")
+            return True
+        except Exception as e:
+            logger.error(f"停止飞牛调度器失败: {e}")
+            return False
+
+    def _default_feiniu_cron_trigger(self) -> CronTrigger:
+        """与 config.ini / get_feiniu_config 默认一致：每 15 分钟"""
+        return CronTrigger(
+            minute="*/15",
+            hour="*",
+            day="*",
+            month="*",
+            day_of_week="*",
+        )
+
+    def _parse_cron(self, cron_expression: str) -> CronTrigger:
+        parts = cron_expression.split()
+        if len(parts) != 5:
+            logger.warning(f"飞牛 Cron 无效，使用默认每 15 分钟: {cron_expression}")
+            return self._default_feiniu_cron_trigger()
+        return CronTrigger(
+            minute=parts[0],
+            hour=parts[1],
+            day=parts[2],
+            month=parts[3],
+            day_of_week=parts[4],
+        )
+
+    def _schedule_or_refresh_job(self) -> None:
+        if not self.scheduler or not self.scheduler.running:
+            return
+        cfg = config_manager.get_feiniu_config()
+        cron_expr = cfg.get("sync_interval") or "*/15 * * * *"
+        trigger = self._parse_cron(str(cron_expr))
+
+        try:
+            self.scheduler.remove_job(self.JOB_ID)
+        except Exception:
+            pass
+
+        self.scheduler.add_job(
+            func=self._run_sync_job,
+            trigger=trigger,
+            id=self.JOB_ID,
+            name="Feiniu trimmedia sync",
+            replace_existing=True,
+        )
+        logger.info(f"飞牛定时任务已注册: {cron_expr}")
+
+    async def _run_sync_job(self) -> None:
+        if not self._feiniu_enabled_with_db():
+            logger.debug("飞牛未启用或数据库不可用，跳过定时同步")
+            return
+        timeout = self._scheduler_config.get("job_timeout", 300)
+        try:
+            await asyncio.wait_for(feiniu_sync_service.run_sync(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.error(f"飞牛定时同步超时 ({timeout} 秒)")
+        except Exception as e:
+            logger.error(f"飞牛定时同步失败: {e}")
+
+    def reload_job_if_running(self) -> None:
+        """配置保存后若调度器在运行，则按新 Cron 重建任务（无需整进程重启）"""
+        if self.scheduler and self.scheduler.running and self._feiniu_enabled_with_db():
+            self._schedule_or_refresh_job()
+
+    async def apply_config_after_save(self) -> None:
+        """保存 config.ini 后同步调度状态（与 Web 配置联动）"""
+        if self._feiniu_enabled_with_db():
+            if not self.scheduler or not self.scheduler.running:
+                await self.start()
+            else:
+                self._schedule_or_refresh_job()
+        else:
+            await self.stop()
+
+
+feiniu_scheduler = FeiniuScheduler()

--- a/app/services/feiniu/sync_service.py
+++ b/app/services/feiniu/sync_service.py
@@ -1,0 +1,135 @@
+"""飞牛观看记录 → CustomItem → SyncService"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...core.config import config_manager
+from ...core.database import FEINIU_MIN_UPDATE_WATERMARK_META_KEY, database_manager
+from ...core.logging import logger
+from ...models.sync import CustomItem
+from ..sync_service import sync_service
+from .models import FeiniuWatchRecord
+from .reader import fetch_completed_watch_records
+
+# 同步记录 / 通知中的来源标识（与 Plex、Trakt 等并列）
+FEINIU_SYNC_SOURCE = "feiniu"
+
+
+def ensure_feiniu_startup_watermark() -> None:
+    """仅手改 config.ini 启用飞牛时：启动进程若尚无水位则立即写入，避免等到首次定时同步。"""
+    cfg = config_manager.get_feiniu_config()
+    if not cfg.get("enabled"):
+        return
+    db_path = (cfg.get("db_path") or "").strip()
+    if not db_path or not Path(db_path).is_file():
+        return
+    if database_manager.get_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY):
+        return
+    database_manager.set_feiniu_min_update_watermark_now()
+
+
+@dataclass
+class FeiniuSyncResult:
+    success: bool
+    message: str
+    synced_count: int
+    skipped_count: int
+    error_count: int
+
+
+class FeiniuSyncService:
+    def _record_to_custom_item(self, rec: FeiniuWatchRecord) -> CustomItem | None:
+        if rec.display_title.startswith("视频-"):
+            return None
+        ori = rec.original_title if rec.original_title else rec.display_title
+        return CustomItem(
+            media_type="episode",
+            title=rec.display_title,
+            ori_title=ori,
+            season=rec.season,
+            episode=rec.episode,
+            release_date=rec.release_date,
+            user_name=rec.username,
+            source=FEINIU_SYNC_SOURCE,
+        )
+
+    async def run_sync(
+        self,
+        *,
+        user_filter: str | None = None,
+        ignore_enabled: bool = False,
+    ) -> FeiniuSyncResult:
+        cfg = config_manager.get_feiniu_config()
+        if not ignore_enabled and not cfg.get("enabled"):
+            return FeiniuSyncResult(True, "飞牛同步未启用", 0, 0, 0)
+
+        db_path = (cfg.get("db_path") or "").strip()
+        if not db_path:
+            return FeiniuSyncResult(False, "未配置飞牛数据库路径 db_path", 0, 0, 1)
+
+        if not Path(db_path).is_file():
+            return FeiniuSyncResult(False, f"数据库文件不存在: {db_path}", 0, 0, 1)
+
+        uf = (
+            user_filter
+            if user_filter is not None
+            else (cfg.get("user_filter") or "all")
+        )
+        # 仅同步水位建立之后（含首次运行写入时刻）在库中更新的记录，不追溯启用前存量
+        wm_ms = database_manager.get_or_create_feiniu_min_update_watermark_ms()
+        records = fetch_completed_watch_records(
+            db_path,
+            user_guid=str(uf),
+            time_range=str(cfg.get("time_range") or "all"),
+            limit=int(cfg.get("limit") or 100),
+            min_percent=int(cfg.get("min_percent") or 85),
+            min_update_time_ms=wm_ms,
+        )
+
+        synced = skipped = errors = 0
+        for rec in records:
+            if database_manager.is_feiniu_item_synced(rec.user_guid, rec.item_guid):
+                skipped += 1
+                continue
+
+            item = self._record_to_custom_item(rec)
+            if not item:
+                skipped += 1
+                continue
+
+            try:
+                # 同步执行以便根据结果写入 feiniu_sync_history；未预期异常时由 sync_custom_item 的 except 写入 error 记录
+                result = await asyncio.to_thread(
+                    sync_service.sync_custom_item, item, FEINIU_SYNC_SOURCE
+                )
+            except Exception as e:
+                logger.error(f"飞牛单条同步执行失败: {e}")
+                errors += 1
+                await asyncio.sleep(0.05)
+                continue
+
+            if result.status == "success":
+                database_manager.save_feiniu_sync_history(
+                    rec.user_guid, rec.item_guid, rec.update_time_ms or None
+                )
+                synced += 1
+            elif result.status == "ignored":
+                skipped += 1
+            else:
+                errors += 1
+            await asyncio.sleep(0.05)
+
+        ok = errors == 0
+        return FeiniuSyncResult(
+            ok,
+            f"飞牛同步: 已提交 {synced}, 跳过 {skipped}, 失败 {errors}",
+            synced,
+            skipped,
+            errors,
+        )
+
+
+feiniu_sync_service = FeiniuSyncService()

--- a/config.ini
+++ b/config.ini
@@ -246,3 +246,20 @@ max_concurrent_syncs = 3
 job_timeout = 300
 max_retries = 3
 retry_delay = 60
+
+##########################飞牛影视################################
+# 默认关闭；开启后只读挂载飞牛数据库目录下的 trimmedia.db，按进度同步到 Bangumi。
+# 详见 README「飞牛影视」章节。
+
+[feiniu]
+enabled = false
+# 例如 NAS: /usr/local/apps/@appdata/trim.media/database/trimmedia.db
+# Docker（挂载到 /app/data/feiniu-db:ro）: /app/data/feiniu-db/trimmedia.db
+# Windows 本机路径示例: D:/trimmedia/trimmedia.db 或 D:\\trimmedia\\trimmedia.db（反斜杠在 ini 中需转义时可改用正斜杠）
+db_path =
+min_percent = 85
+user_filter = all
+time_range = all
+# 每 15 分钟扫描一次（五段式 Cron）
+sync_interval = */15 * * * *
+limit = 100

--- a/templates/config.html
+++ b/templates/config.html
@@ -692,6 +692,120 @@
                 </div>
             </div>
         </div>
+        <!-- 飞牛影视 -->
+        <div class="row">
+            <div class="col-12">
+                <div class="card shadow-sm mb-4 config-card">
+                    <div class="card-header py-3">
+                        <div class="d-flex align-items-center">
+                            <i class="bi bi-hdd-network me-2 text-secondary"></i>
+                            <h6 class="m-0 fw-semibold">飞牛影视</h6>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-md-12">
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="feiniu-enabled"
+                                           name="feiniu.enabled">
+                                    <label class="form-check-label fw-semibold" for="feiniu-enabled">
+                                        启用飞牛同步
+                                        <i class="bi bi-question-circle ms-1 text-muted"
+                                           data-bs-toggle="tooltip"
+                                           title="默认关闭。开启并保存后会写入同步起点水位，仅处理此后在飞牛库中有更新的观看记录，不会把启用前的历史存量批量推到 Bangumi。关闭并保存会清除水位。"></i>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="col-md-12">
+                                <label for="feiniu-db-path" class="form-label fw-semibold">
+                                    数据库路径 (trimmedia.db)
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="只读打开飞牛的 trimmedia.db，填本机或容器内可访问的绝对路径。Docker 常见为挂载后的路径（见 README 示例）。Windows 建议用正斜杠，如 D:/path/trimmedia.db。"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="feiniu-db-path"
+                                       name="feiniu.db_path"
+                                       placeholder="/app/data/feiniu-db/trimmedia.db">
+                            </div>
+                            <div class="col-md-4">
+                                <label for="feiniu-min-percent" class="form-label fw-semibold">
+                                    视为看完的最低进度 (%)
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="播放进度达到该百分比即参与同步；飞牛已标记看完视为 100%。默认 85%，与飞牛「标记看完」习惯类似。"></i>
+                                </label>
+                                <input type="number"
+                                       class="form-control"
+                                       id="feiniu-min-percent"
+                                       name="feiniu.min_percent"
+                                       min="1"
+                                       max="100"
+                                       value="85">
+                            </div>
+                            <div class="col-md-4">
+                                <label for="feiniu-user-filter" class="form-label fw-semibold">
+                                    飞牛用户
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="填 all 表示不过滤；否则填飞牛用户的 guid。可在已登录 Web 时于调试页请求 GET /api/feiniu/users 查看列表。"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control"
+                                       id="feiniu-user-filter"
+                                       name="feiniu.user_filter"
+                                       placeholder="all 或用户 guid">
+                            </div>
+                            <div class="col-md-4">
+                                <label for="feiniu-time-range" class="form-label fw-semibold">
+                                    时间范围
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="在同步起点水位之上，再限制只处理最近一段时间内有更新的播放记录；选「全部」则不做该维度的过滤。"></i>
+                                </label>
+                                <select class="form-select" id="feiniu-time-range" name="feiniu.time_range">
+                                    <option value="all">全部</option>
+                                    <option value="1day">最近 1 天</option>
+                                    <option value="1week">最近 1 周</option>
+                                    <option value="1month">最近 1 月</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="feiniu-sync-interval" class="form-label fw-semibold">
+                                    定时 Cron
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="五段式 Cron，默认每 15 分钟扫描一次：*/15 * * * *"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control"
+                                       id="feiniu-sync-interval"
+                                       name="feiniu.sync_interval"
+                                       placeholder="*/15 * * * *">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="feiniu-limit" class="form-label fw-semibold">
+                                    单次扫描最大条数
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="单次定时任务从飞牛库中最多拉取多少条候选记录，用于控制单次扫描耗时与负载。"></i>
+                                </label>
+                                <input type="number"
+                                       class="form-control"
+                                       id="feiniu-limit"
+                                       name="feiniu.limit"
+                                       min="1"
+                                       max="500"
+                                       value="100">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
     <!-- 操作按钮 -->
     <div class="row">
@@ -1065,6 +1179,18 @@ function populateForm(config) {
     document.getElementById('cache-ttl').value = config.bangumi_data.cache_ttl_days || 7;
     document.getElementById('data-url').value = config.bangumi_data.data_url || 'https://unpkg.com/bangumi-data@0.3/dist/data.json';
     document.getElementById('local-cache-path').value = config.bangumi_data.local_cache_path || './bangumi_data_cache.json';
+
+    const fn = config.feiniu || {};
+    const fe = document.getElementById('feiniu-enabled');
+    if (fe) {
+        fe.checked = fn.enabled === true || fn.enabled === 'true' || String(fn.enabled).toLowerCase() === 'true';
+        document.getElementById('feiniu-db-path').value = fn.db_path || '';
+        document.getElementById('feiniu-min-percent').value = (fn.min_percent != null && fn.min_percent !== '') ? fn.min_percent : 85;
+        document.getElementById('feiniu-user-filter').value = fn.user_filter || 'all';
+        document.getElementById('feiniu-time-range').value = fn.time_range || 'all';
+        document.getElementById('feiniu-sync-interval').value = fn.sync_interval || '*/15 * * * *';
+        document.getElementById('feiniu-limit').value = (fn.limit != null && fn.limit !== '') ? fn.limit : 100;
+    }
     
     // 填充认证配置
     if (config.auth) {
@@ -1230,6 +1356,15 @@ async function saveConfig() {
                 cache_ttl_days: parseInt(document.getElementById('cache-ttl').value),
                 data_url: document.getElementById('data-url').value,
                 local_cache_path: document.getElementById('local-cache-path').value
+            },
+            feiniu: {
+                enabled: document.getElementById('feiniu-enabled').checked,
+                db_path: document.getElementById('feiniu-db-path').value.trim(),
+                min_percent: parseInt(document.getElementById('feiniu-min-percent').value, 10) || 85,
+                user_filter: document.getElementById('feiniu-user-filter').value.trim() || 'all',
+                time_range: document.getElementById('feiniu-time-range').value || 'all',
+                sync_interval: document.getElementById('feiniu-sync-interval').value.trim() || '*/15 * * * *',
+                limit: parseInt(document.getElementById('feiniu-limit').value, 10) || 100
             },
             auth: {
                 enabled: document.getElementById('auth-enabled').checked,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -310,7 +310,8 @@ function displayRecentRecords(records) {
             'emby': 'success',     // 绿色
             'jellyfin': 'primary', // 蓝色
             'custom': 'secondary', // 灰色
-            'test': 'info'         // 浅蓝色
+            'feiniu': 'info',      // 浅蓝色
+            'test': 'secondary'    // 灰色
         };
         
         // 处理重试来源（retry-xxx）

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -103,6 +103,39 @@
             </div>
         </div>
     </div>
+    <!-- 飞牛同步测试 -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header py-3">
+                    <div class="d-flex align-items-center">
+                        <i class="bi bi-hdd-network me-2 text-secondary"></i>
+                        <h6 class="m-0 fw-semibold">飞牛同步测试</h6>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-8">
+                            <label for="feiniu-debug-user" class="form-label fw-semibold">飞牛用户 guid（可选）</label>
+                            <input type="text"
+                                   class="form-control"
+                                   id="feiniu-debug-user"
+                                   placeholder="留空则使用配置中的 飞牛用户 guid">
+                        </div>
+                        <div class="col-md-4">
+                            <button type="button"
+                                    class="btn btn-secondary w-100"
+                                    id="feiniu-manual-sync-btn"
+                                    onclick="triggerFeiniuManualSync()">
+                                <i class="bi bi-arrow-repeat me-1"></i>立即触发飞牛同步
+                            </button>
+                        </div>
+                    </div>
+                    <div id="feiniu-sync-test-result" class="mt-3" style="display: none;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <!-- 网络诊断工具 -->
     <div class="row">
         <div class="col-12">
@@ -422,6 +455,65 @@ async function testSync() {
         // 恢复按钮状态
         btn.disabled = false;
         btn.innerHTML = '<i class="bi bi-play-circle me-2"></i>开始测试';
+    }
+}
+
+// 飞牛：手动触发一次同步（与 POST /api/feiniu/sync/manual 一致）
+async function triggerFeiniuManualSync() {
+    const btn = document.getElementById('feiniu-manual-sync-btn');
+    const out = document.getElementById('feiniu-sync-test-result');
+    const user = document.getElementById('feiniu-debug-user').value.trim();
+    let url = appUrl('/api/feiniu/sync/manual');
+    if (user) {
+        url += '?user=' + encodeURIComponent(user);
+    }
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>同步中...';
+    out.style.display = 'block';
+    out.innerHTML = '<div class="alert alert-info mb-0"><i class="bi bi-hourglass-split me-2"></i>正在执行飞牛扫描与同步，请稍候…</div>';
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Accept': 'application/json' }
+        });
+        let data = {};
+        try {
+            data = await response.json();
+        } catch (_) {
+            data = {};
+        }
+        if (!response.ok) {
+            const detail = data.detail != null
+                ? (typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail))
+                : (data.message || '请求失败');
+            out.innerHTML = `
+                <div class="alert alert-danger mb-0">
+                    <i class="bi bi-x-circle me-2"></i><strong>无法执行</strong>（HTTP ${response.status}）<br>
+                    <span class="small">${detail}</span>
+                </div>`;
+            return;
+        }
+        const d = data.data || {};
+        const counts = `已提交 ${d.synced_count ?? 0}，跳过 ${d.skipped_count ?? 0}，失败 ${d.error_count ?? 0}`;
+        const ok = data.status === 'success';
+        out.innerHTML = `
+            <div class="alert alert-${ok ? 'success' : 'warning'} mb-0">
+                <i class="bi bi-${ok ? 'check-circle' : 'exclamation-triangle'} me-2"></i>
+                <strong>${ok ? '执行完成' : '执行结束（含失败项）'}</strong><br>
+                <span class="small">${data.message || ''}</span><br>
+                <span class="small text-muted">${counts}</span>
+            </div>`;
+    } catch (error) {
+        console.error('飞牛手动同步请求失败:', error);
+        out.innerHTML = `
+            <div class="alert alert-danger mb-0">
+                <i class="bi bi-x-circle me-2"></i><strong>网络错误</strong><br>
+                <span class="small">${error.message || String(error)}</span>
+            </div>`;
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i>立即触发飞牛同步';
     }
 }
 

--- a/templates/records.html
+++ b/templates/records.html
@@ -43,6 +43,7 @@
                         <option value="plex">Plex</option>
                         <option value="emby">Emby</option>
                         <option value="jellyfin">Jellyfin</option>
+                        <option value="feiniu">飞牛</option>
                         <option value="test">测试</option>
                         <option value="retry">重试记录</option>
                     </select>
@@ -235,7 +236,8 @@ function getSourceColor(source) {
         case 'emby': return 'success';     // 绿色
         case 'jellyfin': return 'primary'; // 蓝色
         case 'custom': return 'secondary'; // 灰色
-        case 'test': return 'info';        // 浅蓝色
+        case 'feiniu': return 'info';      // 浅蓝色
+        case 'test': return 'secondary';   // 灰色
         default: return 'secondary';
     }
 }

--- a/tests/api/test_feiniu.py
+++ b/tests/api/test_feiniu.py
@@ -1,0 +1,144 @@
+"""飞牛 API 测试"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.api import deps, feiniu
+from app.services.feiniu.models import FeiniuUser
+from app.services.feiniu.sync_service import FeiniuSyncResult
+
+
+def _feiniu_cfg(**overrides):
+    base = {
+        "enabled": False,
+        "db_path": "",
+        "user_filter": "all",
+        "time_range": "all",
+        "sync_interval": "*/15 * * * *",
+        "min_percent": 85,
+        "limit": 100,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def app_feiniu():
+    app = FastAPI()
+    app.include_router(feiniu.router)
+
+    async def mock_user():
+        return {"username": "testuser", "id": 1}
+
+    app.dependency_overrides[deps.get_current_user_flexible] = mock_user
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_feiniu_status(app_feiniu):
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg()
+        transport = ASGITransport(app=app_feiniu)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/feiniu/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["data"]["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_feiniu_manual_disabled(app_feiniu):
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(
+            enabled=False, db_path="/nope.db"
+        )
+        transport = ASGITransport(app=app_feiniu)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.post("/api/feiniu/sync/manual")
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_feiniu_manual_db_missing_when_enabled(app_feiniu):
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(
+            enabled=True, db_path="/nonexistent/trimmedia.db"
+        )
+        transport = ASGITransport(app=app_feiniu)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.post("/api/feiniu/sync/manual")
+    assert r.status_code == 400
+    assert "路径" in r.json()["detail"] or "不存在" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_feiniu_manual_success(tmp_path, app_feiniu):
+    dbf = tmp_path / "trimmedia.db"
+    dbf.write_bytes(b"")
+    result = FeiniuSyncResult(True, "飞牛同步: 已提交 2, 跳过 0, 失败 0", 2, 0, 0)
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(enabled=True, db_path=str(dbf))
+        with patch(
+            "app.api.feiniu.feiniu_sync_service.run_sync", new_callable=AsyncMock
+        ) as rs:
+            rs.return_value = result
+            transport = ASGITransport(app=app_feiniu)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                r = await ac.post("/api/feiniu/sync/manual")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "success"
+    assert body["data"]["synced_count"] == 2
+    rs.assert_awaited_once_with(user_filter=None, ignore_enabled=False)
+
+
+@pytest.mark.asyncio
+async def test_feiniu_manual_with_user_query(tmp_path, app_feiniu):
+    dbf = tmp_path / "t.db"
+    dbf.write_bytes(b"")
+    result = FeiniuSyncResult(True, "ok", 0, 0, 0)
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(enabled=True, db_path=str(dbf))
+        with patch(
+            "app.api.feiniu.feiniu_sync_service.run_sync", new_callable=AsyncMock
+        ) as rs:
+            rs.return_value = result
+            transport = ASGITransport(app=app_feiniu)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                r = await ac.post("/api/feiniu/sync/manual?user=" + "guid-abc-123")
+    assert r.status_code == 200
+    rs.assert_awaited_once_with(user_filter="guid-abc-123", ignore_enabled=False)
+
+
+@pytest.mark.asyncio
+async def test_feiniu_users_empty_when_no_db(app_feiniu):
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(db_path="")
+        transport = ASGITransport(app=app_feiniu)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/feiniu/users")
+    assert r.status_code == 200
+    assert r.json()["data"]["users"] == []
+
+
+@pytest.mark.asyncio
+async def test_feiniu_users_list(tmp_path, app_feiniu):
+    dbf = tmp_path / "u.db"
+    dbf.write_bytes(b"")
+    users = [FeiniuUser(guid="g1", username="n1")]
+    with patch("app.api.feiniu.config_manager") as m:
+        m.get_feiniu_config.return_value = _feiniu_cfg(db_path=str(dbf))
+        with patch("app.api.feiniu.list_feiniu_users", return_value=users):
+            transport = ASGITransport(app=app_feiniu)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                r = await ac.get("/api/feiniu/users")
+    assert r.status_code == 200
+    data = r.json()["data"]["users"]
+    assert len(data) == 1
+    assert data[0]["id"] == "g1"
+    assert data[0]["name"] == "n1"

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -272,3 +272,32 @@ class TestDatabaseManager:
             assert len(result1["records"]) == 5
             assert len(result2["records"]) == 5
             assert len(result3["records"]) == 5
+
+    def test_feiniu_sync_history(self, temp_dir, reset_singletons):
+        db_path = temp_dir / "fn.db"
+        with patch("app.core.database.logger"):
+            from app.core.database import DatabaseManager
+
+            db = DatabaseManager(str(db_path))
+            assert db.is_feiniu_item_synced("u1", "it1") is False
+            assert db.save_feiniu_sync_history("u1", "it1", 12345) is True
+            assert db.is_feiniu_item_synced("u1", "it1") is True
+            assert db.is_feiniu_item_synced("u1", "it2") is False
+
+    def test_feiniu_watermark_meta(self, temp_dir, reset_singletons):
+        db_path = temp_dir / "fnwm.db"
+        with patch("app.core.database.logger"):
+            from app.core.database import DatabaseManager
+
+            db = DatabaseManager(str(db_path))
+            db.clear_feiniu_min_update_watermark()
+            v1 = db.get_or_create_feiniu_min_update_watermark_ms()
+            v2 = db.get_or_create_feiniu_min_update_watermark_ms()
+            assert v1 == v2
+            db.set_feiniu_min_update_watermark_now()
+            v3 = db.get_or_create_feiniu_min_update_watermark_ms()
+            assert v3 >= v1
+            db.clear_feiniu_min_update_watermark()
+            from app.core.database import FEINIU_MIN_UPDATE_WATERMARK_META_KEY
+
+            assert db.get_feiniu_meta(FEINIU_MIN_UPDATE_WATERMARK_META_KEY) is None

--- a/tests/services/test_feiniu_reader.py
+++ b/tests/services/test_feiniu_reader.py
@@ -1,0 +1,201 @@
+"""飞牛 reader 与 trimmedia 最小 schema"""
+
+import sqlite3
+from pathlib import Path
+
+from app.services.feiniu.reader import (
+    fetch_completed_watch_records,
+    list_feiniu_users,
+)
+
+
+def _create_trimmedia_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE user (
+        guid TEXT PRIMARY KEY,
+        username TEXT,
+        status INTEGER
+    )"""
+    )
+    c.execute(
+        """CREATE TABLE item (
+        guid TEXT PRIMARY KEY,
+        title TEXT,
+        original_title TEXT,
+        parent_guid TEXT,
+        runtime INTEGER,
+        episode_number INTEGER,
+        season_number INTEGER
+    )"""
+    )
+    c.execute(
+        """CREATE TABLE item_user_play (
+        item_guid TEXT,
+        user_guid TEXT,
+        watched INTEGER,
+        ts INTEGER,
+        create_time INTEGER,
+        update_time INTEGER,
+        visible INTEGER
+    )"""
+    )
+    c.execute("INSERT INTO user VALUES ('u1', 'fnviewer', 1)")
+    c.execute("INSERT INTO item VALUES ('ep1', '第2集', 'Ep2', NULL, 24, 2, 1)")
+    now_ms = 1_700_000_000_000
+    c.execute(
+        "INSERT INTO item_user_play VALUES ('ep1', 'u1', 1, 1440, ?, ?, 1)",
+        (now_ms, now_ms),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_list_feiniu_users_empty_path():
+    assert list_feiniu_users("") == []
+    assert list_feiniu_users("/nonexistent/trimmedia.db") == []
+
+
+def test_list_and_fetch_completed(tmp_path):
+    dbf = tmp_path / "trimmedia.db"
+    _create_trimmedia_db(dbf)
+    users = list_feiniu_users(str(dbf))
+    assert len(users) == 1
+    assert users[0].guid == "u1"
+    assert users[0].username == "fnviewer"
+
+    rows = fetch_completed_watch_records(
+        str(dbf),
+        user_guid="all",
+        time_range="all",
+        limit=50,
+        min_percent=80,
+    )
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.item_guid == "ep1"
+    assert r.user_guid == "u1"
+    assert r.username == "fnviewer"
+    assert r.episode == 2
+    assert r.season == 1
+    assert r.display_title == "第2集"
+
+
+def test_fetch_respects_min_percent(tmp_path):
+    dbf = tmp_path / "t2.db"
+    conn = sqlite3.connect(str(dbf))
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE user (guid TEXT PRIMARY KEY, username TEXT, status INTEGER)"
+    )
+    c.execute(
+        """CREATE TABLE item (
+        guid TEXT PRIMARY KEY, title TEXT, original_title TEXT,
+        parent_guid TEXT, runtime INTEGER, episode_number INTEGER
+    )"""
+    )
+    c.execute(
+        """CREATE TABLE item_user_play (
+        item_guid TEXT, user_guid TEXT, watched INTEGER, ts INTEGER,
+        create_time INTEGER, update_time INTEGER, visible INTEGER
+    )"""
+    )
+    c.execute("INSERT INTO user VALUES ('u1', 'a', 1)")
+    c.execute("INSERT INTO item VALUES ('e1', '第1集', NULL, NULL, 24, 1)")
+    # 24 分钟片长 → 1440 秒；ts=800 秒约 55% 视为已看（min_percent=5）
+    c.execute("INSERT INTO item_user_play VALUES ('e1', 'u1', 0, 800, 1000, 1000, 1)")
+    conn.commit()
+    conn.close()
+
+    low = fetch_completed_watch_records(
+        str(dbf), user_guid="all", time_range="all", limit=10, min_percent=95
+    )
+    assert low == []
+
+    high = fetch_completed_watch_records(
+        str(dbf), user_guid="all", time_range="all", limit=10, min_percent=5
+    )
+    assert len(high) == 1
+
+
+def test_fetch_respects_min_update_watermark(tmp_path):
+    """仅 update_time >= 水位线的记录参与（与启用起点一致）"""
+    dbf = tmp_path / "wm.db"
+    conn = sqlite3.connect(str(dbf))
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE user (guid TEXT PRIMARY KEY, username TEXT, status INTEGER)"
+    )
+    c.execute(
+        """CREATE TABLE item (
+        guid TEXT PRIMARY KEY, title TEXT, original_title TEXT,
+        parent_guid TEXT, runtime INTEGER, episode_number INTEGER
+    )"""
+    )
+    c.execute(
+        """CREATE TABLE item_user_play (
+        item_guid TEXT, user_guid TEXT, watched INTEGER, ts INTEGER,
+        create_time INTEGER, update_time INTEGER, visible INTEGER
+    )"""
+    )
+    c.execute("INSERT INTO user VALUES ('u1', 'a', 1)")
+    c.execute("INSERT INTO item VALUES ('old', '第1集', NULL, NULL, 24, 1)")
+    c.execute("INSERT INTO item VALUES ('new', '第2集', NULL, NULL, 24, 2)")
+    c.execute("INSERT INTO item_user_play VALUES ('old', 'u1', 1, 1440, 100, 100, 1)")
+    c.execute("INSERT INTO item_user_play VALUES ('new', 'u1', 1, 1440, 5000, 5000, 1)")
+    conn.commit()
+    conn.close()
+
+    wm = 2000
+    rows = fetch_completed_watch_records(
+        str(dbf),
+        user_guid="all",
+        time_range="all",
+        limit=10,
+        min_percent=1,
+        min_update_time_ms=wm,
+    )
+    assert len(rows) == 1
+    assert rows[0].item_guid == "new"
+
+
+def test_fetch_respects_user_guid_filter(tmp_path):
+    """user_guid 非 all 时只拉指定用户"""
+    dbf = tmp_path / "uf.db"
+    conn = sqlite3.connect(str(dbf))
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE user (guid TEXT PRIMARY KEY, username TEXT, status INTEGER)"
+    )
+    c.execute(
+        """CREATE TABLE item (
+        guid TEXT PRIMARY KEY, title TEXT, original_title TEXT,
+        parent_guid TEXT, runtime INTEGER, episode_number INTEGER
+    )"""
+    )
+    c.execute(
+        """CREATE TABLE item_user_play (
+        item_guid TEXT, user_guid TEXT, watched INTEGER, ts INTEGER,
+        create_time INTEGER, update_time INTEGER, visible INTEGER
+    )"""
+    )
+    c.execute("INSERT INTO user VALUES ('u1', 'a', 1)")
+    c.execute("INSERT INTO user VALUES ('u2', 'b', 1)")
+    c.execute("INSERT INTO item VALUES ('e1', '第1集', NULL, NULL, 24, 1)")
+    c.execute("INSERT INTO item VALUES ('e2', '第1集', NULL, NULL, 24, 1)")
+    c.execute("INSERT INTO item_user_play VALUES ('e1', 'u1', 1, 1440, 1, 1, 1)")
+    c.execute("INSERT INTO item_user_play VALUES ('e2', 'u2', 1, 1440, 2, 2, 1)")
+    conn.commit()
+    conn.close()
+
+    only_u2 = fetch_completed_watch_records(
+        str(dbf),
+        user_guid="u2",
+        time_range="all",
+        limit=10,
+        min_percent=1,
+    )
+    assert len(only_u2) == 1
+    assert only_u2[0].item_guid == "e2"
+    assert only_u2[0].user_guid == "u2"

--- a/tests/services/test_feiniu_scheduler.py
+++ b/tests/services/test_feiniu_scheduler.py
@@ -1,0 +1,23 @@
+"""飞牛调度器 Cron 解析"""
+
+from apscheduler.triggers.cron import CronTrigger
+
+from app.services.feiniu.scheduler import FeiniuScheduler
+
+
+def test_default_feiniu_cron_trigger():
+    s = FeiniuScheduler()
+    t = s._default_feiniu_cron_trigger()
+    assert isinstance(t, CronTrigger)
+
+
+def test_parse_cron_invalid_falls_back_to_default():
+    s = FeiniuScheduler()
+    t = s._parse_cron("not-five-fields")
+    assert isinstance(t, CronTrigger)
+
+
+def test_parse_cron_valid_five_fields():
+    s = FeiniuScheduler()
+    t = s._parse_cron("0 3 * * *")
+    assert isinstance(t, CronTrigger)

--- a/tests/services/test_feiniu_sync_service.py
+++ b/tests/services/test_feiniu_sync_service.py
@@ -1,0 +1,300 @@
+"""飞牛 sync_service 启动水位与 run_sync"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.sync import SyncResponse
+from app.services.feiniu.models import FeiniuWatchRecord
+from app.services.feiniu.sync_service import feiniu_sync_service
+
+
+def _enabled_cfg(db_path: str) -> dict:
+    return {
+        "enabled": True,
+        "db_path": db_path,
+        "user_filter": "all",
+        "time_range": "all",
+        "limit": 100,
+        "min_percent": 85,
+    }
+
+
+def _sample_record(**kwargs) -> FeiniuWatchRecord:
+    base = dict(
+        item_guid="it1",
+        user_guid="u1",
+        username="viewer",
+        display_title="测试番剧",
+        original_title=None,
+        season=1,
+        episode=1,
+        release_date="2024-01-01",
+        update_time_ms=1_700_000_000_000,
+    )
+    base.update(kwargs)
+    return FeiniuWatchRecord(**base)
+
+
+def test_ensure_feiniu_startup_watermark_when_missing():
+    from app.services.feiniu.sync_service import ensure_feiniu_startup_watermark
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = {
+            "enabled": True,
+            "db_path": "/fake/trimmedia.db",
+        }
+        with patch("app.services.feiniu.sync_service.Path") as PC:
+            path_mock = MagicMock()
+            path_mock.is_file.return_value = True
+            PC.return_value = path_mock
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_feiniu_meta.return_value = None
+                ensure_feiniu_startup_watermark()
+                dbm.set_feiniu_min_update_watermark_now.assert_called_once()
+
+
+def test_ensure_feiniu_startup_watermark_skips_when_meta_exists():
+    from app.services.feiniu.sync_service import ensure_feiniu_startup_watermark
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = {
+            "enabled": True,
+            "db_path": "/fake/trimmedia.db",
+        }
+        with patch("app.services.feiniu.sync_service.Path") as PC:
+            path_mock = MagicMock()
+            path_mock.is_file.return_value = True
+            PC.return_value = path_mock
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_feiniu_meta.return_value = "123"
+                ensure_feiniu_startup_watermark()
+                dbm.set_feiniu_min_update_watermark_now.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sync_not_enabled():
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = {"enabled": False, "db_path": "/x"}
+        r = await feiniu_sync_service.run_sync()
+    assert r.success is True
+    assert "未启用" in r.message
+    assert r.synced_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_empty_db_path():
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = {"enabled": True, "db_path": "  "}
+        r = await feiniu_sync_service.run_sync()
+    assert r.success is False
+    assert "db_path" in r.message
+
+
+@pytest.mark.asyncio
+async def test_run_sync_db_file_missing(tmp_path):
+    missing = tmp_path / "nope.db"
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(missing))
+        r = await feiniu_sync_service.run_sync()
+    assert r.success is False
+    assert "不存在" in r.message
+
+
+@pytest.mark.asyncio
+async def test_run_sync_success_saves_history(tmp_path):
+    dbf = tmp_path / "trim.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="success", message="已标记为看过")
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(dbf))
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = False
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync()
+    assert r.success is True
+    assert r.synced_count == 1
+    assert r.skipped_count == 0
+    assert r.error_count == 0
+    dbm.save_feiniu_sync_history.assert_called_once_with(
+        "u1", "it1", rec.update_time_ms
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_sync_error_does_not_save_history(tmp_path):
+    dbf = tmp_path / "trim2.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="error", message="未找到匹配的番剧")
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(dbf))
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = False
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync()
+    assert r.success is False
+    assert r.error_count == 1
+    dbm.save_feiniu_sync_history.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sync_ignored_counts_skipped(tmp_path):
+    dbf = tmp_path / "trim3.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="ignored", message="屏蔽关键词")
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(dbf))
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = False
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync()
+    assert r.success is True
+    assert r.skipped_count == 1
+    assert r.synced_count == 0
+    dbm.save_feiniu_sync_history.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sync_skips_video_placeholder_title(tmp_path):
+    dbf = tmp_path / "trim4.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record(display_title="视频-deadbeef", item_guid="vid1")
+
+    async def fail_to_thread(*_a, **_kw):
+        raise AssertionError("不应调用 Bangumi 同步")
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(dbf))
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = False
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                    side_effect=fail_to_thread,
+                ):
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync()
+    assert r.success is True
+    assert r.skipped_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_sync_skip_already_in_history(tmp_path):
+    dbf = tmp_path / "trim5.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record()
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = _enabled_cfg(str(dbf))
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = True
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                ) as tt:
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync()
+    assert r.success is True
+    assert r.skipped_count == 1
+    assert r.synced_count == 0
+    tt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sync_ignore_enabled_when_switch_off(tmp_path):
+    """ignore_enabled 时即使 Web 开关为关也执行扫描"""
+    dbf = tmp_path / "trim6.db"
+    dbf.write_bytes(b"")
+    rec = _sample_record()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="success", message="ok")
+
+    with patch("app.services.feiniu.sync_service.config_manager") as cm:
+        cm.get_feiniu_config.return_value = {
+            "enabled": False,
+            "db_path": str(dbf),
+            "user_filter": "all",
+            "time_range": "all",
+            "limit": 100,
+            "min_percent": 85,
+        }
+        with patch(
+            "app.services.feiniu.sync_service.fetch_completed_watch_records",
+            return_value=[rec],
+        ):
+            with patch("app.services.feiniu.sync_service.database_manager") as dbm:
+                dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
+                dbm.is_feiniu_item_synced.return_value = False
+                with patch(
+                    "app.services.feiniu.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.feiniu.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await feiniu_sync_service.run_sync(ignore_enabled=True)
+    assert r.synced_count == 1


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
✨ 新功能 (feature)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
- **飞牛影视同步**：只读 `trimmedia.db`，按水位与 Cron 扫描「已看完 / 达进度阈值」条目，经 `CustomItem` 走既有 Bangumi 同步；`sync_records.source` 为 `feiniu`（记录页筛选用中文「飞牛」展示）。
- **配置与 Docker**：`[feiniu]` 配置、环境变量 `FEINIU_DB_PATH`；推荐库挂载 `…:/app/data/feiniu-db:ro`，`db_path` 示例 `/app/data/feiniu-db/trimmedia.db`（含 Windows 路径说明）；默认 Cron **每 15 分钟** `*/15 * * * *`，与调度器回退一致。
- **调度与启动**：与 Trakt 同延迟启动；未启用或无有效库时不注册 APScheduler；启动日志表述与「不注册任务」对齐；进程启动时补写飞牛水位（手改 ini 启用场景）。
- **同步逻辑**：飞牛循环改为 `asyncio.to_thread(sync_custom_item)` 等待结果后再写 `feiniu_sync_history`；`sync_custom_item` 仍保持「多数校验失败不落库」的既有约定。
- **Web**：配置页飞牛卡片与各字段问号提示；记录/仪表板来源样式（`feiniu` 浅蓝、`test` 灰）；调试页「立即触发飞牛同步」对接 `POST /api/feiniu/sync/manual`。
- **测试**：补充 `run_sync`、API（含 `/users`、手动同步与 `user` 查询）、reader 用户过滤、调度 Cron 解析等单测；API mock 默认 15 分钟 Cron。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
飞牛同步功能非经详细测试，可能存在bug，后续反馈有问题再修