### PR TITLE
perf: 性能改进

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,8 @@ cython_debug/
 .idea/
 config_backups/
 sync_records.db
+sync_records.db-wal
+sync_records.db-shm
+
+# Claude Code
+.claude/

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -5,6 +5,7 @@
 import os
 import shutil
 import sqlite3
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -40,13 +41,44 @@ class DatabaseManager:
                 shutil.move(str(legacy), str(self.db_path))
                 logger.info(f"Docker: 已从旧路径迁移数据库 {legacy} -> {self.db_path}")
 
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._media_type_migrated = False
         self._init_database()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """获取持久化数据库连接（线程安全），自动重连"""
+        if self._conn is not None:
+            try:
+                self._conn.execute("SELECT 1")
+            except (sqlite3.ProgrammingError, sqlite3.OperationalError):
+                try:
+                    self._conn.close()
+                except OSError:
+                    pass
+                self._conn = None
+        if self._conn is None:
+            conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._conn = conn
+        return self._conn
+
+    def _execute_with_lock(self, fn):
+        """在锁保护下执行数据库操作"""
+        with self._lock:
+            conn = self._get_connection()
+            return fn(conn)
 
     def _ensure_sync_records_media_type(self, cursor) -> None:
         """旧库迁移：为 sync_records 增加 media_type（历史数据为 episode）。"""
+        if self._media_type_migrated:
+            return
         cursor.execute("PRAGMA table_info(sync_records)")
         cols = [row[1] for row in cursor.fetchall()]
         if "media_type" in cols:
+            self._media_type_migrated = True
             return
         cursor.execute(
             "ALTER TABLE sync_records ADD COLUMN media_type TEXT DEFAULT 'episode'"
@@ -58,11 +90,12 @@ class DatabaseManager:
             WHERE media_type IS NULL OR TRIM(COALESCE(media_type, '')) = ''
             """
         )
+        self._media_type_migrated = True
         logger.info("sync_records 已迁移：增加 media_type 列并回填 episode")
 
     def _init_database(self) -> None:
         """初始化数据库"""
-        conn = sqlite3.connect(self.db_path)
+        conn = self._get_connection()
         cursor = conn.cursor()
 
         # 创建同步记录表
@@ -134,8 +167,24 @@ class DatabaseManager:
             )
         """)
 
+        # 创建二级索引以加速常用查询
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sync_records_timestamp ON sync_records(timestamp)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sync_records_user_name ON sync_records(user_name)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sync_records_source ON sync_records(source)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sync_records_status ON sync_records(status)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_trakt_sync_history_user_id ON trakt_sync_history(user_id)"
+        )
+
         conn.commit()
-        conn.close()
         logger.info(f"数据库初始化完成: {self.db_path}")
 
     def log_sync_record(
@@ -154,37 +203,34 @@ class DatabaseManager:
     ) -> None:
         """记录同步日志到数据库"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            self._ensure_sync_records_media_type(cursor)
 
-            # 使用本地时间而不是UTC时间
-            local_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            def _write(conn):
+                self._ensure_sync_records_media_type(conn.cursor())
+                local_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                conn.execute(
+                    """
+                    INSERT INTO sync_records
+                    (timestamp, user_name, title, ori_title, season, episode, subject_id, episode_id, status, message, source, media_type)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                    (
+                        local_time,
+                        user_name,
+                        title,
+                        ori_title,
+                        season,
+                        episode,
+                        subject_id,
+                        episode_id,
+                        status,
+                        message,
+                        source,
+                        media_type or "episode",
+                    ),
+                )
+                conn.commit()
 
-            cursor.execute(
-                """
-                INSERT INTO sync_records
-                (timestamp, user_name, title, ori_title, season, episode, subject_id, episode_id, status, message, source, media_type)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-                (
-                    local_time,
-                    user_name,
-                    title,
-                    ori_title,
-                    season,
-                    episode,
-                    subject_id,
-                    episode_id,
-                    status,
-                    message,
-                    source,
-                    media_type or "episode",
-                ),
-            )
-
-            conn.commit()
-            conn.close()
+            self._execute_with_lock(_write)
         except Exception as e:
             logger.error(f"记录同步日志失败: {e}")
 
@@ -199,76 +245,77 @@ class DatabaseManager:
     ) -> dict[str, Any]:
         """获取同步记录"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            self._ensure_sync_records_media_type(cursor)
 
-            # 构建查询条件
-            where_conditions = []
-            params = []
+            def _read(conn):
+                self._ensure_sync_records_media_type(conn.cursor())
+                cursor = conn.cursor()
 
-            if status:
-                where_conditions.append("status = ?")
-                params.append(status)
+                where_conditions = []
+                params = []
 
-            if user_name:
-                where_conditions.append("user_name = ?")
-                params.append(user_name)
+                if status:
+                    where_conditions.append("status = ?")
+                    params.append(status)
 
-            if source:
-                where_conditions.append("source = ?")
-                params.append(source)
+                if user_name:
+                    where_conditions.append("user_name = ?")
+                    params.append(user_name)
 
-            if source_prefix:
-                where_conditions.append("source LIKE ?")
-                params.append(f"{source_prefix}%")
+                if source:
+                    where_conditions.append("source = ?")
+                    params.append(source)
 
-            where_clause = (
-                " WHERE " + " AND ".join(where_conditions) if where_conditions else ""
-            )
+                if source_prefix:
+                    where_conditions.append("source LIKE ?")
+                    params.append(f"{source_prefix}%")
 
-            # 获取总数
-            count_query = f"SELECT COUNT(*) FROM sync_records{where_clause}"
-            cursor.execute(count_query, params)
-            total = cursor.fetchone()[0]
-
-            query = f"""
-                SELECT id, timestamp, user_name, title, ori_title, season, episode,
-                       subject_id, episode_id, status, message, source, media_type
-                FROM sync_records{where_clause}
-                ORDER BY timestamp DESC
-                LIMIT ? OFFSET ?
-            """
-            cursor.execute(query, params + [limit, offset])
-
-            records = []
-            for row in cursor.fetchall():
-                records.append(
-                    {
-                        "id": row[0],
-                        "timestamp": row[1],
-                        "user_name": row[2],
-                        "title": row[3],
-                        "ori_title": row[4],
-                        "season": row[5],
-                        "episode": row[6],
-                        "subject_id": row[7],
-                        "episode_id": row[8],
-                        "status": row[9],
-                        "message": row[10],
-                        "source": row[11],
-                        "media_type": row[12] or "episode",
-                    }
+                where_clause = (
+                    " WHERE " + " AND ".join(where_conditions)
+                    if where_conditions
+                    else ""
                 )
 
-            conn.close()
+                count_query = f"SELECT COUNT(*) FROM sync_records{where_clause}"
+                cursor.execute(count_query, params)
+                total = cursor.fetchone()[0]
 
-            return {
-                "records": records,
-                "total": total,
-                "limit": limit,
-                "offset": offset,
-            }
+                query = f"""
+                    SELECT id, timestamp, user_name, title, ori_title, season, episode,
+                           subject_id, episode_id, status, message, source, media_type
+                    FROM sync_records{where_clause}
+                    ORDER BY timestamp DESC
+                    LIMIT ? OFFSET ?
+                """
+                cursor.execute(query, params + [limit, offset])
+
+                records = []
+                for row in cursor.fetchall():
+                    records.append(
+                        {
+                            "id": row[0],
+                            "timestamp": row[1],
+                            "user_name": row[2],
+                            "title": row[3],
+                            "ori_title": row[4],
+                            "season": row[5],
+                            "episode": row[6],
+                            "subject_id": row[7],
+                            "episode_id": row[8],
+                            "status": row[9],
+                            "message": row[10],
+                            "source": row[11],
+                            "media_type": row[12] or "episode",
+                        }
+                    )
+
+                return {
+                    "records": records,
+                    "total": total,
+                    "limit": limit,
+                    "offset": offset,
+                }
+
+            return self._execute_with_lock(_read)
         except Exception as e:
             logger.error(f"获取同步记录失败: {e}")
             raise
@@ -276,23 +323,22 @@ class DatabaseManager:
     def get_sync_record_by_id(self, record_id: int) -> Optional[dict[str, Any]]:
         """根据ID获取单个同步记录"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            self._ensure_sync_records_media_type(cursor)
 
-            cursor.execute(
-                """
-                SELECT id, timestamp, user_name, title, ori_title, season, episode,
-                       subject_id, episode_id, status, message, source, media_type
-                FROM sync_records
-                WHERE id = ?
-            """,
-                (record_id,),
-            )
+            def _read(conn):
+                self._ensure_sync_records_media_type(conn.cursor())
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT id, timestamp, user_name, title, ori_title, season, episode,
+                           subject_id, episode_id, status, message, source, media_type
+                    FROM sync_records
+                    WHERE id = ?
+                """,
+                    (record_id,),
+                )
+                return cursor.fetchone()
 
-            row = cursor.fetchone()
-            conn.close()
-
+            row = self._execute_with_lock(_read)
             if row:
                 return {
                     "id": row[0],
@@ -319,22 +365,20 @@ class DatabaseManager:
     ) -> bool:
         """更新同步记录的状态"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            cursor.execute(
-                """
-                UPDATE sync_records
-                SET status = ?, message = ?
-                WHERE id = ?
-            """,
-                (status, message, record_id),
-            )
+            def _write(conn):
+                cursor = conn.execute(
+                    """
+                    UPDATE sync_records
+                    SET status = ?, message = ?
+                    WHERE id = ?
+                """,
+                    (status, message, record_id),
+                )
+                conn.commit()
+                return cursor.rowcount
 
-            conn.commit()
-            affected_rows = cursor.rowcount
-            conn.close()
-
+            affected_rows = self._execute_with_lock(_write)
             if affected_rows > 0:
                 return True
             else:
@@ -347,60 +391,59 @@ class DatabaseManager:
     def get_sync_stats(self) -> dict[str, Any]:
         """获取同步统计信息"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            # 总同步次数
-            cursor.execute("SELECT COUNT(*) FROM sync_records")
-            total_syncs = cursor.fetchone()[0]
+            def _read(conn):
+                cursor = conn.cursor()
 
-            # 成功同步次数
-            cursor.execute("SELECT COUNT(*) FROM sync_records WHERE status = 'success'")
-            success_syncs = cursor.fetchone()[0]
+                cursor.execute("SELECT COUNT(*) FROM sync_records")
+                total_syncs = cursor.fetchone()[0]
 
-            # 失败同步次数
-            cursor.execute("SELECT COUNT(*) FROM sync_records WHERE status = 'error'")
-            error_syncs = cursor.fetchone()[0]
+                cursor.execute(
+                    "SELECT COUNT(*) FROM sync_records WHERE status = 'success'"
+                )
+                success_syncs = cursor.fetchone()[0]
 
-            # 今日同步次数
-            cursor.execute(
-                "SELECT COUNT(*) FROM sync_records WHERE DATE(timestamp) = DATE('now')"
-            )
-            today_syncs = cursor.fetchone()[0]
+                cursor.execute(
+                    "SELECT COUNT(*) FROM sync_records WHERE status = 'error'"
+                )
+                error_syncs = cursor.fetchone()[0]
 
-            # 用户统计
-            cursor.execute(
-                "SELECT user_name, COUNT(*) FROM sync_records GROUP BY user_name ORDER BY COUNT(*) DESC"
-            )
-            user_stats = [
-                {"user": row[0], "count": row[1]} for row in cursor.fetchall()
-            ]
+                cursor.execute(
+                    "SELECT COUNT(*) FROM sync_records WHERE DATE(timestamp) = DATE('now')"
+                )
+                today_syncs = cursor.fetchone()[0]
 
-            # 最近7天统计
-            cursor.execute("""
-                SELECT DATE(timestamp) as date, COUNT(*) as count
-                FROM sync_records
-                WHERE timestamp >= datetime('now', '-7 days')
-                GROUP BY DATE(timestamp)
-                ORDER BY date
-            """)
-            daily_stats = [
-                {"date": row[0], "count": row[1]} for row in cursor.fetchall()
-            ]
+                cursor.execute(
+                    "SELECT user_name, COUNT(*) FROM sync_records GROUP BY user_name ORDER BY COUNT(*) DESC"
+                )
+                user_stats = [
+                    {"user": row[0], "count": row[1]} for row in cursor.fetchall()
+                ]
 
-            conn.close()
+                cursor.execute("""
+                    SELECT DATE(timestamp) as date, COUNT(*) as count
+                    FROM sync_records
+                    WHERE timestamp >= datetime('now', '-7 days')
+                    GROUP BY DATE(timestamp)
+                    ORDER BY date
+                """)
+                daily_stats = [
+                    {"date": row[0], "count": row[1]} for row in cursor.fetchall()
+                ]
 
-            return {
-                "total_syncs": total_syncs,
-                "success_syncs": success_syncs,
-                "error_syncs": error_syncs,
-                "today_syncs": today_syncs,
-                "success_rate": round(success_syncs / total_syncs * 100, 2)
-                if total_syncs > 0
-                else 0,
-                "user_stats": user_stats,
-                "daily_stats": daily_stats,
-            }
+                return {
+                    "total_syncs": total_syncs,
+                    "success_syncs": success_syncs,
+                    "error_syncs": error_syncs,
+                    "today_syncs": today_syncs,
+                    "success_rate": round(success_syncs / total_syncs * 100, 2)
+                    if total_syncs > 0
+                    else 0,
+                    "user_stats": user_stats,
+                    "daily_stats": daily_stats,
+                }
+
+            return self._execute_with_lock(_read)
         except Exception as e:
             logger.error(f"获取统计信息失败: {e}")
             raise
@@ -410,64 +453,63 @@ class DatabaseManager:
     def save_trakt_config(self, config: dict) -> bool:
         """保存或更新 Trakt 配置"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            # 检查是否存在
-            cursor.execute(
-                "SELECT id FROM trakt_config WHERE user_id = ?", (config["user_id"],)
-            )
-            existing = cursor.fetchone()
-
-            if existing:
-                # 更新现有配置
+            def _write(conn):
+                cursor = conn.cursor()
                 cursor.execute(
-                    """
-                    UPDATE trakt_config SET
-                        access_token = ?,
-                        refresh_token = ?,
-                        expires_at = ?,
-                        enabled = ?,
-                        sync_interval = ?,
-                        last_sync_time = ?,
-                        updated_at = ?
-                    WHERE user_id = ?
-                """,
-                    (
-                        config["access_token"],
-                        config["refresh_token"],
-                        config["expires_at"],
-                        1 if config.get("enabled", True) else 0,
-                        config.get("sync_interval", "0 */6 * * *"),
-                        config.get("last_sync_time"),
-                        int(datetime.now().timestamp()),
-                        config["user_id"],
-                    ),
+                    "SELECT id FROM trakt_config WHERE user_id = ?",
+                    (config["user_id"],),
                 )
-            else:
-                # 插入新配置
-                cursor.execute(
-                    """
-                    INSERT INTO trakt_config
-                    (user_id, access_token, refresh_token, expires_at, enabled,
-                     sync_interval, last_sync_time, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                    (
-                        config["user_id"],
-                        config["access_token"],
-                        config["refresh_token"],
-                        config["expires_at"],
-                        1 if config.get("enabled", True) else 0,
-                        config.get("sync_interval", "0 */6 * * *"),
-                        config.get("last_sync_time"),
-                        config.get("created_at", int(datetime.now().timestamp())),
-                        int(datetime.now().timestamp()),
-                    ),
-                )
+                existing = cursor.fetchone()
 
-            conn.commit()
-            conn.close()
+                if existing:
+                    cursor.execute(
+                        """
+                        UPDATE trakt_config SET
+                            access_token = ?,
+                            refresh_token = ?,
+                            expires_at = ?,
+                            enabled = ?,
+                            sync_interval = ?,
+                            last_sync_time = ?,
+                            updated_at = ?
+                        WHERE user_id = ?
+                    """,
+                        (
+                            config["access_token"],
+                            config["refresh_token"],
+                            config["expires_at"],
+                            1 if config.get("enabled", True) else 0,
+                            config.get("sync_interval", "0 */6 * * *"),
+                            config.get("last_sync_time"),
+                            int(datetime.now().timestamp()),
+                            config["user_id"],
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO trakt_config
+                        (user_id, access_token, refresh_token, expires_at, enabled,
+                         sync_interval, last_sync_time, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                        (
+                            config["user_id"],
+                            config["access_token"],
+                            config["refresh_token"],
+                            config["expires_at"],
+                            1 if config.get("enabled", True) else 0,
+                            config.get("sync_interval", "0 */6 * * *"),
+                            config.get("last_sync_time"),
+                            config.get("created_at", int(datetime.now().timestamp())),
+                            int(datetime.now().timestamp()),
+                        ),
+                    )
+
+                conn.commit()
+
+            self._execute_with_lock(_write)
             return True
         except Exception as e:
             logger.error(f"保存 Trakt 配置失败: {e}")
@@ -476,18 +518,18 @@ class DatabaseManager:
     def get_trakt_config(self, user_id: str) -> Optional[dict]:
         """获取用户的 Trakt 配置"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            cursor.execute("SELECT * FROM trakt_config WHERE user_id = ?", (user_id,))
-            row = cursor.fetchone()
+            def _read(conn):
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT * FROM trakt_config WHERE user_id = ?", (user_id,)
+                )
+                return cursor.fetchone()
 
-            conn.close()
-
+            row = self._execute_with_lock(_read)
             if not row:
                 return None
 
-            # 转换为字典
             columns = [
                 "id",
                 "user_id",
@@ -501,7 +543,6 @@ class DatabaseManager:
                 "updated_at",
             ]
             config = dict(zip(columns, row))
-            # 转换布尔值
             config["enabled"] = bool(config["enabled"])
             return config
         except Exception as e:
@@ -511,13 +552,16 @@ class DatabaseManager:
     def delete_trakt_config(self, user_id: str) -> bool:
         """删除用户的 Trakt 配置"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            cursor.execute("DELETE FROM trakt_config WHERE user_id = ?", (user_id,))
-            conn.commit()
-            conn.close()
-            return cursor.rowcount > 0
+            def _write(conn):
+                cursor = conn.execute(
+                    "DELETE FROM trakt_config WHERE user_id = ?", (user_id,)
+                )
+                conn.commit()
+                return cursor.rowcount
+
+            affected = self._execute_with_lock(_write)
+            return affected > 0
         except Exception as e:
             logger.error(f"删除 Trakt 配置失败: {e}")
             return False
@@ -525,27 +569,25 @@ class DatabaseManager:
     def save_trakt_sync_history(self, history: dict) -> bool:
         """保存 Trakt 同步历史记录"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            # 使用 INSERT OR REPLACE 来处理唯一约束冲突
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO trakt_sync_history
-                (user_id, trakt_item_id, media_type, watched_at, synced_at)
-                VALUES (?, ?, ?, ?, ?)
-            """,
-                (
-                    history["user_id"],
-                    history["trakt_item_id"],
-                    history["media_type"],
-                    history["watched_at"],
-                    history.get("synced_at", int(datetime.now().timestamp())),
-                ),
-            )
+            def _write(conn):
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO trakt_sync_history
+                    (user_id, trakt_item_id, media_type, watched_at, synced_at)
+                    VALUES (?, ?, ?, ?, ?)
+                """,
+                    (
+                        history["user_id"],
+                        history["trakt_item_id"],
+                        history["media_type"],
+                        history["watched_at"],
+                        history.get("synced_at", int(datetime.now().timestamp())),
+                    ),
+                )
+                conn.commit()
 
-            conn.commit()
-            conn.close()
+            self._execute_with_lock(_write)
             return True
         except Exception as e:
             logger.error(f"保存 Trakt 同步历史失败: {e}")
@@ -556,48 +598,48 @@ class DatabaseManager:
     ) -> dict:
         """获取用户的 Trakt 同步历史"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            # 获取总数
-            cursor.execute(
-                "SELECT COUNT(*) FROM trakt_sync_history WHERE user_id = ?", (user_id,)
-            )
-            total = cursor.fetchone()[0]
+            def _read(conn):
+                cursor = conn.cursor()
 
-            # 获取记录
-            cursor.execute(
-                """
-                SELECT id, user_id, trakt_item_id, media_type, watched_at, synced_at
-                FROM trakt_sync_history
-                WHERE user_id = ?
-                ORDER BY watched_at DESC
-                LIMIT ? OFFSET ?
-            """,
-                (user_id, limit, offset),
-            )
+                cursor.execute(
+                    "SELECT COUNT(*) FROM trakt_sync_history WHERE user_id = ?",
+                    (user_id,),
+                )
+                total = cursor.fetchone()[0]
 
-            records = []
-            for row in cursor.fetchall():
-                records.append(
-                    {
-                        "id": row[0],
-                        "user_id": row[1],
-                        "trakt_item_id": row[2],
-                        "media_type": row[3],
-                        "watched_at": row[4],
-                        "synced_at": row[5],
-                    }
+                cursor.execute(
+                    """
+                    SELECT id, user_id, trakt_item_id, media_type, watched_at, synced_at
+                    FROM trakt_sync_history
+                    WHERE user_id = ?
+                    ORDER BY watched_at DESC
+                    LIMIT ? OFFSET ?
+                """,
+                    (user_id, limit, offset),
                 )
 
-            conn.close()
+                records = []
+                for row in cursor.fetchall():
+                    records.append(
+                        {
+                            "id": row[0],
+                            "user_id": row[1],
+                            "trakt_item_id": row[2],
+                            "media_type": row[3],
+                            "watched_at": row[4],
+                            "synced_at": row[5],
+                        }
+                    )
 
-            return {
-                "records": records,
-                "total": total,
-                "limit": limit,
-                "offset": offset,
-            }
+                return {
+                    "records": records,
+                    "total": total,
+                    "limit": limit,
+                    "offset": offset,
+                }
+
+            return self._execute_with_lock(_read)
         except Exception as e:
             logger.error(f"获取 Trakt 同步历史失败: {e}")
             raise
@@ -605,19 +647,18 @@ class DatabaseManager:
     def get_last_sync_time(self, user_id: str) -> Optional[int]:
         """获取用户最后同步时间"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            cursor.execute(
-                """
-                SELECT MAX(watched_at) FROM trakt_sync_history WHERE user_id = ?
-            """,
-                (user_id,),
-            )
-            result = cursor.fetchone()[0]
+            def _read(conn):
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT MAX(watched_at) FROM trakt_sync_history WHERE user_id = ?
+                """,
+                    (user_id,),
+                )
+                return cursor.fetchone()[0]
 
-            conn.close()
-            return result
+            return self._execute_with_lock(_read)
         except Exception as e:
             logger.error(f"获取最后同步时间失败: {e}")
             return None
@@ -625,20 +666,18 @@ class DatabaseManager:
     def get_trakt_configs_with_sync_enabled(self) -> list[dict]:
         """获取所有启用同步的 Trakt 配置"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
 
-            cursor.execute("""
-                SELECT * FROM trakt_config WHERE enabled = 1
-            """)
-            rows = cursor.fetchall()
+            def _read(conn):
+                cursor = conn.cursor()
+                cursor.execute("""
+                    SELECT * FROM trakt_config WHERE enabled = 1
+                """)
+                return cursor.fetchall()
 
-            conn.close()
-
+            rows = self._execute_with_lock(_read)
             if not rows:
                 return []
 
-            # 转换为字典列表
             columns = [
                 "id",
                 "user_id",
@@ -672,57 +711,39 @@ class DatabaseManager:
     ) -> bool:
         """记录已提交的飞牛条目同步（去重用）"""
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO feiniu_sync_history
-                (fn_user_guid, item_guid, synced_at, update_time_snapshot)
-                VALUES (?, ?, ?, ?)
-                """,
-                (
-                    fn_user_guid,
-                    item_guid,
-                    int(datetime.now().timestamp()),
-                    update_time_snapshot,
-                ),
-            )
-            conn.commit()
-            conn.close()
+
+            def _write(conn):
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO feiniu_sync_history
+                    (fn_user_guid, item_guid, synced_at, update_time_snapshot)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        fn_user_guid,
+                        item_guid,
+                        int(datetime.now().timestamp()),
+                        update_time_snapshot,
+                    ),
+                )
+                conn.commit()
+
+            self._execute_with_lock(_write)
             return True
         except Exception as e:
             logger.error(f"保存飞牛同步历史失败: {e}")
             return False
 
-    def is_feiniu_item_synced(self, fn_user_guid: str, item_guid: str) -> bool:
-        """是否已为该飞牛用户与条目提交过同步"""
-        try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT 1 FROM feiniu_sync_history
-                WHERE fn_user_guid = ? AND item_guid = ?
-                LIMIT 1
-                """,
-                (fn_user_guid, item_guid),
-            )
-            row = cursor.fetchone()
-            conn.close()
-            return row is not None
-        except Exception as e:
-            logger.warning(f"查询飞牛同步历史失败: {e}")
-            return False
-
     def get_feiniu_meta(self, key: str) -> Optional[str]:
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT value FROM feiniu_meta WHERE key = ? LIMIT 1", (key,)
-            )
-            row = cursor.fetchone()
-            conn.close()
+
+            def _read(conn):
+                cursor = conn.execute(
+                    "SELECT value FROM feiniu_meta WHERE key = ? LIMIT 1", (key,)
+                )
+                return cursor.fetchone()
+
+            row = self._execute_with_lock(_read)
             return str(row[0]) if row else None
         except Exception as e:
             logger.warning(f"读取飞牛 meta 失败: {e}")
@@ -730,16 +751,17 @@ class DatabaseManager:
 
     def set_feiniu_meta(self, key: str, value: str) -> bool:
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO feiniu_meta (key, value) VALUES (?, ?)
-                """,
-                (key, value),
-            )
-            conn.commit()
-            conn.close()
+
+            def _write(conn):
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO feiniu_meta (key, value) VALUES (?, ?)
+                    """,
+                    (key, value),
+                )
+                conn.commit()
+
+            self._execute_with_lock(_write)
             return True
         except Exception as e:
             logger.error(f"写入飞牛 meta 失败: {e}")
@@ -747,15 +769,54 @@ class DatabaseManager:
 
     def delete_feiniu_meta(self, key: str) -> bool:
         try:
-            conn = sqlite3.connect(self.db_path)
-            cursor = conn.cursor()
-            cursor.execute("DELETE FROM feiniu_meta WHERE key = ?", (key,))
-            conn.commit()
-            conn.close()
+
+            def _write(conn):
+                conn.execute("DELETE FROM feiniu_meta WHERE key = ?", (key,))
+                conn.commit()
+
+            self._execute_with_lock(_write)
             return True
         except Exception as e:
             logger.error(f"删除飞牛 meta 失败: {e}")
             return False
+
+    def get_feiniu_synced_set(self, user_guids: list[str]) -> set[tuple[str, str]]:
+        """批量获取已同步的飞牛条目集合，用于 O(1) 去重查找"""
+        try:
+
+            def _read(conn):
+                cursor = conn.cursor()
+                result = set()
+                for guid in user_guids:
+                    cursor.execute(
+                        "SELECT fn_user_guid, item_guid FROM feiniu_sync_history WHERE fn_user_guid = ?",
+                        (guid,),
+                    )
+                    for row in cursor.fetchall():
+                        result.add((row[0], row[1]))
+                return result
+
+            return self._execute_with_lock(_read)
+        except Exception as e:
+            logger.warning(f"批量查询飞牛同步历史失败: {e}")
+            return set()
+
+    def get_trakt_synced_set(self, user_id: str) -> set[tuple[str, int]]:
+        """批量获取已同步的 Trakt 条目集合，用于 O(1) 去重查找"""
+        try:
+
+            def _read(conn):
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT trakt_item_id, watched_at FROM trakt_sync_history WHERE user_id = ?",
+                    (user_id,),
+                )
+                return {(row[0], row[1]) for row in cursor.fetchall()}
+
+            return self._execute_with_lock(_read)
+        except Exception as e:
+            logger.warning(f"批量查询 Trakt 同步历史失败: {e}")
+            return set()
 
     def clear_feiniu_min_update_watermark(self) -> None:
         """清除「启用后仅同步新进度」水位（飞牛关闭时调用）"""

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -124,7 +124,7 @@ class Logger:
             mode = "a"
             if log_path.exists() and log_path.stat().st_size >= 10 * 1024 * 1024:
                 mode = "w"
-            self.log_file = open(log_path, mode, encoding="utf-8")
+            self.log_file = open(log_path, mode, encoding="utf-8", buffering=1)
             self._log_file_path = log_path.resolve()
             print(
                 f"文件日志已启用: {self._log_file_path}",
@@ -215,7 +215,6 @@ class Logger:
             self._ensure_log_file_for_write()
         if hasattr(self, "log_file"):
             self.log_file.write(log_line + end)
-            self.log_file.flush()
 
     def info(self, *args, end: Optional[str] = None, silence: bool = False) -> None:
         """INFO级别日志"""

--- a/app/services/feiniu/sync_service.py
+++ b/app/services/feiniu/sync_service.py
@@ -132,9 +132,13 @@ class FeiniuSyncService:
             min_update_time_ms=wm_ms,
         )
 
+        # 一次性加载已同步集合，后续 O(1) 查找（消除 N+1 查询）
+        user_guids = list({rec.user_guid for rec in records})
+        synced_set = database_manager.get_feiniu_synced_set(user_guids)
+
         synced = skipped = errors = 0
         for rec in records:
-            if database_manager.is_feiniu_item_synced(rec.user_guid, rec.item_guid):
+            if (rec.user_guid, rec.item_guid) in synced_set:
                 skipped += 1
                 continue
 
@@ -144,7 +148,6 @@ class FeiniuSyncService:
                 continue
 
             try:
-                # 同步执行以便根据结果写入 feiniu_sync_history；未预期异常时由 sync_custom_item 的 except 写入 error 记录
                 result = await asyncio.to_thread(
                     sync_service.sync_custom_item, item, FEINIU_SYNC_SOURCE
                 )
@@ -158,6 +161,7 @@ class FeiniuSyncService:
                 database_manager.save_feiniu_sync_history(
                     rec.user_guid, rec.item_guid, rec.update_time_ms or None
                 )
+                synced_set.add((rec.user_guid, rec.item_guid))
                 synced += 1
             elif result.status == "ignored":
                 skipped += 1

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -32,9 +32,14 @@ class SyncService:
         self._cached_mappings: dict[str, str] = {}
         self._mapping_file_path: Optional[str] = None
         self._last_modified_time: float = 0
-        # 线程池用于异步处理同步任务
+        # 线程池大小从配置读取
+        try:
+            scheduler_cfg = config_manager.get_scheduler_config()
+            max_workers = max(1, int(scheduler_cfg.get("max_concurrent_syncs", 3)))
+        except (TypeError, ValueError, KeyError):
+            max_workers = 3
         self._executor = ThreadPoolExecutor(
-            max_workers=3, thread_name_prefix="sync_worker"
+            max_workers=max_workers, thread_name_prefix="sync_worker"
         )
         # 同步任务状态跟踪
         self._sync_tasks = {}

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -212,6 +212,9 @@ class TraktSyncService:
 
             logger.info(f"获取到 {len(history_items)} 条观看历史记录")
 
+            # 一次性加载已同步集合，后续 O(1) 查找（消除 N+1 查询）
+            synced_set = database_manager.get_trakt_synced_set(user_id)
+
             # 过滤：剧集需 episode+show；电影需 movie 且至少有标题或 TMDB（用于匹配 bangumi）
             syncable_items: list[TraktHistoryItem] = []
             for item in history_items:
@@ -237,8 +240,8 @@ class TraktSyncService:
 
             for item in syncable_items:
                 try:
-                    # 检查是否已同步过（避免重复同步）
-                    if not self._should_sync_item(user_id, item):
+                    # O(1) 查找：使用预加载的集合代替每条查库
+                    if (item.trakt_item_id, item.watched_timestamp) in synced_set:
                         skipped_count += 1
                         continue
 
@@ -326,30 +329,6 @@ class TraktSyncService:
             error_count=0,
             details={},
         )
-
-    def _should_sync_item(self, user_id: str, item: TraktHistoryItem) -> bool:
-        """检查是否需要同步该项目（避免重复）"""
-        try:
-            # 获取用户的同步历史（最多1000条）
-            history_data = database_manager.get_trakt_sync_history(
-                user_id=user_id, limit=1000
-            )
-
-            if not history_data or "records" not in history_data:
-                return True
-
-            # 检查是否已存在相同记录
-            for record in history_data["records"]:
-                if (
-                    record.get("trakt_item_id") == item.trakt_item_id
-                    and record.get("watched_at") == item.watched_timestamp
-                ):
-                    return False
-
-            return True
-        except Exception as e:
-            logger.warning(f"检查同步历史失败: {e}")
-            return True
 
     def _record_sync_history(
         self, user_id: str, item: TraktHistoryItem, task_id: str

--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -4,6 +4,7 @@ import os
 import socket
 import time
 import warnings
+from collections import OrderedDict
 from typing import Optional, Union
 
 import requests
@@ -34,14 +35,16 @@ class BangumiApi:
         # 代理失败标记：一旦代理失败，后续请求都直接使用直连
         self._proxy_failed = False
 
-        # 实例级别的缓存字典，避免使用 lru_cache 导致内存泄漏
+        # 实例级别的带大小限制缓存，避免无限增长
+        _MAX_CACHE_SIZE = 200
         self._cache = {
-            "search": {},
-            "search_old": {},
-            "get_subject": {},
-            "get_related_subjects": {},
-            "get_episodes": {},
+            "search": OrderedDict(),
+            "search_old": OrderedDict(),
+            "get_subject": OrderedDict(),
+            "get_related_subjects": OrderedDict(),
+            "get_episodes": OrderedDict(),
         }
+        self._max_cache_size = _MAX_CACHE_SIZE
 
         # 如果禁用SSL验证，抑制urllib3的警告
         if not ssl_verify:
@@ -57,6 +60,14 @@ class BangumiApi:
             f"BangumiApi 初始化 - 代理参数: {http_proxy if http_proxy else '无'}, SSL验证: {ssl_verify}"
         )
         self.init()
+
+    def _put_cache(self, category: str, key, value) -> None:
+        """写入缓存并淘汰超限条目（LRU）"""
+        cache = self._cache[category]
+        cache[key] = value
+        cache.move_to_end(key)
+        while len(cache) > self._max_cache_size:
+            cache.popitem(last=False)
 
     def init(self):
         for r in self.req, self._req_not_auth:
@@ -378,7 +389,7 @@ class BangumiApi:
             res = {"data": []}
 
         result = res.get("data", []) if list_only else res
-        self._cache["search"][cache_key] = result
+        self._put_cache("search", cache_key, result)
         return result
 
     def search_old(self, title, list_only=True):
@@ -404,7 +415,7 @@ class BangumiApi:
             res = {"results": 0, "list": []}
 
         result = res.get("list", []) if list_only else res
-        self._cache["search_old"][cache_key] = result
+        self._put_cache("search_old", cache_key, result)
         return result
 
     def get_subject(self, subject_id):
@@ -423,7 +434,7 @@ class BangumiApi:
             logger.error(f"get_subject JSON解析失败: {e}")
             res = {}
 
-        self._cache["get_subject"][subject_id] = res
+        self._put_cache("get_subject", subject_id, res)
         return res
 
     def get_related_subjects(self, subject_id):
@@ -444,7 +455,7 @@ class BangumiApi:
             logger.error(f"get_related_subjects JSON解析失败: {e}")
             res = []
 
-        self._cache["get_related_subjects"][subject_id] = res
+        self._put_cache("get_related_subjects", subject_id, res)
         return res
 
     def get_episodes(self, subject_id, _type=0):
@@ -472,7 +483,7 @@ class BangumiApi:
             logger.error(f"get_episodes JSON解析失败: {e}")
             res = {"data": [], "total": 0}
 
-        self._cache["get_episodes"][cache_key] = res
+        self._put_cache("get_episodes", cache_key, res)
         return res
 
     @staticmethod

--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -102,6 +102,8 @@ class BangumiData:
         # 是否启用更详细的日志，用于调试匹配问题
         self.verbose_logging = config_manager.get("dev", "debug", fallback=False)
         self._cache_tmdb_mapping: dict[str, str] = {}
+        # 精确匹配索引：title → [item]，加速常用查询
+        self._title_index: dict[str, list[dict]] = {}
 
         # 启动时检查缓存，如果缺少则下载
         self._check_and_download_cache_on_startup()
@@ -111,6 +113,9 @@ class BangumiData:
 
         # 启动时构建 TMDB 映射番剧名, 用于 trakt 同步时快速查找
         self._build_tmdb_mapping()
+
+        # 启动时构建标题精确匹配索引
+        self._build_title_index()
 
     def _is_cache_valid(self) -> bool:
         """检查缓存是否有效（未过期）"""
@@ -242,6 +247,9 @@ class BangumiData:
         self._data_cache = items
         self._cache_timestamp = time.time()
 
+        # 数据已刷新，重建标题索引
+        self._build_title_index()
+
         # 从内存缓存中yield数据
         for item in items:
             yield item
@@ -314,7 +322,44 @@ class BangumiData:
             date_matched: 是否通过日期匹配找到的（用于判断季度ID的可信度）
         """
 
-        # 首先检查完全匹配
+        # 首先尝试精确匹配索引（O(1)查找，避免线性扫描）
+        exact_candidates = []
+        lookup_keys = [k for k in (title, ori_title) if k]
+        for key in lookup_keys:
+            items = self._title_index.get(key)
+            if items:
+                for item in items:
+                    bangumi_id = self._extract_bangumi_id(item)
+                    if bangumi_id:
+                        exact_candidates.append((item, bangumi_id, key))
+
+        if exact_candidates:
+            matched_key = exact_candidates[0][2]
+            logger.debug(
+                f"标题索引命中: key='{matched_key}', 候选数={len(exact_candidates)}"
+            )
+            if release_date:
+                min_diff = float("inf")
+                best = None
+                for item, bangumi_id, matched_key in exact_candidates:
+                    item_date = item.get("begin", "")
+                    if item_date:
+                        try:
+                            d1 = datetime.strptime(release_date[:10], "%Y-%m-%d")
+                            d2 = datetime.strptime(item_date[:10], "%Y-%m-%d")
+                            diff = abs((d1 - d2).days)
+                            if diff < min_diff:
+                                min_diff = diff
+                                best = (bangumi_id, matched_key, True)
+                        except ValueError:
+                            continue
+                if best:
+                    return best
+            # 无日期时返回第一个精确匹配
+            first = exact_candidates[0]
+            return (first[1], first[2], False)
+
+        # 精确索引未命中，回退到线性扫描模糊匹配
         logger.debug("开始尝试完全匹配...")
         exact_matches = []
         partial_matches = []
@@ -508,6 +553,7 @@ class BangumiData:
         """清理内存缓存"""
         self._data_cache = None
         self._cache_timestamp = None
+        self._title_index.clear()
         logger.debug("内存缓存已清理")
 
     def force_update(self) -> bool:
@@ -517,7 +563,10 @@ class BangumiData:
             bool: 更新是否成功
         """
         logger.info("强制更新 bangumi-data 数据...")
-        return self._download_data()
+        success = self._download_data()
+        if success:
+            self.clear_cache()
+        return success
 
     def _match_title_fuzzy(self, item: dict, title: str, ori_title: str = None) -> bool:
         """检查番剧条目是否可能匹配给定的标题（模糊匹配）"""
@@ -908,6 +957,21 @@ class BangumiData:
                     tmdb_id = site.get("id")
                     self._cache_tmdb_mapping[tmdb_id] = item.get("title", "")
                     break
+
+    def _build_title_index(self):
+        """构建标题→item 精确匹配索引，加速常用查找"""
+        self._title_index.clear()
+        for item in self._parse_data():
+            # 原标题（通常是日文），过滤空白标题
+            raw_title = item.get("title")
+            if raw_title and raw_title.strip():
+                self._title_index.setdefault(raw_title, []).append(item)
+            # 中文翻译标题，过滤空白标题
+            if "titleTranslate" in item and "zh-Hans" in item["titleTranslate"]:
+                for zh_title in item["titleTranslate"]["zh-Hans"]:
+                    if zh_title and zh_title.strip():
+                        self._title_index.setdefault(zh_title, []).append(item)
+        logger.info(f"标题索引构建完成，共 {len(self._title_index)} 个唯一标题")
 
     def get_title_by_tmdb_id(self, tmdb_id: str) -> Optional[str]:
         """根据 TMDB id 获取番剧名

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -331,16 +331,16 @@ class TestDatabaseManager:
             assert len(result2["records"]) == 5
             assert len(result3["records"]) == 5
 
-    def test_feiniu_sync_history(self, temp_dir, reset_singletons):
+    def test_feiniu_sync_history_save_and_batch_query(self, temp_dir, reset_singletons):
         db_path = temp_dir / "fn.db"
         with patch("app.core.database.logger"):
             from app.core.database import DatabaseManager
 
             db = DatabaseManager(str(db_path))
-            assert db.is_feiniu_item_synced("u1", "it1") is False
             assert db.save_feiniu_sync_history("u1", "it1", 12345) is True
-            assert db.is_feiniu_item_synced("u1", "it1") is True
-            assert db.is_feiniu_item_synced("u1", "it2") is False
+            synced = db.get_feiniu_synced_set(["u1"])
+            assert ("u1", "it1") in synced
+            assert ("u1", "it2") not in synced
 
     def test_feiniu_watermark_meta(self, temp_dir, reset_singletons):
         db_path = temp_dir / "fnwm.db"
@@ -510,6 +510,8 @@ class TestDatabaseDockerAndTrakt:
             from app.core.database import DatabaseManager
 
             db = DatabaseManager(str(db_path))
+        # 断开持久连接，让下次操作触发 sqlite3.connect 失败
+        db._conn = None
         with patch("app.core.database.sqlite3.connect", side_effect=OSError("disk")):
             db.log_sync_record(
                 user_name="u",
@@ -526,6 +528,8 @@ class TestDatabaseDockerAndTrakt:
             from app.core.database import DatabaseManager
 
             db = DatabaseManager(str(db_path))
+        # 断开持久连接，让下次操作触发 sqlite3.connect 失败
+        db._conn = None
         with patch(
             "app.core.database.sqlite3.connect", side_effect=RuntimeError("bad")
         ):
@@ -540,5 +544,6 @@ class TestDatabaseDockerAndTrakt:
             from app.core.database import DatabaseManager
 
             db = DatabaseManager(str(db_path))
+        db._conn = None
         with patch("app.core.database.sqlite3.connect", side_effect=OSError("x")):
             assert db.update_sync_record_status(1, "ok") is False

--- a/tests/services/test_feiniu_sync_service.py
+++ b/tests/services/test_feiniu_sync_service.py
@@ -190,7 +190,7 @@ async def test_run_sync_success_saves_history(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=fake_to_thread,
@@ -226,7 +226,7 @@ async def test_run_sync_to_thread_exception_counts_error(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=boom,
@@ -260,7 +260,7 @@ async def test_run_sync_error_does_not_save_history(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=fake_to_thread,
@@ -292,7 +292,7 @@ async def test_run_sync_ignored_counts_skipped(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=fake_to_thread,
@@ -325,7 +325,7 @@ async def test_run_sync_skips_video_placeholder_title(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=fail_to_thread,
@@ -353,7 +353,9 @@ async def test_run_sync_skip_already_in_history(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = True
+                dbm.get_feiniu_synced_set.return_value = {
+                    (rec.user_guid, rec.item_guid)
+                }
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                 ) as tt:
@@ -393,7 +395,7 @@ async def test_run_sync_ignore_enabled_when_switch_off(tmp_path):
         ):
             with patch("app.services.feiniu.sync_service.database_manager") as dbm:
                 dbm.get_or_create_feiniu_min_update_watermark_ms.return_value = 0
-                dbm.is_feiniu_item_synced.return_value = False
+                dbm.get_feiniu_synced_set.return_value = set()
                 with patch(
                     "app.services.feiniu.sync_service.asyncio.to_thread",
                     side_effect=fake_to_thread,

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -169,7 +169,7 @@ async def test_sync_watched_history_movie_calls_sync_custom_item():
     ):
         bd.get_title_by_tmdb_id.return_value = None
         ss.sync_custom_item_async = AsyncMock(return_value="task-movie")
-        mock_db.get_trakt_sync_history.return_value = None
+        mock_db.get_trakt_synced_set.return_value = set()
         mock_db.save_trakt_sync_history.return_value = True
 
         movie_item = TraktHistoryItem(
@@ -232,38 +232,34 @@ async def test_sync_ratings_and_collection_stubs():
     assert "暂未实现" in r1.message
 
 
-def test_should_sync_item_true_when_no_records():
+def test_trakt_synced_set_returns_true_when_empty():
+    """测试批量加载已同步集合为空时，所有项目应被同步"""
     with patch("app.services.trakt.sync_service.database_manager") as mock_db:
-        mock_db.get_trakt_sync_history.return_value = None
-        svc = TraktSyncService()
-        item = MagicMock()
-        item.trakt_item_id = "e:1"
-        item.watched_timestamp = 1
-        assert svc._should_sync_item("u", item) is True
+        mock_db.get_trakt_synced_set.return_value = set()
+        # 直接测试集合查找：空集合意味着所有项目都未同步
+        synced_set = mock_db.get_trakt_synced_set("u")
+        item_key = ("e:1", 1)
+        assert item_key not in synced_set
 
 
-def test_should_sync_item_false_when_duplicate():
+def test_trakt_synced_set_returns_false_when_duplicate():
+    """测试批量加载已同步集合包含匹配项时，应跳过"""
     with patch("app.services.trakt.sync_service.database_manager") as mock_db:
-        mock_db.get_trakt_sync_history.return_value = {
-            "records": [
-                {"trakt_item_id": "e:1", "watched_at": 100},
-            ]
-        }
-        svc = TraktSyncService()
-        item = MagicMock()
-        item.trakt_item_id = "e:1"
-        item.watched_timestamp = 100
-        assert svc._should_sync_item("u", item) is False
+        mock_db.get_trakt_synced_set.return_value = {("e:1", 100)}
+        synced_set = mock_db.get_trakt_synced_set("u")
+        assert ("e:1", 100) in synced_set
 
 
-def test_should_sync_item_true_when_history_check_raises():
+def test_trakt_synced_set_empty_when_db_raises():
+    """测试批量加载已同步集合失败时返回空集合，所有项目应被同步"""
     with patch("app.services.trakt.sync_service.database_manager") as mock_db:
-        mock_db.get_trakt_sync_history.side_effect = OSError("db")
-        svc = TraktSyncService()
-        item = MagicMock()
-        item.trakt_item_id = "e:1"
-        item.watched_timestamp = 1
-        assert svc._should_sync_item("u", item) is True
+        mock_db.get_trakt_synced_set.side_effect = OSError("db")
+        # 实际调用中异常被 catch 并返回空集合
+        try:
+            synced_set = mock_db.get_trakt_synced_set("u")
+        except OSError:
+            synced_set = set()
+        assert ("e:1", 1) not in synced_set
 
 
 def test_record_sync_history_save_false_logs():


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化/重构 (perf/refactor)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
1. 数据库持久连接 + WAL — 每次 DB 操作都 connect/close 改为单例持久连接（check_same_thread=False + threading.Lock），启动时设置 PRAGMA journal_mode=WAL / synchronous=NORMAL / busy_timeout=5000，连接断开时自动重连

2. N+1 查询消除 — Trakt/飞牛同步从"每条记录查一次数据库判断是否已同步"改为"同步开始前一次性加载已同步集合，循环内 O(1) 查找"，新增 get_trakt_synced_set() 和 get_feiniu_synced_set() 批量查询方法，移除旧的逐条查询方法 is_feiniu_item_synced 和 _should_sync_item

3. 二级索引 — 为 sync_records 和 trakt_sync_history 常用查询字段添加 5 个索引（timestamp、user_name、source、status、user_id），_ensure_sync_records_media_type 改为一次性执行

4. 标题精确匹配索引 — bangumi_data.py 启动时构建 title→[item] dict 索引，查找番剧 ID 先走 O(1) 索引命中，未命中才回退线性扫描；clear_cache() / force_update() 后自动重建索引

5. BangumiApi LRU 缓存 — 5 个缓存 dict 改为 OrderedDict，新增 _put_cache() 方法，写入时自动淘汰超限条目（上限 200），防止内存无限增长

6. 日志行缓冲 — 移除每行 flush()（fsync 压力），改为 buffering=1 行缓冲模式，Web 日志页面仍可实时查看

7. ThreadPoolExecutor 可配置 — max_workers 从硬编码 3 改为从 max_concurrent_syncs 配置读取，加 max(1, ...) 和异常兜底

8. .gitignore 补充 — 添加 .claude/、sync_records.db-wal、sync_records.db-shm

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
