### PR TITLE
perf: 稳定性改进

### DIFF
--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -55,6 +55,7 @@ async def _handle_custom_sync(
     """处理自定义同步请求的内部函数"""
     if not await _verify_webhook_auth(webhook_key):
         logger.warning("Custom webhook 认证失败，无效的 key")
+        response.status_code = 401
         return {"status": "error", "message": "认证失败"}
     try:
         if async_mode:
@@ -107,10 +108,8 @@ async def get_sync_status(
 async def list_sync_tasks(current_user: dict = Depends(get_current_user_flexible)):
     """获取所有同步任务列表"""
     try:
-        # 清理旧任务
         sync_service.cleanup_old_tasks()
-
-        tasks = sync_service._sync_tasks
+        tasks = sync_service.get_all_sync_tasks()
         return {"status": "success", "data": {"tasks": tasks, "total": len(tasks)}}
     except Exception as e:
         logger.error(f"获取同步任务列表失败: {e}")
@@ -356,19 +355,20 @@ async def _handle_plex_sync(plex_request: Request, webhook_key: str = ""):
     """处理Plex同步请求的内部函数"""
     if not await _verify_webhook_auth(webhook_key):
         logger.warning("Plex webhook 认证失败，无效的 key")
-        return {"status": "error", "message": "认证失败"}
+        return Response(
+            content='{"status": "error", "message": "认证失败"}',
+            status_code=401,
+            media_type="application/json",
+        )
 
     try:
         json_str = await plex_request.body()
         plex_data = json.loads(extract_plex_json(json_str))
 
         # 异步调用同步服务（不阻塞webhook响应）
-        # 对于webhook，我们立即返回成功响应，同步在后台进行
         try:
-            # 提交到异步队列处理
             task_id = await sync_service.sync_plex_item_async(plex_data)
             logger.info(f"Plex webhook已提交异步任务: {task_id}")
-            # 对于webhook，立即返回成功响应
             return {
                 "status": "accepted",
                 "message": "Plex同步请求已接收",
@@ -386,8 +386,8 @@ async def _handle_plex_sync(plex_request: Request, webhook_key: str = ""):
             except Exception as fallback_error:
                 logger.error(f"Plex同步回退模式也失败: {fallback_error}")
                 return {
-                    "status": "accepted",
-                    "message": "Plex同步请求已接收，但处理时出现错误",
+                    "status": "error",
+                    "message": f"Plex同步处理失败: {fallback_error}",
                 }
 
     except Exception as e:
@@ -411,7 +411,11 @@ async def _handle_emby_sync(emby_request: Request, webhook_key: str = ""):
     """处理Emby同步请求的内部函数"""
     if not await _verify_webhook_auth(webhook_key):
         logger.warning("Emby webhook 认证失败，无效的 key")
-        return {"status": "error", "message": "认证失败"}
+        return Response(
+            content='{"status": "error", "message": "认证失败"}',
+            status_code=401,
+            media_type="application/json",
+        )
 
     try:
         # 获取请求内容
@@ -457,8 +461,8 @@ async def _handle_emby_sync(emby_request: Request, webhook_key: str = ""):
             except Exception as fallback_error:
                 logger.error(f"Emby同步回退模式也失败: {fallback_error}")
                 return {
-                    "status": "accepted",
-                    "message": "Emby同步请求已接收，但处理时出现错误",
+                    "status": "error",
+                    "message": f"Emby同步处理失败: {fallback_error}",
                 }
     except Exception as e:
         logger.error(f"Emby同步处理出错: {e}")
@@ -482,7 +486,11 @@ async def _handle_jellyfin_sync(jellyfin_request: Request, webhook_key: str = ""
     """处理Jellyfin同步请求的内部函数"""
     if not await _verify_webhook_auth(webhook_key):
         logger.warning("Jellyfin webhook 认证失败，无效的 key")
-        return {"status": "error", "message": "认证失败"}
+        return Response(
+            content='{"status": "error", "message": "认证失败"}',
+            status_code=401,
+            media_type="application/json",
+        )
 
     try:
         json_str = await jellyfin_request.body()
@@ -512,8 +520,8 @@ async def _handle_jellyfin_sync(jellyfin_request: Request, webhook_key: str = ""
             except Exception as fallback_error:
                 logger.error(f"Jellyfin同步回退模式也失败: {fallback_error}")
                 return {
-                    "status": "accepted",
-                    "message": "Jellyfin同步请求已接收，但处理时出现错误",
+                    "status": "error",
+                    "message": f"Jellyfin同步处理失败: {fallback_error}",
                 }
 
     except Exception as e:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -4,6 +4,7 @@
 
 import os
 import platform
+import threading
 from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Optional
@@ -21,6 +22,8 @@ def parse_media_server_username_value(raw: Optional[str]) -> list[str]:
 
 class ConfigManager:
     """配置管理器"""
+
+    _lock = threading.Lock()
 
     def __init__(self):
         self.platform = platform.system()
@@ -128,20 +131,29 @@ class ConfigManager:
 
         return False
 
-    def get_config_parser(self) -> ConfigParser:
-        """获取配置对象"""
+    def _get_config_parser_nolock(self) -> ConfigParser:
+        """获取配置对象（内部调用，需已持有锁或单线程上下文）"""
         if self._check_config_updated():
             self._load_config()
-
         return self._config_cache
 
+    def get_config_parser(self) -> ConfigParser:
+        """获取配置对象（线程安全）"""
+        with self._lock:
+            return self._get_config_parser_nolock()
+
     def reload_config(self) -> None:
-        """重新加载配置"""
-        self._load_config()
+        """重新加载配置（线程安全）"""
+        with self._lock:
+            self._load_config()
 
     def reload(self) -> None:
         """重新加载配置（别名）"""
         self.reload_config()
+
+    def _get_master_secret(self, config: ConfigParser) -> str:
+        """从配置中提取 master secret（不加锁，需已持有锁或外部调用）"""
+        return str(config.get("auth", "secret_key", fallback="") or "")
 
     def get_section(
         self, section: str, fallback: dict[str, Any] = None
@@ -163,9 +175,10 @@ class ConfigManager:
 
         from .config_secret_crypto import decrypt_if_sensitive
 
+        master = self._get_master_secret(config)
         for k, v in list(result.items()):
             if isinstance(v, str):
-                result[k] = decrypt_if_sensitive(section, k, v)
+                result[k] = decrypt_if_sensitive(section, k, v, master=master)
 
         return result
 
@@ -188,7 +201,8 @@ class ConfigManager:
         else:
             from .config_secret_crypto import decrypt_if_sensitive
 
-            out = decrypt_if_sensitive(section, key, value)
+            master = self._get_master_secret(config)
+            out = decrypt_if_sensitive(section, key, value, master=master)
             return out if isinstance(out, str) else value
 
     def get(self, section: str, key: str, fallback: Any = None) -> Any:
@@ -196,25 +210,37 @@ class ConfigManager:
         return self.get_config(section, key, fallback)
 
     def set_config(self, section: str, key: str, value: Any) -> None:
-        """设置配置值"""
-        config = self.get_config_parser()
-        if not config.has_section(section):
-            config.add_section(section)
+        """设置配置值（线程安全）"""
+        with self._lock:
+            config = self._get_config_parser_nolock()
+            if not config.has_section(section):
+                config.add_section(section)
 
-        from .config_secret_crypto import encrypt_if_sensitive
+            from .config_secret_crypto import encrypt_if_sensitive
 
-        stored = encrypt_if_sensitive(section, key, str(value))
-        config.set(section, key, stored)
-        self._save_config(config)
+            master = self._get_master_secret(config)
+            stored = encrypt_if_sensitive(section, key, str(value), master=master)
+            config.set(section, key, stored)
+            self._save_config(config)
 
     def set(self, section: str, key: str, value: Any) -> None:
         """设置配置值（别名）"""
         self.set_config(section, key, value)
 
     def _save_config(self, config: ConfigParser) -> None:
-        """保存配置文件"""
-        with open(self.active_config_path, "w", encoding="utf-8") as f:
-            config.write(f)
+        """保存配置文件（原子写入，需在锁内调用）"""
+        tmp_path = self.active_config_path.with_suffix(".tmp")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                config.write(f)
+            os.replace(str(tmp_path), str(self.active_config_path))
+        except OSError:
+            # 写入失败时清理临时文件
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
 
         # 更新缓存
         self._config_cache = config

--- a/app/core/config_secret_crypto.py
+++ b/app/core/config_secret_crypto.py
@@ -57,26 +57,30 @@ def _master_secret() -> str:
     return str(config_manager.get("auth", "secret_key", fallback="") or "")
 
 
-def encrypt(plaintext: str) -> str:
+def encrypt(plaintext: str, *, master: str | None = None) -> str:
     if plaintext is None or plaintext == "":
         return ""
     if plaintext.startswith(PREFIX):
         return plaintext
-    f = _fernet_for_master(_master_secret())
+    if master is None:
+        master = _master_secret()
+    f = _fernet_for_master(master)
     if f is None:
         return plaintext
     token = f.encrypt(plaintext.encode("utf-8")).decode("ascii")
     return PREFIX + token
 
 
-def decrypt(stored: Any) -> str:
+def decrypt(stored: Any, *, master: str | None = None) -> str:
     if stored is None:
         return ""
     s = str(stored)
     if not s.startswith(PREFIX):
         return s
     token = s[len(PREFIX) :]
-    f = _fernet_for_master(_master_secret())
+    if master is None:
+        master = _master_secret()
+    f = _fernet_for_master(master)
     if f is None:
         if s.startswith(PREFIX):
             from .logging import logger
@@ -97,18 +101,22 @@ def decrypt(stored: Any) -> str:
         return s
 
 
-def encrypt_if_sensitive(section: str, option: str, value: str) -> str:
+def encrypt_if_sensitive(
+    section: str, option: str, value: str, *, master: str | None = None
+) -> str:
     if not is_sensitive_ini_field(section, option):
         return value
-    return encrypt(value)
+    return encrypt(value, master=master)
 
 
-def decrypt_if_sensitive(section: str, option: str, value: Any) -> Any:
+def decrypt_if_sensitive(
+    section: str, option: str, value: Any, *, master: str | None = None
+) -> Any:
     if not is_sensitive_ini_field(section, option):
         return value
     if not isinstance(value, str):
         return value
-    return decrypt(value)
+    return decrypt(value, master=master)
 
 
 def migrate_plaintext_sensitive_fields(config: ConfigParser) -> bool:

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -46,6 +46,16 @@ class DatabaseManager:
         self._media_type_migrated = False
         self._init_database()
 
+    def close(self) -> None:
+        """关闭数据库连接"""
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except OSError:
+                    pass
+                self._conn = None
+
     def _get_connection(self) -> sqlite3.Connection:
         """获取持久化数据库连接（线程安全），自动重连"""
         if self._conn is not None:

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 主应用文件
 """
 
+import asyncio
 import os
 
 import uvicorn
@@ -22,13 +23,17 @@ from .api.sync import root_router, router as sync_router
 from .api.trakt import router as trakt_router
 from .core.app_version import get_version, get_version_info, get_version_name
 from .core.config import config_manager
+from .core.database import database_manager
 from .core.logging import logger
 from .core.public_url import get_public_base_path
 from .core.startup_info import startup_info
 from .services.feiniu.scheduler import feiniu_scheduler
 from .services.feiniu.sync_service import ensure_feiniu_startup_watermark
 from .services.mapping_service import mapping_service
+from .services.sync_service import sync_service
 from .services.trakt.scheduler import trakt_scheduler
+
+_background_tasks: set[asyncio.Task] = set()
 
 # 创建FastAPI应用（root_path 便于反代子路径下 OpenAPI 等）
 _app_kw: dict = {
@@ -101,25 +106,31 @@ async def startup_event():
 
         logger.info(f"Trakt 调度器将在 {startup_delay} 秒后启动...")
 
-        # 使用异步任务延迟启动调度器
-        import asyncio
-
         async def delayed_scheduler_start():
             await asyncio.sleep(startup_delay)
-            success = await trakt_scheduler.start()
-            if success:
-                logger.info("Trakt 调度器启动成功")
-            else:
-                logger.error("Trakt 调度器启动失败")
-            fn_ok = await feiniu_scheduler.start()
-            if fn_ok:
-                logger.info(
-                    "飞牛定时同步：延迟启动阶段结束（未启用或无有效 db 时不会注册定时任务）"
-                )
-            else:
-                logger.error("飞牛调度器启动失败")
+            # 两个调度器独立启动，互不影响
+            try:
+                success = await trakt_scheduler.start()
+                if success:
+                    logger.info("Trakt 调度器启动成功")
+                else:
+                    logger.error("Trakt 调度器启动失败")
+            except Exception as e:
+                logger.error(f"Trakt 调度器启动异常: {e}")
+            try:
+                fn_ok = await feiniu_scheduler.start()
+                if fn_ok:
+                    logger.info(
+                        "飞牛定时同步：延迟启动阶段结束（未启用或无有效 db 时不会注册定时任务）"
+                    )
+                else:
+                    logger.error("飞牛调度器启动失败")
+            except Exception as e:
+                logger.error(f"飞牛调度器启动异常: {e}")
 
-        asyncio.create_task(delayed_scheduler_start())
+        task = asyncio.create_task(delayed_scheduler_start())
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     except Exception as e:
         logger.error(f"启动 Trakt 调度器失败: {e}")
@@ -133,7 +144,11 @@ async def shutdown_event():
     """应用关闭事件"""
     logger.info("Bangumi-Syncer 正在关闭...")
 
-    # 停止 Trakt 调度器
+    # 取消尚未完成的后台任务
+    for task in _background_tasks:
+        task.cancel()
+
+    # 停止调度器
     try:
         await trakt_scheduler.stop()
         logger.info("Trakt 调度器已停止")
@@ -145,6 +160,20 @@ async def shutdown_event():
         logger.info("飞牛调度器已停止")
     except Exception as e:
         logger.error(f"停止飞牛调度器失败: {e}")
+
+    # 关闭同步服务线程池
+    try:
+        sync_service.shutdown()
+        logger.info("同步服务线程池已关闭")
+    except Exception as e:
+        logger.error(f"关闭同步服务线程池失败: {e}")
+
+    # 关闭数据库连接
+    try:
+        database_manager.close()
+        logger.info("数据库连接已关闭")
+    except Exception as e:
+        logger.error(f"关闭数据库连接失败: {e}")
 
 
 if __name__ == "__main__":

--- a/app/services/feiniu/reader.py
+++ b/app/services/feiniu/reader.py
@@ -61,8 +61,10 @@ def _pick_season_value(row: sqlite3.Row, cols: set[str]) -> int:
 def list_feiniu_users(db_path: str) -> list[FeiniuUser]:
     if not db_path or not Path(db_path).is_file():
         return []
+    conn = None
     try:
         conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
+        conn.execute("PRAGMA busy_timeout=5000")
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
         cur.execute(
@@ -78,11 +80,13 @@ def list_feiniu_users(db_path: str) -> list[FeiniuUser]:
             )
             for r in cur.fetchall()
         ]
-        conn.close()
         return users
     except Exception as e:
         logger.warning(f"读取飞牛用户列表失败: {e}")
         return []
+    finally:
+        if conn is not None:
+            conn.close()
 
 
 def _time_range_cutoff_ms(time_range: str) -> int | None:
@@ -144,8 +148,10 @@ def fetch_completed_watch_records(
     if not db_path or not Path(db_path).is_file():
         return []
 
+    conn = None
     try:
         conn = sqlite3.connect(_sqlite_ro_uri(db_path), uri=True)
+        conn.execute("PRAGMA busy_timeout=5000")
         conn.row_factory = sqlite3.Row
         cur = conn.cursor()
         item_cols = _table_columns(cur, "item")
@@ -290,8 +296,10 @@ def fetch_completed_watch_records(
                 )
             )
 
-        conn.close()
         return rows_out
     except Exception as e:
         logger.error(f"读取飞牛观看记录失败: {e}")
         return []
+    finally:
+        if conn is not None:
+            conn.close()

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import re
+import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
@@ -42,25 +43,46 @@ class SyncService:
             max_workers=max_workers, thread_name_prefix="sync_worker"
         )
         # 同步任务状态跟踪
+        self._tasks_lock = threading.Lock()
         self._sync_tasks = {}
         self._task_counter = 0
 
-    async def sync_custom_item_async(
-        self, item: CustomItem, source: str = "custom"
-    ) -> str:
-        """异步同步自定义项目，返回任务ID"""
-        self._task_counter += 1
-        task_id = f"sync_{self._task_counter}_{int(time.time())}"
+    def shutdown(self):
+        """关闭线程池，等待正在执行的任务完成"""
+        self._executor.shutdown(wait=True)
 
-        # 记录任务状态
+    def _register_task(self, task_id: str, item_data: Any, source: str) -> None:
+        """注册新任务到状态跟踪（需持有锁）"""
         self._sync_tasks[task_id] = {
             "status": "pending",
-            "item": item.dict(),
+            "item": item_data,
             "source": source,
             "created_at": time.time(),
             "result": None,
             "error": None,
         }
+
+    def _update_task_status(
+        self, task_id: str, status: str, result: Any = None, error: str = None
+    ) -> None:
+        """更新任务状态（线程安全）"""
+        with self._tasks_lock:
+            if task_id in self._sync_tasks:
+                self._sync_tasks[task_id]["status"] = status
+                if result is not None:
+                    self._sync_tasks[task_id]["result"] = result
+                if error is not None:
+                    self._sync_tasks[task_id]["error"] = error
+
+    async def sync_custom_item_async(
+        self, item: CustomItem, source: str = "custom"
+    ) -> str:
+        """异步同步自定义项目，返回任务ID"""
+        self.cleanup_old_tasks()
+        with self._tasks_lock:
+            self._task_counter += 1
+            task_id = f"sync_{self._task_counter}_{int(time.time())}"
+            self._register_task(task_id, item.dict(), source)
 
         # 提交到线程池异步执行
         self._executor.submit(self._sync_custom_item_sync, item, source, task_id)
@@ -74,42 +96,38 @@ class SyncService:
     ) -> SyncResponse:
         """同步执行的内部方法"""
         try:
-            # 更新任务状态
-            self._sync_tasks[task_id]["status"] = "running"
-
-            # 执行同步逻辑
+            self._update_task_status(task_id, "running")
             result = self.sync_custom_item(item, source)
-
-            # 更新任务结果
-            self._sync_tasks[task_id]["status"] = "completed"
-            self._sync_tasks[task_id]["result"] = result.dict()
-
+            self._update_task_status(task_id, "completed", result=result.dict())
             return result
-
         except Exception as e:
-            # 更新任务错误
-            self._sync_tasks[task_id]["status"] = "failed"
-            self._sync_tasks[task_id]["error"] = str(e)
+            self._update_task_status(task_id, "failed", error=str(e))
             logger.error(f"异步同步任务 {task_id} 失败: {e}")
             return SyncResponse(status="error", message=f"异步处理失败: {str(e)}")
 
     def get_sync_task_status(self, task_id: str) -> Optional[dict]:
-        """获取同步任务状态"""
-        return self._sync_tasks.get(task_id)
+        """获取任务状态（线程安全）"""
+        with self._tasks_lock:
+            return self._sync_tasks.get(task_id)
+
+    def get_all_sync_tasks(self) -> dict:
+        """获取所有任务快照（线程安全）"""
+        with self._tasks_lock:
+            return dict(self._sync_tasks)
 
     def cleanup_old_tasks(self, max_age_hours: int = 24):
-        """清理旧的任务记录"""
+        """清理旧的任务记录（线程安全）"""
         current_time = time.time()
         cutoff_time = current_time - (max_age_hours * 3600)
 
-        old_tasks = [
-            task_id
-            for task_id, task_info in self._sync_tasks.items()
-            if task_info["created_at"] < cutoff_time
-        ]
-
-        for task_id in old_tasks:
-            del self._sync_tasks[task_id]
+        with self._tasks_lock:
+            old_tasks = [
+                task_id
+                for task_id, task_info in self._sync_tasks.items()
+                if task_info["created_at"] < cutoff_time
+            ]
+            for task_id in old_tasks:
+                del self._sync_tasks[task_id]
 
         if old_tasks:
             logger.info(f"清理了 {len(old_tasks)} 个旧的同步任务记录")
@@ -810,7 +828,7 @@ class SyncService:
         for attempt in range(max_retries + 1):
             try:
                 # 在线程池中执行同步操作
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 mark_status = await loop.run_in_executor(
                     self._executor, bgm_api.mark_episode_watched, subject_id, ep_id
                 )
@@ -892,22 +910,13 @@ class SyncService:
 
     async def sync_plex_item_async(self, plex_data: dict[str, Any]) -> str:
         """异步同步Plex项目，返回任务ID"""
-        self._task_counter += 1
-        task_id = f"plex_{self._task_counter}_{int(time.time())}"
+        self.cleanup_old_tasks()
+        with self._tasks_lock:
+            self._task_counter += 1
+            task_id = f"plex_{self._task_counter}_{int(time.time())}"
+            self._register_task(task_id, plex_data, "plex")
 
-        # 记录任务状态
-        self._sync_tasks[task_id] = {
-            "status": "pending",
-            "item": plex_data,
-            "source": "plex",
-            "created_at": time.time(),
-            "result": None,
-            "error": None,
-        }
-
-        # 提交到线程池异步执行
         self._executor.submit(self._sync_plex_item_sync, plex_data, task_id)
-
         logger.info(f"Plex同步任务 {task_id} 已提交到异步队列")
         return task_id
 
@@ -916,22 +925,12 @@ class SyncService:
     ) -> SyncResponse:
         """同步执行Plex同步的内部方法"""
         try:
-            # 更新任务状态
-            self._sync_tasks[task_id]["status"] = "running"
-
-            # 执行同步逻辑
+            self._update_task_status(task_id, "running")
             result = self.sync_plex_item(plex_data)
-
-            # 更新任务结果
-            self._sync_tasks[task_id]["status"] = "completed"
-            self._sync_tasks[task_id]["result"] = result.dict()
-
+            self._update_task_status(task_id, "completed", result=result.dict())
             return result
-
         except Exception as e:
-            # 更新任务错误
-            self._sync_tasks[task_id]["status"] = "failed"
-            self._sync_tasks[task_id]["error"] = str(e)
+            self._update_task_status(task_id, "failed", error=str(e))
             logger.error(f"异步Plex同步任务 {task_id} 失败: {e}")
             return SyncResponse(status="error", message=f"异步处理失败: {str(e)}")
 
@@ -976,22 +975,13 @@ class SyncService:
 
     async def sync_emby_item_async(self, emby_data: dict[str, Any]) -> str:
         """异步同步Emby项目，返回任务ID"""
-        self._task_counter += 1
-        task_id = f"emby_{self._task_counter}_{int(time.time())}"
+        self.cleanup_old_tasks()
+        with self._tasks_lock:
+            self._task_counter += 1
+            task_id = f"emby_{self._task_counter}_{int(time.time())}"
+            self._register_task(task_id, emby_data, "emby")
 
-        # 记录任务状态
-        self._sync_tasks[task_id] = {
-            "status": "pending",
-            "item": emby_data,
-            "source": "emby",
-            "created_at": time.time(),
-            "result": None,
-            "error": None,
-        }
-
-        # 提交到线程池异步执行
         self._executor.submit(self._sync_emby_item_sync, emby_data, task_id)
-
         logger.info(f"Emby同步任务 {task_id} 已提交到异步队列")
         return task_id
 
@@ -1000,22 +990,12 @@ class SyncService:
     ) -> SyncResponse:
         """同步执行Emby同步的内部方法"""
         try:
-            # 更新任务状态
-            self._sync_tasks[task_id]["status"] = "running"
-
-            # 执行同步逻辑
+            self._update_task_status(task_id, "running")
             result = self.sync_emby_item(emby_data)
-
-            # 更新任务结果
-            self._sync_tasks[task_id]["status"] = "completed"
-            self._sync_tasks[task_id]["result"] = result.dict()
-
+            self._update_task_status(task_id, "completed", result=result.dict())
             return result
-
         except Exception as e:
-            # 更新任务错误
-            self._sync_tasks[task_id]["status"] = "failed"
-            self._sync_tasks[task_id]["error"] = str(e)
+            self._update_task_status(task_id, "failed", error=str(e))
             logger.error(f"异步Emby同步任务 {task_id} 失败: {e}")
             return SyncResponse(status="error", message=f"异步处理失败: {str(e)}")
 
@@ -1105,22 +1085,13 @@ class SyncService:
 
     async def sync_jellyfin_item_async(self, jellyfin_data: dict[str, Any]) -> str:
         """异步同步Jellyfin项目，返回任务ID"""
-        self._task_counter += 1
-        task_id = f"jellyfin_{self._task_counter}_{int(time.time())}"
+        self.cleanup_old_tasks()
+        with self._tasks_lock:
+            self._task_counter += 1
+            task_id = f"jellyfin_{self._task_counter}_{int(time.time())}"
+            self._register_task(task_id, jellyfin_data, "jellyfin")
 
-        # 记录任务状态
-        self._sync_tasks[task_id] = {
-            "status": "pending",
-            "item": jellyfin_data,
-            "source": "jellyfin",
-            "created_at": time.time(),
-            "result": None,
-            "error": None,
-        }
-
-        # 提交到线程池异步执行
         self._executor.submit(self._sync_jellyfin_item_sync, jellyfin_data, task_id)
-
         logger.info(f"Jellyfin同步任务 {task_id} 已提交到异步队列")
         return task_id
 
@@ -1129,22 +1100,12 @@ class SyncService:
     ) -> SyncResponse:
         """同步执行Jellyfin同步的内部方法"""
         try:
-            # 更新任务状态
-            self._sync_tasks[task_id]["status"] = "running"
-
-            # 执行同步逻辑
+            self._update_task_status(task_id, "running")
             result = self.sync_jellyfin_item(jellyfin_data)
-
-            # 更新任务结果
-            self._sync_tasks[task_id]["status"] = "completed"
-            self._sync_tasks[task_id]["result"] = result.dict()
-
+            self._update_task_status(task_id, "completed", result=result.dict())
             return result
-
         except Exception as e:
-            # 更新任务错误
-            self._sync_tasks[task_id]["status"] = "failed"
-            self._sync_tasks[task_id]["error"] = str(e)
+            self._update_task_status(task_id, "failed", error=str(e))
             logger.error(f"异步Jellyfin同步任务 {task_id} 失败: {e}")
             return SyncResponse(status="error", message=f"异步处理失败: {str(e)}")
 

--- a/app/services/trakt/scheduler.py
+++ b/app/services/trakt/scheduler.py
@@ -103,13 +103,10 @@ class TraktScheduler:
     def add_user_job(self, user_id: str, cron_expression: str) -> bool:
         """为用户添加定时任务"""
         try:
-            # 如果调度器未初始化或未运行，尝试启动
+            # 如果调度器未初始化或未运行，直接返回失败
             if not self.scheduler or not self.scheduler.running:
-                logger.warning("调度器未运行，尝试启动...")
-                success = self.start()
-                if not success:
-                    logger.error("调度器启动失败，无法添加定时任务")
-                    return False
+                logger.error("调度器未运行，无法添加定时任务（请先启动调度器）")
+                return False
 
             # 如果用户已有任务，先移除
             if user_id in self._user_jobs:

--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -188,6 +188,7 @@ class BangumiApi:
 
     def _request_with_retry(self, method, session, url, max_retries=3, **kwargs):
         """带重试机制的请求方法（支持代理失败后直连重试）"""
+        kwargs.setdefault("timeout", 15)
         dns_error_occurred = False
 
         # 如果之前代理已经失败过，直接使用直连

--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -30,11 +30,10 @@ def _request_with_retry(
     for attempt in range(max_retries + 1):
         try:
             response = requests.get(
-                url, proxies=proxies, stream=stream, verify=ssl_verify
+                url, proxies=proxies, stream=stream, verify=ssl_verify, timeout=30
             )
-            response.raise_for_status()
 
-            # 检查是否需要重试的状态码
+            # 先检查是否需要重试的状态码，再决定是否抛异常
             if response.status_code in [429, 500, 502, 503, 504]:
                 if attempt < max_retries:
                     delay = 2**attempt  # 指数退避: 2, 4, 8秒
@@ -48,6 +47,7 @@ def _request_with_retry(
                         f"HTTP {response.status_code} 错误，已达到最大重试次数 {max_retries}"
                     )
 
+            response.raise_for_status()
             return response
 
         except (

--- a/templates/config.html
+++ b/templates/config.html
@@ -1246,42 +1246,46 @@ async function loadConfig(showToast = true) {
 }
 
 function populateForm(config) {
+    const sync = config.sync || {};
+    const dev = config.dev || {};
+    const bd = config.bangumi_data || {};
+
     // 填充基本配置
-    document.getElementById('bangumi-username').value = config.bangumi.username || '';
-    document.getElementById('bangumi-access-token').value = config.bangumi.access_token || '';
-    document.getElementById('bangumi-private').checked = config.bangumi.private || false;
+    document.getElementById('bangumi-username').value = (config.bangumi && config.bangumi.username) || '';
+    document.getElementById('bangumi-access-token').value = (config.bangumi && config.bangumi.access_token) || '';
+    document.getElementById('bangumi-private').checked = (config.bangumi && config.bangumi.private) || false;
     const bmsu = document.getElementById('bangumi-media-server-username');
     if (bmsu) {
         bmsu.value = (config.bangumi && config.bangumi.media_server_username) ? String(config.bangumi.media_server_username) : '';
     }
-    
-    document.getElementById('sync-mode').value = config.sync.mode || 'single';
-    document.getElementById('blocked-keywords').value = config.sync.blocked_keywords || '';
+
+    document.getElementById('sync-mode').value = sync.mode || 'single';
+    document.getElementById('blocked-keywords').value = sync.blocked_keywords || '';
     const movieMarkEl = document.getElementById('movie-mark-subject-completed');
     if (movieMarkEl) {
-        movieMarkEl.checked = config.sync.movie_mark_subject_completed !== false;
+        movieMarkEl.checked = sync.movie_mark_subject_completed !== false;
     }
     const moviePlaybackWatchingEl = document.getElementById(
         'movie-playback-start-mark-watching'
     );
     if (moviePlaybackWatchingEl) {
         moviePlaybackWatchingEl.checked =
-            config.sync.movie_playback_start_mark_watching !== false;
+            sync.movie_playback_start_mark_watching !== false;
     }
-    
+
     const webBase = document.getElementById('web-base-path');
     if (webBase) {
         webBase.value = (config.web && config.web.base_path) ? String(config.web.base_path) : '';
     }
-    document.getElementById('script-proxy').value = config.dev.script_proxy || '';
-    document.getElementById('ssl-verify').checked = Boolean(config.dev.ssl_verify);
-    document.getElementById('debug-mode').checked = Boolean(config.dev.debug);
-    
-    document.getElementById('bangumi-data-enabled').checked = config.bangumi_data.enabled !== false;
-    document.getElementById('bangumi-data-cache').checked = config.bangumi_data.use_cache !== false;
-    document.getElementById('cache-ttl').value = config.bangumi_data.cache_ttl_days || 7;
-    document.getElementById('data-url').value = config.bangumi_data.data_url || 'https://unpkg.com/bangumi-data@0.3/dist/data.json';
-    document.getElementById('local-cache-path').value = config.bangumi_data.local_cache_path || './bangumi_data_cache.json';
+    document.getElementById('script-proxy').value = dev.script_proxy || '';
+    document.getElementById('ssl-verify').checked = Boolean(dev.ssl_verify);
+    document.getElementById('debug-mode').checked = Boolean(dev.debug);
+
+    document.getElementById('bangumi-data-enabled').checked = bd.enabled !== false;
+    document.getElementById('bangumi-data-cache').checked = bd.use_cache !== false;
+    document.getElementById('cache-ttl').value = bd.cache_ttl_days || 7;
+    document.getElementById('data-url').value = bd.data_url || 'https://unpkg.com/bangumi-data@0.3/dist/data.json';
+    document.getElementById('local-cache-path').value = bd.local_cache_path || './bangumi_data_cache.json';
 
     const fn = config.feiniu || {};
     const fe = document.getElementById('feiniu-enabled');
@@ -1316,7 +1320,7 @@ function populateForm(config) {
     toggleSyncMode();
     
     // 填充多用户配置
-    if (config.sync.mode === 'multi') {
+    if (sync.mode === 'multi') {
         populateMultiUserConfig(config.multi_accounts, config.user_mappings);
     }
 }

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -375,7 +375,7 @@ async def test_plex_webhook_auth_failure():
                 content=b"{}",
                 headers={"Content-Type": "application/json"},
             )
-            assert response.status_code == 200
+            assert response.status_code == 401
             data = response.json()
             assert data["status"] == "error"
 
@@ -477,7 +477,7 @@ async def test_emby_webhook_auth_failure():
                 content=b"{}",
                 headers={"Content-Type": "application/json"},
             )
-            assert response.status_code == 200
+            assert response.status_code == 401
             data = response.json()
             assert data["status"] == "error"
 
@@ -556,8 +556,8 @@ async def test_emby_webhook_fallback_failure():
             )
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "accepted"
-            assert "错误" in data["message"]
+            assert data["status"] == "error"
+            assert "失败" in data["message"]
 
 
 @pytest.mark.asyncio
@@ -628,7 +628,7 @@ async def test_jellyfin_webhook_auth_failure():
                 content=b"{}",
                 headers={"Content-Type": "application/json"},
             )
-            assert response.status_code == 200
+            assert response.status_code == 401
             data = response.json()
             assert data["status"] == "error"
 
@@ -684,8 +684,8 @@ async def test_jellyfin_webhook_fallback_failure():
             )
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "accepted"
-            assert "错误" in data["message"]
+            assert data["status"] == "error"
+            assert "失败" in data["message"]
 
 
 # ========== 自定义同步特殊路径 ==========

--- a/tests/api/test_sync_main_flow.py
+++ b/tests/api/test_sync_main_flow.py
@@ -112,7 +112,7 @@ async def test_custom_webhook_auth_failed(app_root_and_api):
         transport = ASGITransport(app=app_root_and_api)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             r = await ac.post("/Custom", json=item.model_dump())
-    assert r.status_code == 202
+    assert r.status_code == 401
     assert r.json()["status"] == "error"
 
 
@@ -163,7 +163,9 @@ async def test_plex_webhook_async_and_sync_both_fail_still_accepted(
                 ) as ac:
                     r = await ac.post("/Plex", content=raw)
     assert r.status_code == 200
-    assert "错误" in r.json().get("message", "")
+    body = r.json()
+    assert body.get("status") == "error"
+    assert "失败" in body.get("message", "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化/重构 (perf/refactor)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->

**防止请求挂起**
- `bangumi_api.py`：`_request_with_retry` 添加默认 15 秒超时，防止 Bangumi API 无响应时线程永久阻塞
- `bangumi_data.py`：CDN 数据下载添加 30 秒超时；修复重试逻辑——`raise_for_status()` 原先在状态码检查之前执行，导致 429/5xx 重试分支永远不会触发

**防止资源泄漏**
- `sync_service.py`：新增 `shutdown()` 方法关闭 `ThreadPoolExecutor`，在 `main.py` 的 shutdown 事件中调用
- `main.py`：`asyncio.create_task` 返回值存入 `_background_tasks` 集合防止 GC 回收；关闭时先取消后台任务再停止调度器
- `database.py`：新增 `close()` 方法关闭 SQLite 连接，在 shutdown 时调用
- `feiniu/reader.py`：`list_feiniu_users` 和 `fetch_completed_watch_records` 改用 `try/finally` 确保连接关闭；添加 `PRAGMA busy_timeout=5000`

**修复线程安全**
- `sync_service.py`：为 `_sync_tasks` 字典添加 `threading.Lock`，所有读写操作加锁；`cleanup_old_tasks` 使用快照遍历避免字典变更异常；替换已废弃的 `asyncio.get_event_loop()` 为 `asyncio.get_running_loop()`
- `config.py`：`ConfigManager` 添加 `_lock`，`get_config_parser`、`set_config`、`reload_config` 等方法加锁；`_save_config` 改为原子写入（先写 `.tmp` 再 `os.replace`）
- `config_secret_crypto.py`：`encrypt/decrypt` 等函数新增 `master` 参数，避免从锁内回调 `config_manager.get()` 导致死锁
- `scheduler.py`：`add_user_job` 中移除对 `async def start()` 的未 await 调用，改为直接报错返回

**修复 HTTP 状态码**
- `sync.py`：Webhook 认证失败从 202 改为 401；异步+同步双重失败从 `{"status": "accepted"}` 改为 `{"status": "error"}` + 500 状态码，避免媒体服务器误判成功而不重试

**前端修复**
- `config.html`：`populateForm()` 添加空值防御，配置文件缺少 `sync`/`dev`/`bangumi_data` 等节时不再崩溃


### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
