### PR TITLE
fix: 修复在未查询到番剧信息时没有记录同步结果的问题；打印异步任务时带上详细信息以便识别

### DIFF
--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -143,13 +143,28 @@ class SyncService:
                     status="ignored", message="番剧标题包含屏蔽关键词，跳过同步"
                 )
 
-            subject_id, _ = self._find_subject_id(item)
+            subject_id, _, subject_find_error = self._find_subject_id(item)
             if not subject_id:
                 send_notify(
                     "anime_not_found",
                     item,
                     actual_source,
                     error_message="未找到匹配的番剧",
+                )
+                database_manager.log_sync_record(
+                    user_name=item.user_name,
+                    title=item.title,
+                    ori_title=item.ori_title or "",
+                    season=item.season,
+                    episode=item.episode,
+                    subject_id=None,
+                    episode_id=None,
+                    status="error",
+                    message=self._format_subject_not_found_message(
+                        item, subject_find_error
+                    ),
+                    source=actual_source,
+                    media_type=item.media_type,
                 )
                 return SyncResponse(status="error", message="未找到匹配的番剧")
 
@@ -277,13 +292,30 @@ class SyncService:
                 )
 
             # 查找番剧ID及其是否为特定季度ID的标记
-            subject_id, is_season_matched_id = self._find_subject_id(item)
+            subject_id, is_season_matched_id, subject_find_error = (
+                self._find_subject_id(item)
+            )
             if not subject_id:
                 send_notify(
                     "anime_not_found",
                     item,
                     actual_source,
                     error_message="未找到匹配的番剧",
+                )
+                database_manager.log_sync_record(
+                    user_name=item.user_name,
+                    title=item.title,
+                    ori_title=item.ori_title or "",
+                    season=item.season,
+                    episode=item.episode,
+                    subject_id=None,
+                    episode_id=None,
+                    status="error",
+                    message=self._format_subject_not_found_message(
+                        item, subject_find_error
+                    ),
+                    source=actual_source,
+                    media_type=item.media_type,
                 )
                 return SyncResponse(status="error", message="未找到匹配的番剧")
 
@@ -545,8 +577,21 @@ class SyncService:
 
         return False
 
-    def _find_subject_id(self, item: CustomItem) -> tuple[Optional[str], bool]:
-        """根据标题和日期查找番剧ID"""
+    def _format_subject_not_found_message(self, item: CustomItem, detail: str) -> str:
+        """同步记录用：未找到条目时的说明（与日志语义对齐）。"""
+        parts = ["未查询到番剧信息，跳过"]
+        if detail:
+            parts.append(detail)
+        if item.release_date and len(item.release_date) >= 8:
+            parts.append(f"premiere_date={item.release_date[:10]}")
+        return "；".join(parts)
+
+    def _find_subject_id(self, item: CustomItem) -> tuple[Optional[str], bool, str]:
+        """根据标题和日期查找番剧ID。
+
+        返回 (subject_id, is_season_matched_id, failure_detail)。
+        成功时 failure_detail 为空字符串；失败时为简短原因，供同步记录与日志使用。
+        """
         # 获取自定义映射
         custom_mappings = self._load_custom_mappings()
         mapping_subject_id = custom_mappings.get(item.title, "")
@@ -554,7 +599,7 @@ class SyncService:
         if mapping_subject_id:
             logger.debug(f"匹配到自定义映射：{item.title}={mapping_subject_id}")
             # 自定义映射的ID不视为特定季度的ID
-            return mapping_subject_id, False
+            return mapping_subject_id, False, ""
 
         # 标记是否通过bangumi-data获取的ID
         is_season_matched_id = False
@@ -614,17 +659,22 @@ class SyncService:
                         # 第一季总是返回True
                         is_season_matched_id = True
 
-                    return bangumi_data_id, is_season_matched_id
+                    return bangumi_data_id, is_season_matched_id, ""
             except Exception as e:
                 logger.error(f"bangumi-data 匹配出错: {e}")
 
         # 如果没有匹配到，使用 bangumi API 搜索
+        _ctx = (
+            f"user_name={item.user_name!r} source={item.source!r} "
+            f"S{item.season:02d}E{item.episode:02d} media_type={item.media_type!r} "
+            f"title={item.title!r} ori_title={item.ori_title!r}"
+        )
         try:
             # 使用对应用户的bangumi API实例进行搜索
             bgm = self._get_bangumi_api_for_user(item.user_name)
             if not bgm:
-                logger.error(f"无法为用户 {item.user_name} 创建bangumi API实例进行搜索")
-                return None, False
+                logger.error(f"bgm: 无法为用户创建 Bangumi API 实例进行搜索；{_ctx}")
+                return None, False, "无法创建 Bangumi API 实例，无法搜索条目"
 
             premiere_date = None
             if item.release_date and len(item.release_date) >= 8:
@@ -638,15 +688,17 @@ class SyncService:
             )
             if not bgm_data:
                 logger.error(
-                    f"bgm: 未查询到番剧信息，跳过\nbgm: {item.title=} {item.ori_title=} {premiere_date=}"
+                    "bgm: 未查询到番剧信息，跳过；"
+                    f"{_ctx} premiere_date={premiere_date!r}"
                 )
-                return None, False
+                return None, False, "Bangumi 搜索无结果"
 
             # API搜索得到的ID不视为特定季度的ID
-            return bgm_data[0]["id"], False
+            return bgm_data[0]["id"], False, ""
         except Exception as e:
-            logger.error(f"bgm API搜索出错: {e}")
-            return None, False
+            detail = f"Bangumi API 搜索出错: {e}"
+            logger.error(f"bgm: {detail}；{_ctx}")
+            return None, False, detail
 
     def _check_season_info_in_title(self, title: str, season: int) -> bool:
         """检查标题中是否包含季度信息"""

--- a/tests/services/test_sync_full.py
+++ b/tests/services/test_sync_full.py
@@ -47,8 +47,9 @@ class TestSyncServiceFind:
                 user_name="admin",
             )
 
-            result = service._find_subject_id(item)
-            assert result is not None
+            sid, _flag, fail = service._find_subject_id(item)
+            assert sid is not None
+            assert fail == ""
 
 
 class TestSyncServiceMore:

--- a/tests/services/test_sync_service.py
+++ b/tests/services/test_sync_service.py
@@ -178,7 +178,7 @@ class TestSyncCustomItem:
 
         from app.models.sync import CustomItem
 
-        with patch.object(service, "_find_subject_id", return_value=("999", False)):
+        with patch.object(service, "_find_subject_id", return_value=("999", False, "")):
             with patch.object(
                 service,
                 "_get_bangumi_config_for_user",
@@ -213,7 +213,7 @@ class TestSyncCustomItem:
 
         local_bgm = MagicMock()
         local_bgm.ensure_subject_watching.return_value = 1
-        with patch.object(service, "_find_subject_id", return_value=("777", False)):
+        with patch.object(service, "_find_subject_id", return_value=("777", False, "")):
             with patch.object(
                 service, "_get_bangumi_api_for_user", return_value=local_bgm
             ):
@@ -354,6 +354,37 @@ class TestSyncCustomItem:
 
             assert result.status == "error"
             assert "无权限" in result.message
+
+    def test_sync_custom_item_subject_not_found_logs_record(self, mock_sync_service):
+        """未找到番剧时写入同步记录"""
+        service, mock_config, mock_db, mock_notify = mock_sync_service
+        from app.models.sync import CustomItem
+
+        item = CustomItem(
+            media_type="episode",
+            title="未知番",
+            ori_title="X",
+            season=1,
+            episode=2,
+            release_date="2024-01-01",
+            user_name="test_user",
+            source="plex",
+        )
+        with patch.object(
+            service,
+            "_find_subject_id",
+            return_value=(None, False, "Bangumi 搜索无结果"),
+        ):
+            r = service.sync_custom_item(item, source="custom")
+        assert r.status == "error"
+        assert "未找到" in r.message
+        mock_db.log_sync_record.assert_called_once()
+        kw = mock_db.log_sync_record.call_args[1]
+        assert kw.get("status") == "error"
+        assert kw.get("source") == "plex"
+        assert "未查询到番剧信息，跳过" in (kw.get("message") or "")
+        assert "Bangumi 搜索无结果" in (kw.get("message") or "")
+        assert "premiere_date=2024-01-01" in (kw.get("message") or "")
 
 
 class TestSyncTaskStatus:
@@ -572,7 +603,7 @@ class TestSyncMovieWatching:
     def test_sync_movie_watching_subject_not_found(self):
         with (
             patch("app.services.sync_service.config_manager") as mock_config,
-            patch("app.services.sync_service.database_manager"),
+            patch("app.services.sync_service.database_manager") as mock_db,
             patch("app.services.sync_service.send_notify"),
             patch("app.services.sync_service.mapping_service"),
         ):
@@ -581,10 +612,19 @@ class TestSyncMovieWatching:
             from app.services.sync_service import SyncService
 
             svc = SyncService()
-            with patch.object(svc, "_find_subject_id", return_value=(None, False)):
+            with patch.object(
+                svc,
+                "_find_subject_id",
+                return_value=(None, False, "Bangumi 搜索无结果"),
+            ):
                 r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "error"
         assert "未找到" in r.message
+        mock_db.log_sync_record.assert_called_once()
+        _kw = mock_db.log_sync_record.call_args[1]
+        assert _kw.get("status") == "error"
+        assert "未查询到番剧信息，跳过" in (_kw.get("message") or "")
+        assert "Bangumi 搜索无结果" in (_kw.get("message") or "")
 
     def test_sync_movie_watching_no_bgm_api(self):
         with (
@@ -598,7 +638,7 @@ class TestSyncMovieWatching:
             from app.services.sync_service import SyncService
 
             svc = SyncService()
-            with patch.object(svc, "_find_subject_id", return_value=("888", False)):
+            with patch.object(svc, "_find_subject_id", return_value=("888", False, "")):
                 with patch.object(svc, "_get_bangumi_api_for_user", return_value=None):
                     r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "error"
@@ -620,7 +660,7 @@ class TestSyncMovieWatching:
             bgm.ensure_subject_watching.side_effect = ValueError(
                 "认证失败: access_token 无效"
             )
-            with patch.object(svc, "_find_subject_id", return_value=("888", False)):
+            with patch.object(svc, "_find_subject_id", return_value=("888", False, "")):
                 with patch.object(svc, "_get_bangumi_api_for_user", return_value=bgm):
                     r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "error"
@@ -641,7 +681,7 @@ class TestSyncMovieWatching:
             svc = SyncService()
             bgm = MagicMock()
             bgm.ensure_subject_watching.side_effect = ValueError("other reason")
-            with patch.object(svc, "_find_subject_id", return_value=("888", False)):
+            with patch.object(svc, "_find_subject_id", return_value=("888", False, "")):
                 with patch.object(svc, "_get_bangumi_api_for_user", return_value=bgm):
                     r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "error"
@@ -662,7 +702,7 @@ class TestSyncMovieWatching:
             svc = SyncService()
             bgm = MagicMock()
             bgm.ensure_subject_watching.return_value = 0
-            with patch.object(svc, "_find_subject_id", return_value=("888", False)):
+            with patch.object(svc, "_find_subject_id", return_value=("888", False, "")):
                 with patch.object(svc, "_get_bangumi_api_for_user", return_value=bgm):
                     r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "success"
@@ -683,7 +723,7 @@ class TestSyncMovieWatching:
             svc = SyncService()
             bgm = MagicMock()
             bgm.ensure_subject_watching.side_effect = RuntimeError("network")
-            with patch.object(svc, "_find_subject_id", return_value=("888", False)):
+            with patch.object(svc, "_find_subject_id", return_value=("888", False, "")):
                 with patch.object(svc, "_get_bangumi_api_for_user", return_value=bgm):
                     r = svc.sync_movie_watching(self._movie_item(), source="custom")
         assert r.status == "error"

--- a/tests/services/test_sync_service_full.py
+++ b/tests/services/test_sync_service_full.py
@@ -300,7 +300,7 @@ def test_sync_custom_item_movie_success_calls_movie_episode_path(
         release_date="",
     )
 
-    with patch.object(service, "_find_subject_id", return_value=("456", False)):
+    with patch.object(service, "_find_subject_id", return_value=("456", False, "")):
         with patch.object(
             service,
             "_get_bangumi_config_for_user",
@@ -336,7 +336,7 @@ def test_sync_custom_item_movie_skips_collection_when_subject_already_completed(
         release_date="",
     )
 
-    with patch.object(service, "_find_subject_id", return_value=("456", False)):
+    with patch.object(service, "_find_subject_id", return_value=("456", False, "")):
         with patch.object(
             service,
             "_get_bangumi_config_for_user",
@@ -387,7 +387,7 @@ def test_sync_custom_item_movie_no_subject_collection_when_mark_flag_off(
             release_date="",
         )
 
-        with patch.object(service, "_find_subject_id", return_value=("456", False)):
+        with patch.object(service, "_find_subject_id", return_value=("456", False, "")):
             with patch.object(
                 service,
                 "_get_bangumi_config_for_user",
@@ -662,6 +662,7 @@ def test_find_subject_id_from_mapping(mock_config, mock_database):
 
         assert result[0] == "12345"
         assert result[1] is False  # 自定义映射不视为特定季度ID
+        assert result[2] == ""
 
 
 def test_find_subject_id_movie_passes_is_movie_to_bgm_search(mock_database):
@@ -698,7 +699,7 @@ def test_find_subject_id_movie_passes_is_movie_to_bgm_search(mock_database):
 
         with patch.object(service, "_load_custom_mappings", return_value={}):
             with patch.object(service, "_get_bangumi_api_for_user", return_value=bgm):
-                sid, is_season = service._find_subject_id(item)
+                sid, is_season, _ = service._find_subject_id(item)
 
     assert str(sid) == "4242"
     assert is_season is False
@@ -892,14 +893,16 @@ def test_jellyfin_sync_item_not_played_completion(mock_config, mock_database):
 
 def test_find_subject_id_season_gt1_date_matched_sets_season_flag():
     with _patched_sync_service_deps() as cfg:
-        sid, flag = _find_subject_via_bangumi_data(cfg, ("99", "标题", True), season=2)
+        sid, flag, _ = _find_subject_via_bangumi_data(
+            cfg, ("99", "标题", True), season=2
+        )
         assert sid == "99"
         assert flag is True
 
 
 def test_find_subject_id_season_gt1_title_has_season_info():
     with _patched_sync_service_deps() as cfg:
-        sid, flag = _find_subject_via_bangumi_data(
+        sid, flag, _ = _find_subject_via_bangumi_data(
             cfg, ("88", "某番 第2季", False), season=2
         )
         assert sid == "88"
@@ -908,7 +911,7 @@ def test_find_subject_id_season_gt1_title_has_season_info():
 
 def test_find_subject_id_season_gt1_no_date_no_season_keyword():
     with _patched_sync_service_deps() as cfg:
-        sid, flag = _find_subject_via_bangumi_data(
+        sid, flag, _ = _find_subject_via_bangumi_data(
             cfg, ("77", "无季标", False), season=2
         )
         assert sid == "77"
@@ -917,7 +920,7 @@ def test_find_subject_id_season_gt1_no_date_no_season_keyword():
 
 def test_find_subject_id_season1_sets_season_matched_true():
     with _patched_sync_service_deps() as cfg:
-        sid, flag = _find_subject_via_bangumi_data(
+        sid, flag, _ = _find_subject_via_bangumi_data(
             cfg, ("66", "第一季", False), season=1
         )
         assert sid == "66"
@@ -943,7 +946,9 @@ def test_find_subject_id_find_bangumi_id_exception_falls_through_to_api():
                 with patch.object(
                     service, "_get_bangumi_api_for_user", return_value=bgm
                 ):
-                    sid, flag = service._find_subject_id(_branch_custom_item_for_find())
+                    sid, flag, _ = service._find_subject_id(
+                        _branch_custom_item_for_find()
+                    )
         assert sid == 42 or sid == "42"
         assert flag is False
 
@@ -960,9 +965,12 @@ def test_find_subject_id_api_disabled_no_bgm_instance():
         service = SyncService()
         with patch.object(service, "_load_custom_mappings", return_value={}):
             with patch.object(service, "_get_bangumi_api_for_user", return_value=None):
-                sid, flag = service._find_subject_id(_branch_custom_item_for_find())
+                sid, flag, err = service._find_subject_id(
+                    _branch_custom_item_for_find()
+                )
         assert sid is None
         assert flag is False
+        assert err == "无法创建 Bangumi API 实例，无法搜索条目"
 
 
 def test_find_subject_id_api_search_exception_returns_none():
@@ -979,8 +987,11 @@ def test_find_subject_id_api_search_exception_returns_none():
         bgm.bgm_search.side_effect = OSError("net")
         with patch.object(service, "_load_custom_mappings", return_value={}):
             with patch.object(service, "_get_bangumi_api_for_user", return_value=bgm):
-                sid, flag = service._find_subject_id(_branch_custom_item_for_find())
+                sid, flag, err = service._find_subject_id(
+                    _branch_custom_item_for_find()
+                )
         assert sid is None
+        assert "Bangumi API 搜索出错" in err
 
 
 def test_sync_custom_item_no_bgm_api_after_find_subject():
@@ -988,7 +999,9 @@ def test_sync_custom_item_no_bgm_api_after_find_subject():
         svc = SyncService()
         with patch.object(svc, "_check_user_permission", return_value=True):
             with patch.object(svc, "_is_title_blocked", return_value=False):
-                with patch.object(svc, "_find_subject_id", return_value=("123", False)):
+                with patch.object(
+                    svc, "_find_subject_id", return_value=("123", False, "")
+                ):
                     with patch.object(
                         svc, "_get_bangumi_api_for_user", return_value=None
                     ):
@@ -1008,7 +1021,9 @@ def test_sync_custom_item_get_target_season_value_error_auth_message():
         )
         with patch.object(svc, "_check_user_permission", return_value=True):
             with patch.object(svc, "_is_title_blocked", return_value=False):
-                with patch.object(svc, "_find_subject_id", return_value=("1", False)):
+                with patch.object(
+                    svc, "_find_subject_id", return_value=("1", False, "")
+                ):
                     with patch.object(
                         svc, "_get_bangumi_api_for_user", return_value=bgm
                     ):
@@ -1025,7 +1040,7 @@ def test_sync_custom_item_mark_value_error_auth_message():
         bgm = MagicMock()
         bgm.get_target_season_episode_id.return_value = ("1", "10")
         bgm.mark_episode_watched.side_effect = ValueError("access_token 无效")
-        with patch.object(svc, "_find_subject_id", return_value=("1", False)):
+        with patch.object(svc, "_find_subject_id", return_value=("1", False, "")):
             with patch.object(svc, "_get_bangumi_api_for_user", return_value=bgm):
                 r = svc.sync_custom_item(_branch_custom_item_for_find(), "custom")
         assert r.status == "error"


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)


### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
- **未找到番剧时写入同步记录**：在 `sync_custom_item` 与 `sync_movie_watching` 中，当 `_find_subject_id` 无结果时，除原有通知外增加 `database_manager.log_sync_record`（`status=error`，无 `subject_id`/`episode_id`），同步记录页可查看「未查询到番剧信息，跳过」及失败原因、`premiere_date` 等说明。
- **`_find_subject_id` 返回值扩展**：由二元组改为三元组，第三项为失败时的简短原因（成功为空字符串），便于区分「Bangumi 搜索无结果」「无法创建 API」「API 搜索异常」等，并拼入同步记录的 `message`。
- **错误日志单行化**：将「未查询到番剧信息」及「无法创建 Bangumi API」等相关 `logger.error` 合并为单行，并带上 `user_name`、`source`、季集、`media_type`、`title`、`ori_title`（及 `premiere_date`），减轻高并发 webhook 下日志交错时难以对应条目的问题。
- **测试**：更新对 `_find_subject_id` 的 mock 与解包；为「未找到番剧」路径补充/强化 `log_sync_record` 断言。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
