### PR TITLE
fix: 为日期择优的采纳增加安全校验，避免遇到相似结果产生误判

### DIFF
--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -393,16 +393,30 @@ class BangumiData:
                                 min_partial_diff = diff
                                 best_partial_match = (match_item, match_id, score)
 
-                    # 若部分匹配中有日期误差小于等于 90 天的条目，优先采用该部分匹配条目
+                    # 若部分匹配中有日期误差小于等于 90 天的条目，启动安全校验决定是否采用该部分匹配条目
                     if best_partial_match and min_partial_diff <= 90:
-                        matched_title = self._get_best_matched_title(
-                            best_partial_match[0]
+                        pm_item = best_partial_match[0]
+                        pm_score = best_partial_match[2]
+                        # 收集该条目的原名和所有中文翻译
+                        pm_all_names = [
+                            pm_item.get("title", "")
+                        ] + self._get_zh_hans_titles(pm_item)
+
+                        # 安全校验：搜索词必须被包含在候选名的其中之一里，或者模糊匹配相似度 > 0.8
+                        is_safe_to_override = pm_score >= 0.8 or any(
+                            title in name for name in pm_all_names
                         )
-                        logger.info(
-                            f"因完全匹配结果日期差异过大，采纳日期择优番剧: {matched_title}， (日期差距 {min_partial_diff} 天)"
-                        )
-                        # 通过日期严格筛选，标记为可信季度ID (date_matched = True)
-                        return (best_partial_match[1], matched_title, True)
+
+                        if is_safe_to_override:
+                            matched_title = self._get_best_matched_title(pm_item)
+                            logger.debug(
+                                f"因完全匹配结果日期差异过大，采纳日期择优番剧: {matched_title} (日期差距 {min_partial_diff} 天)"
+                            )
+                            return (best_partial_match[1], matched_title, True)
+                        else:
+                            logger.debug(
+                                f"拒绝日期择优: {pm_item.get('title', '')} 虽然日期接近，但名称差异过大"
+                            )
 
                 # 处理存在多个完全匹配的情况，返回日期最接近的条目
                 if len(exact_matches) > 1 and best_exact_match:

--- a/tests/utils/test_bangumi_data_comprehensive.py
+++ b/tests/utils/test_bangumi_data_comprehensive.py
@@ -107,6 +107,43 @@ class TestBangumiDataMatching:
         # 断言：由于是严格依靠日期反杀的，可信度必须被标记为 True
         assert result[2] is True
 
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_find_bangumi_id_date_override_rejected_by_safety_lock(
+        self, mock_parse_data, mock_preload
+    ):
+        """测试日期择优机制的安全校验：当日期接近但名称完全不包含时，拒绝采用该匹配条目"""
+        data = BangumiData()
+
+        # 模拟内存数据：小圆和伊莉雅的哈希碰撞
+        mock_parse_data.return_value = [
+            {
+                "title": "魔法少女まどか☆マギカ",
+                "titleTranslate": {"zh-Hans": ["魔法少女小圆"]},
+                "begin": "2011-01-07",
+                "sites": [{"site": "bangumi", "id": "10001"}],
+            },
+            {
+                "title": "Fate/kaleid liner プリズマ☆イリヤ",
+                "titleTranslate": {"zh-Hans": ["魔法少女伊莉雅"]},
+                "begin": "2013-07-13",
+                "sites": [{"site": "bangumi", "id": "90009"}],
+            },
+        ]
+
+        # 模拟请求：搜索“魔法少女小圆”，但传入的是 2013 年（伊莉雅播出的时间）
+        # 此时伊莉雅因为带有“魔法少女”四个字，会有基础模糊得分，且日期极度接近
+        result = data._find_bangumi_id_optimized(
+            title="魔法少女小圆", ori_title="", release_date="2013-07-12", season=1
+        )
+
+        # 断言：安全校验必须生效拒绝采用，退回到完全匹配（小圆的 ID 10001）
+        assert result is not None
+        assert result[0] == "10001"
+        assert result[1] == "魔法少女小圆"
+        # 断言：由于防误判锁生效拒绝了日期择优，可信度必须退回到 False，交给后端去爬树
+        assert result[2] is False
+
 
 class TestBangumiDataTitle:
     """标题处理测试"""


### PR DESCRIPTION
主要是对 https://github.com/SanaeMio/Bangumi-syncer/pull/117 的防御性改进，直接跳过关系链采纳日期最接近的部分匹配结果还是太激进了，如果有名称非常接近且日期也接近的结果就会误判，
其实也能做成依旧使用完美匹配结果爬关系链，在关系链里面选择日期最接近的，这是保守手段但是相比现在的方案会额外请求很多次relation接口，并且为了解决上个pr玉响番剧问题还得让S1也请求relation（
所以还是在当前方案基础上增加安全校验，提高标题相似度阀值

## 📝 PR 描述

### 变更类型
- 🐛 Bug 修复 (bug)
- 🚀 优化/重构 (perf/refactor)

### 变更内容
本次 PR 是对 `bangumi_data.py` 中“全局日期择优机制”的防御性增强，旨在解决当不同番剧具有相似通用前缀（如“魔法少女小圆”与“魔法少女伊莉雅”）且播出日期接近时，可能引发的误判（哈希碰撞）问题。

1. **引入严格名称包含安全锁**：在部分匹配结果触发“90天内日期反杀”逻辑前，新增 `is_safe_to_override` 校验。
2. **多语言别名核验**：系统会提取部分匹配条目的日文原名及所有中文翻译 (`titleTranslate.zh-Hans`)，要求搜索词必须**被完整包含**在候选名的其中之一内，或者其模糊匹配相似度达到极高阈值（`>= 0.8`），才允许执行日期择优替换。
3. **安全降级策略**：若日期符合但名称未通过安全锁（名称差异过大），系统将拒绝择优，撤销可信度标记（`date_matched = False`），并安全退回后端的常规网络请求爬树流程。
4. **新增防撞击单测**：在 `test_bangumi_data_comprehensive.py` 中新增负面测试用例 `test_find_bangumi_id_date_override_rejected_by_safety_lock`。通过 Mock 模拟名称相似但完全无关的条目碰撞场景，验证安全锁能够正确拦截并拒绝误判。

### 相关 Issue
无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
- 本次优化遵循防御性编程原则，确保“日期择优机制”在解决 OVA 抢占问题的同时，将误杀率严格控制为零。