### PR TITLE
fix: 修复日志没写入文件的问题

### DIFF
--- a/app/api/logs.py
+++ b/app/api/logs.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ..core.config import config_manager
-from ..core.logging import logger
+from ..core.logging import logger, resolved_dev_log_file_path
 from .deps import get_current_user_flexible
 
 router = APIRouter(prefix="/api", tags=["logs"])
@@ -24,15 +24,17 @@ async def get_logs(
 ):
     """获取日志内容"""
     try:
-        # 从配置文件中获取日志文件路径
-        log_file_path = config_manager.get_config(
-            "dev", "log_file", fallback="./log.txt"
-        )
+        log_path = resolved_dev_log_file_path(config_manager)
+        if log_path is None:
+            return {
+                "status": "success",
+                "data": {
+                    "content": "",
+                    "stats": {"size": 0, "lines": 0, "modified": None, "errors": 0},
+                },
+            }
 
-        # 处理相对路径
-        if log_file_path.startswith("./"):
-            cwd = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-            log_file_path = os.path.join(cwd, log_file_path.split("./", 1)[1])
+        log_file_path = os.fspath(log_path)
 
         if not os.path.exists(log_file_path):
             return {
@@ -95,15 +97,11 @@ async def clear_logs(
 ):
     """清空日志文件"""
     try:
-        # 从配置文件中获取日志文件路径
-        log_file_path = config_manager.get_config(
-            "dev", "log_file", fallback="./log.txt"
-        )
+        log_path = resolved_dev_log_file_path(config_manager)
+        if log_path is None:
+            return {"status": "success", "message": "日志清空成功"}
 
-        # 处理相对路径
-        if log_file_path.startswith("./"):
-            cwd = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-            log_file_path = os.path.join(cwd, log_file_path.split("./", 1)[1])
+        log_file_path = os.fspath(log_path)
 
         if os.path.exists(log_file_path):
             # 清空日志文件

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -4,8 +4,50 @@
 
 import datetime
 import os
+import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .config import ConfigManager
+
+# 与 config.ini / Web 日志 API 对齐的默认相对路径（相对项目根）
+DEFAULT_DEV_LOG_FILE = "./log.txt"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def resolve_dev_log_file_path(raw: str) -> Path:
+    """将配置中的 log_file 转为绝对 Path（仅将以 ./ 开头的视为相对项目根）。"""
+    if raw.startswith("./"):
+        return _REPO_ROOT / raw.split("./", 1)[1]
+    return Path(raw)
+
+
+def effective_dev_log_file_raw(config_manager: "ConfigManager") -> Optional[str]:
+    """
+    返回将用于打开日志文件的原始配置字符串；None 表示显式留空、禁用文件日志。
+    缺键时使用 DEFAULT_DEV_LOG_FILE。
+    """
+    cfg = config_manager.get_config_parser()
+    if not cfg.has_section("dev"):
+        return DEFAULT_DEV_LOG_FILE
+    if not cfg.has_option("dev", "log_file"):
+        return DEFAULT_DEV_LOG_FILE
+    raw = str(cfg.get("dev", "log_file", fallback="")).strip()
+    if raw == "":
+        return None
+    return raw
+
+
+def resolved_dev_log_file_path(
+    config_manager: "ConfigManager",
+) -> Optional[Path]:
+    """当前配置下解析后的日志文件绝对路径；禁用时为 None。"""
+    raw = effective_dev_log_file_raw(config_manager)
+    if raw is None:
+        return None
+    return resolve_dev_log_file_path(raw).resolve()
 
 
 class Logger:
@@ -26,9 +68,10 @@ class Logger:
 
         # 延迟获取debug_mode，避免循环依赖
         self._debug_mode = None
-
-        # 初始化日志文件
-        self._setup_log_file()
+        self._log_file_path: Optional[Path] = None
+        # 不在 __init__ 中打开日志文件：模块执行 logger = Logger() 时，若此处导入
+        # config，而 config 初始化链又 import logger，会触发 partially initialized 循环依赖。
+        self._log_file_lazy_initialized = False
 
     def _get_safe_username(self) -> str:
         """安全地获取用户名"""
@@ -38,35 +81,75 @@ class Logger:
             # Docker环境或其他无法获取登录用户的环境
             return os.environ.get("USER", os.environ.get("USERNAME", "docker_user"))
 
+    def _close_log_file_handle(self) -> None:
+        if hasattr(self, "log_file"):
+            try:
+                self.log_file.close()
+            except OSError:
+                pass
+            del self.log_file
+        self._log_file_path = None
+
+    def _lazy_init_log_file_once(self) -> None:
+        """首次写日志前再绑定文件与 config（避免与 config 模块循环导入）。"""
+        if self._log_file_lazy_initialized:
+            return
+        self._log_file_lazy_initialized = True
+        self._setup_log_file()
+
     def _setup_log_file(self) -> None:
-        """设置日志文件"""
-        # 延迟导入，避免循环依赖
+        """设置日志文件（成功/跳过/失败均向 stderr 输出一行，便于排查）"""
+        self._close_log_file_handle()
+
         try:
             from .config import config_manager
-        except ImportError:
-            # 如果无法导入，跳过日志文件设置
+        except ImportError as e:
+            print(
+                f"文件日志未启用: 无法导入 config（{e!r}），仅输出到控制台",
+                file=sys.stderr,
+            )
             return
 
-        log_file_path = config_manager.get("dev", "log_file", fallback="")
-        if not log_file_path:
+        raw = effective_dev_log_file_raw(config_manager)
+        if raw is None:
+            print(
+                "文件日志已禁用: [dev] log_file 为空（留空则禁用）",
+                file=sys.stderr,
+            )
             return
 
-        # 处理相对路径
-        if log_file_path.startswith("./"):
-            cwd = Path(__file__).parent.parent.parent
-            log_file_path = cwd / log_file_path.split("./", 1)[1]
+        log_path = resolve_dev_log_file_path(raw)
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            mode = "a"
+            if log_path.exists() and log_path.stat().st_size >= 10 * 1024 * 1024:
+                mode = "w"
+            self.log_file = open(log_path, mode, encoding="utf-8")
+            self._log_file_path = log_path.resolve()
+            print(
+                f"文件日志已启用: {self._log_file_path}",
+                file=sys.stderr,
+            )
+        except OSError as e:
+            print(
+                f"文件日志打开失败: {e!r} 路径={log_path}",
+                file=sys.stderr,
+            )
 
-        # 创建日志目录
-        log_path = Path(log_file_path)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # 检查文件大小，超过10MB时重置
-        mode = "a"
-        if log_path.exists() and log_path.stat().st_size >= 10 * 1024 * 1024:
-            mode = "w"
-
-        # 打开日志文件
-        self.log_file = open(log_path, mode, encoding="utf-8")
+    def _ensure_log_file_for_write(self) -> None:
+        """若磁盘上日志路径已不存在，则关闭句柄并重新打开。"""
+        if not hasattr(self, "log_file") or self._log_file_path is None:
+            return
+        try:
+            exists = self._log_file_path.exists()
+        except OSError:
+            exists = False
+        if not exists:
+            print(
+                f"文件日志路径已丢失，尝试重新打开: {self._log_file_path}",
+                file=sys.stderr,
+            )
+            self._setup_log_file()
 
     @property
     def debug_mode(self) -> bool:
@@ -109,6 +192,8 @@ class Logger:
         if silence:
             return
 
+        self._lazy_init_log_file_once()
+
         # 根据日志级别添加对应的标识符
         level_prefix = f"[{level}]" if level else ""
 
@@ -126,6 +211,8 @@ class Logger:
         print(log_line, end=end)
 
         # 输出到日志文件
+        if hasattr(self, "log_file"):
+            self._ensure_log_file_for_write()
         if hasattr(self, "log_file"):
             self.log_file.write(log_line + end)
             self.log_file.flush()

--- a/tests/api/test_daily_use_features.py
+++ b/tests/api/test_daily_use_features.py
@@ -116,15 +116,13 @@ async def test_proxy_test_connectivity(app_auth):
 
 
 @pytest.mark.asyncio
-async def test_logs_api_when_log_file_missing_returns_empty(app_auth):
+async def test_logs_api_when_log_file_missing_returns_empty(app_auth, tmp_path):
     app_auth.include_router(logs.router)
-    with patch(
-        "app.api.logs.config_manager.get_config", return_value="./no_such_log.txt"
-    ):
-        with patch("app.api.logs.os.path.exists", return_value=False):
-            transport = ASGITransport(app=app_auth)
-            async with AsyncClient(transport=transport, base_url="http://test") as ac:
-                r = await ac.get("/api/logs")
+    ghost = tmp_path / "no_such_log.txt"
+    with patch("app.api.logs.resolved_dev_log_file_path", return_value=ghost):
+        transport = ASGITransport(app=app_auth)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/logs")
     assert r.status_code == 200
     payload = r.json()
     assert payload["data"]["content"] == ""

--- a/tests/api/test_logs_comprehensive.py
+++ b/tests/api/test_logs_comprehensive.py
@@ -2,6 +2,7 @@
 日志 API 完整测试
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -40,11 +41,26 @@ class TestLogsAPIComprehensive:
 
 
 @pytest.mark.asyncio
+async def test_get_logs_when_file_log_disabled(app_with_auth):
+    """[dev] log_file 留空禁用时 API 返回空内容"""
+    with patch("app.api.logs.resolved_dev_log_file_path", return_value=None):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/logs")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"]["content"] == ""
+    assert data["data"]["stats"]["size"] == 0
+
+
+@pytest.mark.asyncio
 async def test_get_logs_file_not_found(app_with_auth):
     """测试获取日志文件不存在"""
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "/nonexistent/log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/nonexistent/log.txt"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=False):
             async with AsyncClient(
                 transport=ASGITransport(app=app_with_auth), base_url="http://test"
@@ -66,9 +82,10 @@ async def test_get_logs_with_content(app_with_auth):
 2024-01-01 10:00:02 WARNING Retry attempt 1
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(
@@ -97,9 +114,10 @@ async def test_get_logs_with_level_filter(app_with_auth):
 2024-01-01 10:00:02 WARNING Retry attempt 1
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
@@ -124,9 +142,10 @@ async def test_get_logs_with_search_filter(app_with_auth):
 2024-01-01 10:00:02 WARNING Retry attempt 1
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
@@ -153,9 +172,10 @@ Line 4
 Line 5
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
@@ -182,9 +202,10 @@ Line 2
 Line 3
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
@@ -208,9 +229,10 @@ async def test_get_logs_invalid_limit(app_with_auth):
 Line 2
 """
 
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("app.api.logs.os.stat") as mock_stat:
                 mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
@@ -229,9 +251,10 @@ Line 2
 @pytest.mark.asyncio
 async def test_get_logs_exception(app_with_auth):
     """测试获取日志异常"""
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", side_effect=Exception("Test error")):
             async with AsyncClient(
                 transport=ASGITransport(app=app_with_auth), base_url="http://test"
@@ -244,9 +267,10 @@ async def test_get_logs_exception(app_with_auth):
 @pytest.mark.asyncio
 async def test_clear_logs_success(app_with_auth):
     """测试清空日志成功"""
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=True):
             with patch("builtins.open", mock_open()) as _mock_file:
                 async with AsyncClient(
@@ -263,9 +287,10 @@ async def test_clear_logs_success(app_with_auth):
 @pytest.mark.asyncio
 async def test_clear_logs_file_not_exists(app_with_auth):
     """测试日志文件不存在时清空"""
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/missing.log"),
+    ):
         with patch("app.api.logs.os.path.exists", return_value=False):
             async with AsyncClient(
                 transport=ASGITransport(app=app_with_auth), base_url="http://test"
@@ -280,9 +305,10 @@ async def test_clear_logs_file_not_exists(app_with_auth):
 @pytest.mark.asyncio
 async def test_clear_logs_exception(app_with_auth):
     """测试清空日志异常"""
-    with patch("app.api.logs.config_manager") as mock_cm:
-        mock_cm.get_config.return_value = "./log.txt"
-
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
         with patch("app.api.logs.os.path.exists", side_effect=Exception("Test error")):
             async with AsyncClient(
                 transport=ASGITransport(app=app_with_auth), base_url="http://test"

--- a/tests/api/test_smoke_notification_trakt_logs_proxy.py
+++ b/tests/api/test_smoke_notification_trakt_logs_proxy.py
@@ -230,7 +230,7 @@ async def test_logs_clear_truncates_file(app_logs_proxy, tmp_path):
     log_f = tmp_path / "run.log"
     log_f.write_text("line1\nline2\n", encoding="utf-8")
 
-    with patch("app.api.logs.config_manager.get_config", return_value=str(log_f)):
+    with patch("app.api.logs.resolved_dev_log_file_path", return_value=log_f):
         transport = ASGITransport(app=app_logs_proxy)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             r = await ac.post("/api/logs/clear")

--- a/tests/core/test_log_file_path.py
+++ b/tests/core/test_log_file_path.py
@@ -1,0 +1,111 @@
+"""
+dev.log_file 解析与 Logger 文件重开相关测试
+"""
+
+from configparser import ConfigParser
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _mock_cm_with_ini(text: str) -> MagicMock:
+    cfg = ConfigParser()
+    cfg.read_string(text)
+    m = MagicMock()
+    m.get_config_parser = lambda: cfg
+    return m
+
+
+def test_effective_dev_log_file_raw_missing_option_uses_default():
+    from app.core.logging import DEFAULT_DEV_LOG_FILE, effective_dev_log_file_raw
+
+    cm = _mock_cm_with_ini("[dev]\ndebug = True\n")
+    assert effective_dev_log_file_raw(cm) == DEFAULT_DEV_LOG_FILE
+
+
+def test_effective_dev_log_file_raw_missing_dev_section_uses_default():
+    from app.core.logging import DEFAULT_DEV_LOG_FILE, effective_dev_log_file_raw
+
+    cm = _mock_cm_with_ini("[bangumi]\nx = 1\n")
+    assert effective_dev_log_file_raw(cm) == DEFAULT_DEV_LOG_FILE
+
+
+def test_effective_dev_log_file_raw_explicit_empty_disables():
+    from app.core.logging import effective_dev_log_file_raw
+
+    cm = _mock_cm_with_ini("[dev]\nlog_file = \n")
+    assert effective_dev_log_file_raw(cm) is None
+
+    cm2 = _mock_cm_with_ini("[dev]\nlog_file =    \n")
+    assert effective_dev_log_file_raw(cm2) is None
+
+
+def test_resolve_dev_log_file_path_dot_prefix():
+    from app.core.logging import resolve_dev_log_file_path
+
+    p = resolve_dev_log_file_path("./log.txt")
+    assert p.name == "log.txt"
+    assert p.is_absolute()
+
+
+def test_resolved_dev_log_file_path_none_when_disabled():
+    from app.core.logging import resolved_dev_log_file_path
+
+    cm = _mock_cm_with_ini("[dev]\nlog_file =\n")
+    assert resolved_dev_log_file_path(cm) is None
+
+
+def test_logger_defers_file_open_until_first_log_line(tmp_path):
+    """避免 __init__ 导入 config：构造后尚无 log_file，首次 log 再打开。"""
+    from app.core.logging import Logger
+
+    log_path = tmp_path / "defer.log"
+    with (
+        patch("app.core.logging.os.getlogin", side_effect=OSError()),
+        patch("app.core.logging.os.environ.get", return_value="test_user"),
+        patch(
+            "app.core.logging.effective_dev_log_file_raw", return_value=str(log_path)
+        ),
+    ):
+        lg = Logger()
+        assert lg._log_file_lazy_initialized is False
+        assert not hasattr(lg, "log_file")
+        lg.need_mix = False
+        lg.info("first")
+        assert lg._log_file_lazy_initialized
+        assert hasattr(lg, "log_file")
+        assert log_path.exists()
+
+
+def test_logger_reopens_when_path_reported_missing(tmp_path, monkeypatch):
+    """模拟路径已不可用（不依赖 unlink 已打开文件），再次写入应走 _setup 重开。"""
+    from app.core.logging import Logger
+
+    log_path = tmp_path / "reopen_test.log"
+    fixed = str(log_path)
+    target = log_path.resolve()
+
+    real_exists = Path.exists
+    pretend_missing = {"on": False}
+
+    def exists_wrapper(self):
+        if pretend_missing["on"] and self.resolve() == target:
+            return False
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", exists_wrapper)
+
+    with (
+        patch("app.core.logging.os.getlogin", side_effect=OSError()),
+        patch("app.core.logging.os.environ.get", return_value="test_user"),
+        patch("app.core.logging.effective_dev_log_file_raw", return_value=fixed),
+    ):
+        lg = Logger()
+        lg.need_mix = False
+        lg.info("before reopen")
+        assert "before reopen" in log_path.read_text(encoding="utf-8")
+        pretend_missing["on"] = True
+        lg.info("after reopen")
+        pretend_missing["on"] = False
+        body = log_path.read_text(encoding="utf-8")
+        assert "before reopen" in body
+        assert "after reopen" in body


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
- **文件日志**：`[dev]` 下未配置 `log_file` 时使用默认 `./log.txt`；`log_file` **显式留空**时禁用文件日志，并与 `/api/logs` 的解析逻辑统一（避免「API 能读路径、Logger 却不写」）。
- **循环依赖**：`Logger` 不再在 `__init__` 里导入 `config` 打开日志文件，改为**首次写日志时**再初始化，消除 `partially initialized module 'app.core.logging'` 导致的 `ImportError`。
- **可靠性**：写入前若配置的日志路径在磁盘上已不存在，会关闭旧句柄并**重新打开**同一配置路径下的日志文件。
- **可观测性**：文件日志启用 / 禁用 / 打开失败时向 **stderr** 输出一行说明（含成功时的绝对路径）。
- **测试**：补充 `effective_dev_log_file_raw`、惰性打开、路径「丢失」后重开等用例；日志相关 API 测试改为 mock `resolved_dev_log_file_path`；重开用例改为 mock `Path.exists`，**Windows 上不再 skip**。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
Closes #139 

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
