### PR TITLE
fix: 提高日期数据权重，修复同名前传条目抢占正片导致季数错位的 Bug

### DIFF
--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -365,44 +365,53 @@ class BangumiData:
             # 按匹配类型排序，优先使用中文翻译匹配
             exact_matches.sort(key=lambda x: x[2])
 
-            if release_date and len(exact_matches) > 1:
-                # 如果有多个相同类型的匹配，使用日期最接近的
-                match_type = exact_matches[0][2]
-                matches_of_same_type = [m for m in exact_matches if m[2] == match_type]
+            if release_date:
+                min_exact_diff = float("inf")
+                best_exact_match = None
 
-                if len(matches_of_same_type) > 1:
+                # 找到日期最近的完全匹配
+                for match_item, match_id, match_type in exact_matches:
+                    if "begin" in match_item:
+                        diff = self._date_diff(match_item["begin"], release_date)
+                        if diff < min_exact_diff:
+                            min_exact_diff = diff
+                            best_exact_match = (match_item, match_id, match_type)
+
+                # 当完全匹配的最佳日期相差大于 180 天时，检查部分匹配列表中是否存在日期更接近的条目
+                # 用于处理同名 OVA 或前传导致误判正片的情况
+                if min_exact_diff > 180 and partial_matches:
                     logger.debug(
-                        f"发现 {len(matches_of_same_type)} 个相同类型的匹配，使用日期进行进一步筛选"
+                        f"完全匹配的最佳日期误差高达 {min_exact_diff} 天，启动全局日期择优机制"
                     )
-                    closest_match = None
-                    min_diff = float("inf")
+                    min_partial_diff = float("inf")
+                    best_partial_match = None
 
-                    for match_item, match_id, _ in matches_of_same_type:
+                    for match_item, score, match_id in partial_matches:
                         if "begin" in match_item:
                             diff = self._date_diff(match_item["begin"], release_date)
-                            logger.debug(
-                                f"  候选: {match_item.get('title', '')} (ID: {match_id}), "
-                                f"日期: {match_item['begin']}, 与目标日期差距: {diff}天"
-                            )
-                            if diff < min_diff:
-                                min_diff = diff
-                                closest_match = (match_item, match_id)
+                            if diff < min_partial_diff:
+                                min_partial_diff = diff
+                                best_partial_match = (match_item, match_id, score)
 
-                    if closest_match:
-                        logger.debug(
-                            f"找到最佳日期匹配的番剧: {closest_match[0].get('title', '')}, "
-                            f"bangumi_id: {closest_match[1]}, 日期差距: {min_diff}天"
+                    # 若部分匹配中有日期误差小于等于 90 天的条目，优先采用该部分匹配条目
+                    if best_partial_match and min_partial_diff <= 90:
+                        matched_title = self._get_best_matched_title(
+                            best_partial_match[0]
                         )
-                        # 获取匹配到的标题
-                        matched_title = self._get_best_matched_title(closest_match[0])
-                        # 如果是通过日期匹配找到的，且是非第一季，标记为可信的季度ID
-                        date_matched = season > 1
-                        if date_matched:
-                            logger.info(
-                                f"通过日期匹配找到特定季度 (season={season})，"
-                                f"标记为可信的季度ID，跳过续集遍历"
-                            )
-                        return (closest_match[1], matched_title, date_matched)
+                        logger.info(
+                            f"因完全匹配结果日期差异过大，采纳日期择优番剧: {matched_title}， (日期差距 {min_partial_diff} 天)"
+                        )
+                        # 通过日期严格筛选，标记为可信季度ID (date_matched = True)
+                        return (best_partial_match[1], matched_title, True)
+
+                # 处理存在多个完全匹配的情况，返回日期最接近的条目
+                if len(exact_matches) > 1 and best_exact_match:
+                    logger.debug(
+                        f"从多个完全匹配中择优: {best_exact_match[0].get('title', '')}, 日期差距: {min_exact_diff}天"
+                    )
+                    matched_title = self._get_best_matched_title(best_exact_match[0])
+                    date_matched = season > 1
+                    return (best_exact_match[1], matched_title, date_matched)
 
             # 返回最高优先级的匹配结果
             result_item = exact_matches[0][0]

--- a/tests/utils/test_bangumi_data_comprehensive.py
+++ b/tests/utils/test_bangumi_data_comprehensive.py
@@ -2,6 +2,8 @@
 Bangumi 数据工具完整测试
 """
 
+from unittest.mock import patch
+
 from app.utils.bangumi_data import BangumiData
 
 
@@ -67,6 +69,43 @@ class TestBangumiDataMatching:
 
         result = data._is_date_close("2024-01-01", "2024-01-10")
         assert isinstance(result, bool)
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_find_bangumi_id_optimized_date_override(
+        self, mock_parse_data, mock_preload
+    ):
+        """测试日期择优机制：当完全匹配的日期差距过大时，采用日期接近的部分匹配"""
+        data = BangumiData()
+
+        # 模拟内存中的 bangumi-data 数据流
+        mock_parse_data.return_value = [
+            {
+                "title": "玉响",
+                "titleTranslate": {"zh-Hans": ["玉响"]},
+                "begin": "2010-11-26",
+                "sites": [{"site": "bangumi", "id": "8452"}],
+            },
+            {
+                "title": "たまゆら～hitotose～",
+                "titleTranslate": {"zh-Hans": ["玉响～hitotose～", "玉响～1年～"]},
+                "begin": "2011-10-03",
+                "sites": [{"site": "bangumi", "id": "18605"}],
+            },
+        ]
+
+        # 模拟 Emby 传入的请求：标题完全等于 OVA，但给定的播出时间是正片第一季的时间
+        result = data._find_bangumi_id_optimized(
+            title="玉响", ori_title="", release_date="2011-10-02", season=1
+        )
+
+        # 断言：必须舍弃 ID 8452，返回正片第一季的 ID 18605
+        assert result is not None
+        assert result[0] == "18605"
+        # 断言：返回的应当是最佳中文匹配名
+        assert result[1] == "玉响～hitotose～"
+        # 断言：由于是严格依靠日期反杀的，可信度必须被标记为 True
+        assert result[2] is True
 
 
 class TestBangumiDataTitle:


### PR DESCRIPTION
主要修复朋友碰到的下列问题：
```
[2026/04/17 17:49:08.518] [INFO] 接收到同步请求：media_type='episode' title='玉响' ori_title=' ' season=1 episode=1 release_date='2011-10-02' user_name='Elegy233' source='emby'
[2026/04/17 17:49:11.704] [INFO] 通过 bangumi-data 匹配到番剧 ID: 8452, 匹配标题: 玉响, 日期匹配: False
[2026/04/17 17:49:13.612] [INFO] bgm: 玉响 S01E01 已看过，不再重复标记
```

这部番比较特殊， [玉响](https://chii.in/subject/8452)(OVA) 是 [玉响～hitotose～](https://chii.in/subject/18605)(正传)的前传，同步时传S1会点OVA前传，传S2才会点正传


## 📝 PR 描述

### 变更类型
- 🐛 Bug 修复 (bug)
- 🚀 优化/重构 (perf/refactor)

### 变更内容
本次 PR 主要解决了当番剧的 OVA 或前传（如《玉响》OVA）与总 IP 同名时，触发最高优先级完全匹配，从而导致后续正片（如《玉响～hitotose～》）的季数刮削全部发生偏移（Off-by-one）的问题。

1. **新增全局日期择优（覆盖）机制**：在 `bangumi_data.py` 的 `_find_bangumi_id_optimized` 方法中，当完全匹配项的首播日期与媒体库传入的 `release_date` 误差超过 180 天时，触发全局日期复查。若部分匹配候选池中存在日期误差在 90 天以内的条目，则舍弃完全匹配，优先采用日期更吻合的部分匹配条目。
2. **新增离线 Mock 单元测试**：在 `test_bangumi_data_comprehensive.py` 中新增 `test_find_bangumi_id_optimized_date_override`。通过 `@patch` 拦截底层的 `_parse_data` 和 `_preload_data_to_memory`，在零网络请求的情况下，精准模拟了“完全匹配但日期错误”与“部分匹配但日期精确”的冲突场景，确保该机制长期稳定。

### 相关 Issue
无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明