### PR TITLE
fix: 修复查询trakt同步历史没有过滤其他来源的问题

### DIFF
--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -335,7 +335,7 @@ class TraktConfigPage {
         try {
             this.showLoading('sync-history-body', '正在加载同步历史...');
 
-            const response = await fetch(appUrl(`/api/records?limit=${this.pageSize}&offset=${(this.currentPage - 1) * this.pageSize}`));
+            const response = await fetch(appUrl(`/api/records?limit=${this.pageSize}&offset=${(this.currentPage - 1) * this.pageSize}&source=trakt`));
 
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}`);


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
Trakt 配置页「同步历史」表格原先请求 `/api/records` 时未带来源参数，会混入其他来源的同步记录。本次在 `static/js/trakt/config.js` 的 `loadSyncHistory()` 中为该请求增加查询参数 `source=trakt`，使该页仅展示来源为 Trakt 的同步历史；其他页面（如全局记录页）的请求逻辑未改动。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
