### PR TITLE
fix: 修复无发行日期时报错崩溃，并深度优化番剧别名识别准确率

### DIFF
--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -801,23 +801,45 @@ class BangumiApi:
         return res
 
     def bgm_search(self, title, ori_title, premiere_date: str, is_movie=False):
-        air_date = datetime.datetime.fromisoformat(premiere_date[:10])
-        start_date = air_date - datetime.timedelta(days=2)
-        end_date = air_date + datetime.timedelta(days=2)
         bgm_data = None
-        if ori_title:
-            bgm_data = self.search(
-                title=ori_title, start_date=start_date, end_date=end_date
-            )
-        bgm_data = bgm_data or self.search(
-            title=title, start_date=start_date, end_date=end_date
-        )
-        if not bgm_data and is_movie:
-            title = ori_title or title
-            end_date = air_date + datetime.timedelta(days=200)
-            bgm_data = self.search(
-                title=title, start_date=start_date, end_date=end_date
-            )
+        start_date_str = "无日期"
+        end_date_str = "无日期"
+
+        # 尝试使用 v0 接口进行带首播日期的精确搜索
+        if premiere_date and len(premiere_date) >= 10:
+            try:
+                air_date = datetime.datetime.fromisoformat(premiere_date[:10])
+                start_date = air_date - datetime.timedelta(days=2)
+                end_date = air_date + datetime.timedelta(days=2)
+
+                start_date_str = start_date.strftime("%Y-%m-%d")
+                end_date_str = end_date.strftime("%Y-%m-%d")
+
+                if ori_title:
+                    bgm_data = self.search(
+                        title=ori_title,
+                        start_date=start_date_str,
+                        end_date=end_date_str,
+                    )
+                bgm_data = bgm_data or self.search(
+                    title=title, start_date=start_date_str, end_date=end_date_str
+                )
+
+                if not bgm_data and is_movie:
+                    movie_search_title = ori_title or title
+                    movie_end_date = air_date + datetime.timedelta(days=200)
+                    end_date_str = movie_end_date.strftime("%Y-%m-%d")
+                    bgm_data = self.search(
+                        title=movie_search_title,
+                        start_date=start_date_str,
+                        end_date=end_date_str,
+                    )
+            except ValueError:
+                logger.warning(
+                    f"首播日期格式解析失败: {premiere_date}，降级至无日期模式搜索"
+                )
+
+        # 若精确搜索无结果或相似度低于阈值，使用旧版接口进行无日期名称搜索
         if not bgm_data or (
             bgm_data
             and len(bgm_data) > 0
@@ -826,28 +848,77 @@ class BangumiApi:
             )
             < 0.5
         ):
-            for t in ori_title, title:
-                bgm_data = self.search_old(title=t)
-                if (
-                    bgm_data
-                    and len(bgm_data) > 0
-                    and self.title_diff_ratio(title, ori_title, bgm_data=bgm_data[0])
-                    > 0.5
-                ):
-                    break
+            # 过滤无效的空标题
+            search_titles = [t for t in (ori_title, title) if t and t.strip()]
+
+            for t in search_titles:
+                bgm_data_old = self.search_old(title=t)
+
+                if bgm_data_old and len(bgm_data_old) > 0:
+                    # 旧版接口返回数据不含 infobox 别名信息，需拉取完整条目进行准确相似度计算
+                    subject_id = bgm_data_old[0]["id"]
+                    full_info = self.get_subject(subject_id)
+
+                    if (
+                        full_info
+                        and self.title_diff_ratio(title, ori_title, bgm_data=full_info)
+                        > 0.5
+                    ):
+                        # 包装为统一的列表格式返回
+                        bgm_data = [full_info]
+                        break
             else:
                 bgm_data = None
+
         if not bgm_data or len(bgm_data) == 0:
-            return
-        logger.debug(f"{start_date} {end_date} {bgm_data}")
+            return None
+
+        logger.debug(
+            f"搜索日期区间: {start_date_str} 至 {end_date_str} | 结果: {bgm_data[0].get('name')}"
+        )
         return bgm_data
 
     @staticmethod
     def title_diff_ratio(title, ori_title, bgm_data):
         ori_title = ori_title or title
-        ratio = max(
-            difflib.SequenceMatcher(None, bgm_data["name"], ori_title).quick_ratio(),
-            difflib.SequenceMatcher(None, bgm_data["name_cn"], title).quick_ratio(),
-            difflib.SequenceMatcher(None, bgm_data["name"], title).quick_ratio(),
-        )
-        return ratio
+        candidates = []
+
+        # 提取基础候选项：原名与中文名
+        if bgm_data.get("name"):
+            candidates.append(bgm_data["name"])
+        if bgm_data.get("name_cn"):
+            candidates.append(bgm_data["name_cn"])
+
+        # 提取 infobox 中的别名，兼容多种历史数据格式
+        infobox = bgm_data.get("infobox", [])
+        if isinstance(infobox, list):
+            for info in infobox:
+                if info.get("key") == "别名":
+                    alias_value = info.get("value")
+                    if isinstance(alias_value, list):
+                        for alias_item in alias_value:
+                            if isinstance(alias_item, dict) and "v" in alias_item:
+                                candidates.append(alias_item["v"])
+                            elif isinstance(alias_item, str):
+                                candidates.append(alias_item)
+                    elif isinstance(alias_value, str):
+                        candidates.append(alias_value)
+                    break
+
+        # 计算所有候选项的相似度，取最大值
+        max_ratio = 0.0
+        for candidate in candidates:
+            if not candidate:
+                continue
+
+            ratio_title = difflib.SequenceMatcher(None, candidate, title).quick_ratio()
+            ratio_ori = difflib.SequenceMatcher(
+                None, candidate, ori_title
+            ).quick_ratio()
+            max_ratio = max(max_ratio, ratio_title, ratio_ori)
+
+            # 若发现完全匹配，提前返回
+            if max_ratio >= 1.0:
+                return 1.0
+
+        return max_ratio

--- a/tests/utils/test_bangumi_api_http.py
+++ b/tests/utils/test_bangumi_api_http.py
@@ -279,3 +279,117 @@ def test_api_auth_error():
 
     with pytest.raises(ValueError, match="认证失败"):
         api.get_me()
+
+
+@responses.activate
+def test_bgm_search_invalid_date_fallback():
+    """测试 bgm_search: 遇到无效日期时使用无日期搜索"""
+    api = BangumiApi()
+
+    # 模拟无日期搜索成功
+    responses.add(
+        responses.GET,
+        "https://api.bgm.tv//search/subject/%E6%B5%8B%E8%AF%95%E7%95%AA%E5%89%A7?type=2",
+        json={"list": [{"id": 999, "name": "Test Anime", "name_cn": "测试番剧"}]},
+        status=200,
+    )
+
+    # 模拟获取条目详情
+    responses.add(
+        responses.GET,
+        "https://api.bgm.tv/v0/subjects/999",
+        json={"id": 999, "name": "Test Anime", "name_cn": "测试番剧"},
+        status=200,
+    )
+
+    # 传入空字符串作为首播日期
+    result = api.bgm_search(title="测试番剧", ori_title="", premiere_date="")
+
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["id"] == 999
+
+
+@responses.activate
+def test_bgm_search_alias_fallback_success():
+    """测试 bgm_search: 通过旧版接口与详情接口获取 infobox 别名进行匹配"""
+    api = BangumiApi()
+
+    # 模拟带日期搜索无结果
+    responses.add(
+        responses.POST,
+        "https://api.bgm.tv/v0/search/subjects",
+        json={"data": []},
+        status=200,
+    )
+
+    # 模拟无日期搜索返回简略信息（无 infobox）
+    responses.add(
+        responses.GET,
+        "https://api.bgm.tv//search/subject/%E5%85%B7%E8%B1%A1%E9%9D%A9%E5%91%BD%20%E8%B6%85%E4%BA%BA%E5%B9%BB%E6%83%B3?type=2",
+        json={
+            "list": [
+                {
+                    "id": 139022,
+                    "name": "Concrete Revolutio",
+                    "name_cn": "Concrete Revolutio 超人幻想",
+                }
+            ]
+        },
+        status=200,
+    )
+
+    # 模拟通过 ID 获取包含 infobox 别名的完整数据
+    responses.add(
+        responses.GET,
+        "https://api.bgm.tv/v0/subjects/139022",
+        json={
+            "id": 139022,
+            "name": "Concrete Revolutio",
+            "name_cn": "Concrete Revolutio 超人幻想",
+            "infobox": [
+                {"key": "放送开始", "value": "2015年10月4日"},
+                {
+                    "key": "别名",
+                    "value": [{"v": "具象革命 超人幻想"}, {"v": "コンレボ"}],
+                },
+            ],
+        },
+        status=200,
+    )
+
+    # 模拟传入单集日期与别名
+    result = api.bgm_search(
+        title="具象革命 超人幻想", ori_title="", premiere_date="2015-12-26"
+    )
+
+    # 断言匹配成功并返回正确的条目 ID
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["id"] == 139022
+
+
+def test_title_diff_ratio_infobox_extraction():
+    """测试 title_diff_ratio: 提取 infobox 别名并计算相似度"""
+    api = BangumiApi()
+
+    bgm_data_mock = {
+        "name": "Original Name",
+        "name_cn": "中文主标题",
+        "infobox": [
+            {"key": "其他信息", "value": "无关内容"},
+            {"key": "别名", "value": [{"v": "别名格式1"}, "纯字符串别名格式2"]},
+        ],
+    }
+
+    # 命中中文主标题
+    assert api.title_diff_ratio("中文主标题", "", bgm_data_mock) == 1.0
+
+    # 命中字典格式别名
+    assert api.title_diff_ratio("别名格式1", "", bgm_data_mock) == 1.0
+
+    # 命中字符串格式别名
+    assert api.title_diff_ratio("纯字符串别名格式2", "", bgm_data_mock) == 1.0
+
+    # 无关名称，相似度应低于阈值
+    assert api.title_diff_ratio("毫无关系的名称", "", bgm_data_mock) < 0.5


### PR DESCRIPTION
纯ai vibe coding（）修复我遇到的两个问题：
```
[2026/04/16 10:28:11.973] [INFO] 接收到同步请求：media_type='episode' title='具象革命 超人幻想' ori_title=' ' season=1 episode=13 release_date='2015-12-26' user_name='Elegy233' source='emby'
[2026/04/16 10:28:11.973] [INFO] Emby webhook已提交异步任务: emby_9_1776306491
[2026/04/16 10:28:18.068] [ERROR] bgm: 未查询到番剧信息，跳过

[2026/04/16 10:32:11.534] [INFO] 接收到同步请求：media_type='episode' title='混凝土革命 超人幻想' ori_title='' season=1 episode=13 release_date='' user_name='Elegy233' source='test'
[2026/04/16 10:32:12.926] [INFO] 通过 bangumi-data 匹配到番剧 ID: 139022, 匹配标题: Concrete Revolutio 超人幻想, 日期匹配: False
[2026/04/16 10:32:14.009] [INFO] bgm: 混凝土革命 超人幻想 S01E13 已看过，不再重复标记

[2026/04/16 10:31:38.384] [INFO] 接收到同步请求：media_type='episode' title='具象革命 超人幻想' ori_title='' season=1 episode=13 release_date='' user_name='Elegy233' source='test'
[2026/04/16 10:31:39.823] [ERROR] bgm API搜索出错: Invalid isoformat string: ''

```
1.`具象革命 超人幻想`同样是[Concrete Revolutio 超人幻想](https://chii.in/subject/139022)的别名但是没有被Bangumi-data数据源收录，触发了兜底搜索但是兜底搜索只会拿主标题去对比导致结果被抛弃了
2.发生在Bangumi-data未启用，当没有发行日期的时候引发了ValueError: Invalid isoformat string: ''，导致整个搜索逻辑崩溃

话说我好像没权限添加Labels（）是因为是首次提交吗，另外我不是很确定添加的测试函数是否有必要，姑且按照标准添加了

## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)
🚀 优化/重构 (perf/refactor)

### 变更内容
本次 PR 主要解决了当媒体库（Plex/Emby）传入空发行日期，以及番剧使用非官方主译名（别名）时导致的刮削与同步失败问题：

1. **修复日期解析崩溃**：在 `bgm_search` 中增加对 `premiere_date` 的空值与合法性校验，避免 `datetime.fromisoformat` 解析空字符串引发 `ValueError`，在无日期时平滑降级至无日期的兜底搜索流程。
2. **深度优化别名识别准确率**：重构 `title_diff_ratio` 逻辑，深入解析 `infobox` 字段，提取并兼容各类格式的民间别名/外语名加入候选比对池，一旦命中别名立即短路返回（匹配度 1.0）。
3. **修复旧版接口数据残缺导致的误判**：旧版 `/search/subject/` 兜底接口返回的数据缺乏 `infobox`，导致重构后的别名逻辑无法生效。新增逻辑：在旧接口召回结果后，利用实例缓存 `self.get_subject(id)` 拉取完整条目再进行相似度计算，补全别名数据链路。
4. **新增单元测试**：在 `test_bangumi_api_http.py` 中补充了使用 `responses` 拦截的 Mock 测试，全面覆盖上述边缘场景。

### 相关 Issue
无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
- `app/utils/bangumi_api.py` 的测试覆盖率通过本次新增的用例已提升至 57%。
