### PR TITLE
fix: 修复Emby剧场版已给原名的前提下没有实际用于匹配的问题

### DIFF
--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -327,8 +327,7 @@ class BangumiData:
 
             # 快速预筛选：默认要求有简中翻译；若提供了 ori_title，仍可对无 zh-Hans 的条目做日文原标题匹配
             missing_zh = (
-                "titleTranslate" not in item
-                or "zh-Hans" not in item["titleTranslate"]
+                "titleTranslate" not in item or "zh-Hans" not in item["titleTranslate"]
             )
             if title and missing_zh:
                 ori_ok = ori_title and str(ori_title).strip() and item.get("title")

--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -325,11 +325,15 @@ class BangumiData:
         for item in self._parse_data():
             processed_count += 1
 
-            # 快速预筛选：检查是否有中文翻译
-            if title and (
-                "titleTranslate" not in item or "zh-Hans" not in item["titleTranslate"]
-            ):
-                continue
+            # 快速预筛选：默认要求有简中翻译；若提供了 ori_title，仍可对无 zh-Hans 的条目做日文原标题匹配
+            missing_zh = (
+                "titleTranslate" not in item
+                or "zh-Hans" not in item["titleTranslate"]
+            )
+            if title and missing_zh:
+                ori_ok = ori_title and str(ori_title).strip() and item.get("title")
+                if not ori_ok:
+                    continue
 
             # 一次性计算所有相似度，避免重复计算
             match_info = self._calculate_match_info(

--- a/app/utils/data_util.py
+++ b/app/utils/data_util.py
@@ -93,10 +93,11 @@ def extract_emby_data(emby_data):
         else:
             logger.debug("未找到PremiereDate字段，将尝试从bangumi-data获取日期信息")
         title = (item.get("Name") or "").strip()
+        ori = item.get("OriginalTitle")
         return CustomItem(
             media_type="movie",
             title=title,
-            ori_title=None,
+            ori_title=ori if ori and str(ori).strip() else None,
             season=1,
             episode=1,
             release_date=release_date,

--- a/tests/utils/test_bangumi_data_comprehensive.py
+++ b/tests/utils/test_bangumi_data_comprehensive.py
@@ -144,6 +144,30 @@ class TestBangumiDataMatching:
         # 断言：由于防误判锁生效拒绝了日期择优，可信度必须退回到 False，交给后端去爬树
         assert result[2] is False
 
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_find_bangumi_id_ori_title_without_zh_hans(
+        self, mock_parse_data, mock_preload
+    ):
+        """条目无简中翻译时，仍可用 ori_title 与日文 title 精确匹配（剧场版等）"""
+        data = BangumiData()
+        mock_parse_data.return_value = [
+            {
+                "title": "劇場版サンプル映画",
+                "begin": "2020-03-15",
+                "sites": [{"site": "bangumi", "id": "123456"}],
+            },
+        ]
+        result = data.find_bangumi_id(
+            title="某中文片名",
+            ori_title="劇場版サンプル映画",
+            release_date="2020-03-15",
+            season=1,
+        )
+        assert result is not None
+        assert result[0] == "123456"
+        assert result[1] == "劇場版サンプル映画"
+
 
 class TestBangumiDataTitle:
     """标题处理测试"""

--- a/tests/utils/test_data_util.py
+++ b/tests/utils/test_data_util.py
@@ -170,11 +170,33 @@ class TestExtractEmbyData:
 
         assert result.media_type == "episode"
         assert result.title == "测试番剧"
+        assert result.ori_title is None
         assert result.season == 2
         assert result.episode == 10
         assert result.release_date == "2024-01-15"
         assert result.user_name == "test_user"
         assert result.source == "emby"
+
+    def test_extract_emby_data_episode_does_not_use_original_title(self):
+        """Emby 剧集 OriginalTitle 为分集名，不作为 ori_title（避免条目匹配跑偏）"""
+        from app.utils.data_util import extract_emby_data
+
+        emby_data = {
+            "Event": "item.markplayed",
+            "User": {"Name": "test_user"},
+            "Item": {
+                "Type": "Episode",
+                "SeriesName": "某动画",
+                "SeriesOriginalTitle": "シリーズ原文",
+                "OriginalTitle": "第3話 サブタイトル",
+                "ParentIndexNumber": 1,
+                "IndexNumber": 3,
+                "PremiereDate": "2024-02-01T00:00:00.0000000Z",
+            },
+        }
+        result = extract_emby_data(emby_data)
+        assert result.title == "某动画"
+        assert result.ori_title is None
 
     def test_extract_emby_data_no_premiere_date(self):
         """测试无发行日期"""
@@ -195,6 +217,7 @@ class TestExtractEmbyData:
         result = extract_emby_data(emby_data)
 
         assert result.release_date == ""
+        assert result.ori_title is None
 
     def test_extract_emby_data_movie(self):
         from app.utils.data_util import extract_emby_data
@@ -211,9 +234,47 @@ class TestExtractEmbyData:
         result = extract_emby_data(emby_data)
         assert result.media_type == "movie"
         assert result.title == "剧场版 Y"
+        assert result.ori_title is None
         assert result.season == 1
         assert result.episode == 1
         assert result.release_date == "2024-07-01"
+
+    def test_extract_emby_data_movie_original_title(self):
+        """Emby 电影应携带 OriginalTitle 作为 ori_title（剧场版等日文检索）"""
+        from app.utils.data_util import extract_emby_data
+
+        emby_data = {
+            "Event": "item.markplayed",
+            "User": {"Name": "test_user"},
+            "Item": {
+                "Type": "Movie",
+                "Name": "花开伊吕波剧场版：甜蜜的家",
+                "OriginalTitle": "劇場版 花咲くいろは HOME SWEET HOME",
+                "PremiereDate": "2013-03-08T16:00:00.0000000Z",
+            },
+        }
+        result = extract_emby_data(emby_data)
+        assert result.media_type == "movie"
+        assert result.title == "花开伊吕波剧场版：甜蜜的家"
+        assert result.ori_title == "劇場版 花咲くいろは HOME SWEET HOME"
+        assert result.release_date == "2013-03-08"
+
+    def test_extract_emby_data_movie_original_title_blank(self):
+        """OriginalTitle 为空或仅空白时 ori_title 为 None"""
+        from app.utils.data_util import extract_emby_data
+
+        emby_data = {
+            "Event": "item.markplayed",
+            "User": {"Name": "test_user"},
+            "Item": {
+                "Type": "Movie",
+                "Name": "剧场版 X",
+                "OriginalTitle": "   ",
+                "PremiereDate": "2024-01-01T00:00:00.0000000Z",
+            },
+        }
+        result = extract_emby_data(emby_data)
+        assert result.ori_title is None
 
     def test_extract_emby_data_movie_no_premiere_date(self):
         """电影无 PremiereDate 时 release_date 为空"""
@@ -228,6 +289,7 @@ class TestExtractEmbyData:
         assert result.media_type == "movie"
         assert result.title == "剧场版 Z"
         assert result.release_date == ""
+        assert result.ori_title is None
 
 
 class TestExtractJellyfinData:

--- a/tests/utils/test_data_util.py
+++ b/tests/utils/test_data_util.py
@@ -170,7 +170,7 @@ class TestExtractEmbyData:
 
         assert result.media_type == "episode"
         assert result.title == "测试番剧"
-        assert result.ori_title is None
+        assert result.ori_title == " "
         assert result.season == 2
         assert result.episode == 10
         assert result.release_date == "2024-01-15"
@@ -178,7 +178,7 @@ class TestExtractEmbyData:
         assert result.source == "emby"
 
     def test_extract_emby_data_episode_does_not_use_original_title(self):
-        """Emby 剧集 OriginalTitle 为分集名，不作为 ori_title（避免条目匹配跑偏）"""
+        """剧集仍用单空格占位；即使有 OriginalTitle 也不写入（其为分集名）"""
         from app.utils.data_util import extract_emby_data
 
         emby_data = {
@@ -196,7 +196,7 @@ class TestExtractEmbyData:
         }
         result = extract_emby_data(emby_data)
         assert result.title == "某动画"
-        assert result.ori_title is None
+        assert result.ori_title == " "
 
     def test_extract_emby_data_no_premiere_date(self):
         """测试无发行日期"""
@@ -217,7 +217,7 @@ class TestExtractEmbyData:
         result = extract_emby_data(emby_data)
 
         assert result.release_date == ""
-        assert result.ori_title is None
+        assert result.ori_title == " "
 
     def test_extract_emby_data_movie(self):
         from app.utils.data_util import extract_emby_data


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
- **Emby 电影**：从 webhook `Item.OriginalTitle` 解析并写入 `CustomItem.ori_title`（与 Plex 一致），修复剧场版等场景下原标题丢失导致 bangumi-data / API 匹配失败的问题。
- **bangumi-data 匹配**：当存在有效 `ori_title` 时，不再仅因条目缺少 `titleTranslate.zh-Hans` 就跳过，使仅靠日文 `title` 与 `ori_title` 精确对齐的条目（如部分剧场版数据）可被匹配。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
