### PR TITLE
fix: 修复续集链在某些情况下的匹配错误问题

### DIFF
--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import re
 import socket
 import time
 import warnings
@@ -509,6 +510,42 @@ class BangumiApi:
             return None
         return nxt[0]["id"]
 
+    _CN_NUM = {
+        "一": 1,
+        "二": 2,
+        "三": 3,
+        "四": 4,
+        "五": 5,
+        "六": 6,
+        "七": 7,
+        "八": 8,
+        "九": 9,
+        "十": 10,
+    }
+
+    def _extract_season_number(self, name: str, name_cn: str) -> Optional[int]:
+        """从名称中提取季度编号，用于续集链季度去重计数"""
+        text = f"{name} {name_cn}"
+        # "第X期" / "第X季"（阿拉伯数字）
+        m = re.search(r"第\s*(\d+)\s*[期季]", text)
+        if m:
+            return int(m.group(1))
+        # "第X期" / "第X季"（中文数字）
+        m = re.search(r"第\s*([一二三四五六七八九十]+)\s*[期季]", text)
+        if m:
+            cn = m.group(1)
+            if len(cn) == 1:
+                return self._CN_NUM.get(cn)
+            # "十一"~"十九"
+            if cn.startswith("十"):
+                return 10 + self._CN_NUM.get(cn[1], 0)
+            return self._CN_NUM.get(cn)
+        # "Xnd/Xrd/Xth season"
+        m = re.search(r"(\d+)(?:st|nd|rd|th)\s+season", text, re.IGNORECASE)
+        if m:
+            return int(m.group(1))
+        return None
+
     def _match_target_ep_rows(self, ep_info: list, target_ep: int):
         """与 target_season>1 分支一致的章节匹配规则。"""
         rows = [i for i in ep_info if i.get("sort") == target_ep]
@@ -702,18 +739,15 @@ class BangumiApi:
             return None, None if target_ep else None
 
         # Plex 季数与 Bangumi 多期/续集计数不一致时，用播出日 + 章节 airdate 择优
-        if (
-            release_date
-            and not is_season_subject_id
-            and target_season > 1
-            and target_ep
-        ):
+        # is_season_subject_id=True 但直接匹配失败时（如多 part 季度），也应回退到 airdate
+        if release_date and target_season > 1 and target_ep:
             air_pick = self._try_resolve_sequel_by_airdate(
                 subject_id, target_ep, release_date
             )
             if air_pick is not None:
                 return air_pick[0], air_pick[1]
 
+        last_season_num = None
         while True:
             related = self.get_related_subjects(current_id)
             # 处理related可能是列表或字典的情况
@@ -738,26 +772,30 @@ class BangumiApi:
                 # 修复死循环：如果获取不到剧集信息，应该跳出循环而不是继续
                 break
             logger.debug(ep_info)
-            normal_season = (
-                True
-                if episodes.get("total", 0) > 3 and ep_info[0].get("sort", 0) <= 1
-                else False
-            )
             sort_rows = [i for i in ep_info if i.get("sort") == target_ep]
             _target_ep = self._match_target_ep_rows(ep_info, target_ep)
             logger.debug(_target_ep)
-            # 兼容存在多季情况下，第一集的sort不为1的场景
-            if not sort_rows:
-                if (
-                    target_ep
-                    and _target_ep
-                    and "第2部分" not in current_info.get("name_cn", "")
-                ):
-                    season_num += 1
-                logger.debug(_target_ep)
             ep_found = True if target_ep and _target_ep else False
-            if normal_season:
+
+            # 通过季度标识去重计数，避免 split-cour 被重复计数
+            sn = self._extract_season_number(
+                current_info.get("name", ""), current_info.get("name_cn", "")
+            )
+            if sn is not None and sn != last_season_num:
                 season_num += 1
+                last_season_num = sn
+            elif sn is None:
+                # 兼容 sort 不从 1 开始的续集（如无职转生 S1 sort=0，S2 sort 从 12 开始）
+                if not sort_rows:
+                    if (
+                        target_ep
+                        and _target_ep
+                        and "第2部分" not in current_info.get("name_cn", "")
+                    ):
+                        season_num += 1
+                elif any(ep.get("sort") == 1 for ep in ep_info):
+                    season_num += 1
+                    last_season_num = None
             if season_num > target_season:
                 break
             if season_num == target_season:

--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -354,10 +354,16 @@ class BangumiData:
                         except ValueError:
                             continue
                 if best:
-                    return best
-            # 无日期时返回第一个精确匹配
-            first = exact_candidates[0]
-            return (first[1], first[2], False)
+                    if min_diff <= 180:
+                        return best
+                    # 日期差>180天，fall through 到线性扫描检查部分匹配
+                    logger.debug(
+                        f"标题索引命中但日期差 {min_diff} 天 > 180，回退线性扫描检查部分匹配"
+                    )
+            else:
+                # 无日期时返回第一个精确匹配
+                first = exact_candidates[0]
+                return (first[1], first[2], False)
 
         # 精确索引未命中，回退到线性扫描模糊匹配
         logger.debug("开始尝试完全匹配...")

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -167,7 +167,8 @@ class TestGetTargetSeasonEpisodeIdAirdate:
         assert sid == 300
         assert eid == 30001
 
-    def test_skips_airdate_path_when_season_subject_id_true(self):
+    def test_direct_match_succeeds_skips_airdate(self):
+        """is_season_subject_id=True 且直接匹配成功时，不走 airdate 路径"""
         api = BangumiApi()
         api.get_related_subjects = MagicMock()
         api.get_episodes = MagicMock(
@@ -223,4 +224,232 @@ class TestGetMovieMainEpisodeId:
         api.get_episodes = MagicMock(return_value={"data": [], "total": 0})
         sid, eid = api.get_movie_main_episode_id(300)
         assert sid == "300"
-        assert eid is None
+
+
+class TestGetTargetSeasonEpisodeIdSplitCour:
+    """split-cour 续集链季度计数测试"""
+
+    def _tv_ep(self, sort, ep, eid, airdate="2024-01-01"):
+        return {"sort": sort, "ep": ep, "id": eid, "airdate": airdate}
+
+    def test_rezero_split_cour_season4(self):
+        """Re:Zero 6-subject 链：S1→S2→S2后半→S3袭击篇→S3反击篇→S4
+        target_season=4 应返回 S4 (547888)"""
+        api = BangumiApi()
+
+        related = {
+            140001: [{"relation": "续集", "id": 278826}],
+            278826: [{"relation": "续集", "id": 316247}],
+            316247: [{"relation": "续集", "id": 425998}],
+            425998: [{"relation": "续集", "id": 510728}],
+            510728: [{"relation": "续集", "id": 547888}],
+            547888: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        subjects = {
+            278826: {
+                "platform": "TV",
+                "name": "Re:ゼロから始める異世界生活 2nd season",
+                "name_cn": "Re：从零开始的异世界生活 第二季",
+            },
+            316247: {
+                "platform": "TV",
+                "name": "Re:ゼロから始める異世界生活 2nd season 後半クール",
+                "name_cn": "Re：从零开始的异世界生活 第二季 后半部分",
+            },
+            425998: {
+                "platform": "TV",
+                "name": "Re:ゼロから始める異世界生活 3rd season 襲撃編",
+                "name_cn": "Re：从零开始的异世界生活 第三季 袭击篇",
+            },
+            510728: {
+                "platform": "TV",
+                "name": "Re:ゼロから始める異世界生活 3rd season 反撃篇",
+                "name_cn": "Re：从零开始的异世界生活 第三季 反击篇",
+            },
+            547888: {
+                "platform": "TV",
+                "name": "Re:ゼロから始める異世界生活 4th season 喪失編",
+                "name_cn": "Re：从零开始的异世界生活 第四季 丧失篇",
+            },
+        }
+
+        def get_subject(sid):
+            return subjects.get(int(sid))
+
+        episodes = {
+            278826: {"data": [self._tv_ep(26, 1, 957951)], "total": 13},
+            316247: {"data": [self._tv_ep(26, 1, 994750)], "total": 13},
+            425998: {"data": [self._tv_ep(51, 1, 1353850)], "total": 8},
+            510728: {"data": [self._tv_ep(59, 1, 1400001)], "total": 8},
+            547888: {"data": [self._tv_ep(67, 1, 1500001)], "total": 8},
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=140001,
+            target_season=4,
+            target_ep=1,
+            is_season_subject_id=False,
+            release_date=None,
+        )
+        assert sid == 547888
+        assert eid == 1500001
+
+    def test_split_cour_does_not_overcount(self):
+        """split-cour subject 不应被计为独立季度"""
+        api = BangumiApi()
+
+        related = {
+            1: [{"relation": "续集", "id": 100}],
+            100: [{"relation": "续集", "id": 150}],
+            150: [{"relation": "续集", "id": 200}],
+            200: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        subjects = {
+            100: {
+                "platform": "TV",
+                "name": "Anime 2nd Season",
+                "name_cn": "动画 第二季",
+            },
+            150: {
+                "platform": "TV",
+                "name": "Anime 2nd Season Part 2",
+                "name_cn": "动画 第二季 第2部分",
+            },
+            200: {
+                "platform": "TV",
+                "name": "Anime 3rd Season",
+                "name_cn": "动画 第三季",
+            },
+        }
+
+        def get_subject(sid):
+            return subjects.get(int(sid))
+
+        episodes = {
+            100: {"data": [self._tv_ep(1, 1, 1001)], "total": 12},
+            150: {"data": [self._tv_ep(13, 1, 1501)], "total": 12},
+            200: {"data": [self._tv_ep(1, 1, 2001)], "total": 12},
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        # target_season=3 应返回 200（第三季），而非 150（第二季第2部分）
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=1,
+            target_season=3,
+            target_ep=1,
+            is_season_subject_id=False,
+        )
+        assert sid == 200
+        assert eid == 2001
+
+    def test_sort_offset_no_season_indicator(self):
+        """无职转生 S2 场景：S1 sort=0，S2 sort 从 12 开始，无季度标识"""
+        api = BangumiApi()
+
+        related = {
+            1: [{"relation": "续集", "id": 100}],
+            100: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        def get_subject(sid):
+            # S1 和 S2 都没有季度标识
+            return {"platform": "TV", "name": "Mushoku Tensei", "name_cn": "无职转生"}
+
+        episodes = {
+            1: {
+                "data": [
+                    {"sort": 0, "ep": 1, "id": 101, "airdate": "2021-01-01"},
+                    {"sort": 1, "ep": 2, "id": 102, "airdate": "2021-01-08"},
+                ],
+                "total": 12,
+            },
+            100: {
+                "data": [
+                    {"sort": 12, "ep": 1, "id": 201, "airdate": "2021-10-03"},
+                    {"sort": 13, "ep": 2, "id": 202, "airdate": "2021-10-10"},
+                ],
+                "total": 12,
+            },
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=1,
+            target_season=2,
+            target_ep=1,
+            is_season_subject_id=False,
+        )
+        assert sid == 100
+        assert eid == 201
+
+    def test_no_season_indicator_falls_back_to_sort(self):
+        """无季度标识时，通过 sort=1 判断季度首集"""
+        api = BangumiApi()
+
+        related = {
+            1: [{"relation": "续集", "id": 100}],
+            100: [{"relation": "续集", "id": 200}],
+            200: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        subjects = {
+            100: {"platform": "TV", "name": "Anime S2", "name_cn": ""},
+            200: {"platform": "TV", "name": "Anime S3", "name_cn": ""},
+        }
+
+        def get_subject(sid):
+            return subjects.get(int(sid))
+
+        episodes = {
+            100: {"data": [self._tv_ep(1, 1, 1001)], "total": 12},
+            200: {"data": [self._tv_ep(1, 1, 2001)], "total": 12},
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=1,
+            target_season=3,
+            target_ep=1,
+            is_season_subject_id=False,
+        )
+        assert sid == 200
+        assert eid == 2001

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -952,6 +952,700 @@ class TestFindBangumiIdOptimizedTitleIndex:
         assert result is not None
         assert result[0] == "200"
 
+    def test_exact_index_date_diff_gt_180_falls_through(self):
+        """标题索引命中但日期差>180天时，应回退线性扫描检查部分匹配"""
+        data = _make_data()
+        # 标题索引只有第一季（2016年）
+        data._title_index = {
+            "Re：从零开始的异世界生活": [
+                {
+                    "title": "Re:ゼロから始める異世界生活",
+                    "begin": "2016-04-01",
+                    "titleTranslate": {"zh-Hans": ["Re：从零开始的异世界生活"]},
+                    "sites": [{"site": "bangumi", "id": "140001"}],
+                }
+            ]
+        }
+        # 线性扫描数据包含第一季和第四季
+        all_items = [
+            {
+                "title": "Re:ゼロから始める異世界生活",
+                "begin": "2016-04-01",
+                "titleTranslate": {"zh-Hans": ["Re：从零开始的异世界生活"]},
+                "sites": [{"site": "bangumi", "id": "140001"}],
+            },
+            {
+                "title": "Re:ゼロから始める異世界生活 第4期",
+                "begin": "2026-04-01",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "Re：从零开始的异世界生活 第四季",
+                        "Re：从零开始的异世界生活 第四季 丧失篇",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "547888"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "Re：从零开始的异世界生活", release_date="2026-04-28"
+            )
+        assert result is not None
+        assert result[0] == "547888"
+        assert result[2] is True  # date_matched
+
+    def test_exact_index_date_diff_le_180_returns_directly(self):
+        """标题索引命中且日期差≤180天时，直接返回不回退"""
+        data = _make_data()
+        data._title_index = {
+            "标题": [
+                {
+                    "title": "标题",
+                    "begin": "2024-01-01",
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        with patch.object(data, "_parse_data", return_value=[]):
+            result = data._find_bangumi_id_optimized("标题", release_date="2024-06-01")
+        assert result is not None
+        assert result[0] == "100"
+
+    def test_mushoku_tensei_s2_episode_24_returns_correct_id(self):
+        """无职转生 S2E24 (2024-04-07) 搜索标题匹配到S1，日期差>180天，
+        180天回退机制检查部分匹配，S2 Part 2日期差=0天且标题包含搜索词，
+        直接返回S2 Part 2 (ID=444557, date_matched=True)"""
+        data = _make_data()
+        # 标题索引：搜索词"无职转生～到了异世界就拿出真本事～"精确匹配S1
+        data._title_index = {
+            "无职转生～到了异世界就拿出真本事～": [
+                {
+                    "title": "無職転生～異世界行ったら本気だす～",
+                    "begin": "2021-01-10T15:00:00.000Z",
+                    "titleTranslate": {
+                        "zh-Hans": ["无职转生～到了异世界就拿出真本事～"]
+                    },
+                    "sites": [{"site": "bangumi", "id": "277554"}],
+                }
+            ]
+        }
+        all_items = [
+            # S1 - 精确匹配
+            {
+                "title": "無職転生～異世界行ったら本気だす～",
+                "begin": "2021-01-10T15:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["无职转生～到了异世界就拿出真本事～"]},
+                "sites": [{"site": "bangumi", "id": "277554"}],
+            },
+            # S2 Part 1 - 部分匹配（标题包含搜索词）
+            {
+                "title": "無職転生Ⅱ ～異世界行ったら本気だす～",
+                "begin": "2023-07-02T15:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "无职转生Ⅱ ～到了异世界就拿出真本事～",
+                        "无职转生 ～在异世界认真地活下去～ 第二季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "373247"}],
+            },
+            # S2 Part 2 (ID=444557) - 不同标题，不在索引候选中
+            {
+                "title": "無職転生Ⅱ ～異世界行ったら本気だす～(第2クール)",
+                "begin": "2024-04-07T15:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "无职转生Ⅱ ～到了异世界就拿出真本事～ 第2部分",
+                        "无职转生 ～在异世界认真地活下去～ 第二季 第2部分",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "444557"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            # S2E24 首播日期 2024-04-07
+            result = data._find_bangumi_id_optimized(
+                "无职转生～到了异世界就拿出真本事～",
+                release_date="2024-04-07",
+            )
+        # 180天回退：S2 Part 2 日期差=0天，标题包含搜索词，直接返回
+        assert result is not None
+        assert result[0] == "444557"
+        assert result[2] is True  # date_matched=True
+
+    def test_oshi_no_ko_s3_matches_517057(self):
+        """【我推的孩子】 S03E01 (2026-01-14) 应匹配到 S3 (ID=517057)"""
+        data = _make_data()
+        data._title_index = {
+            "【我推的孩子】": [
+                {
+                    "title": "【推しの子】",
+                    "begin": "2023-04-12T14:00:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["【我推的孩子】"]},
+                    "sites": [{"site": "bangumi", "id": "386809"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "【推しの子】",
+                "begin": "2023-04-12T14:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["【我推的孩子】"]},
+                "sites": [{"site": "bangumi", "id": "386809"}],
+            },
+            {
+                "title": "【推しの子】(第2期)",
+                "begin": "2024-07-03T14:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["【我推的孩子】 第二季"]},
+                "sites": [{"site": "bangumi", "id": "443428"}],
+            },
+            {
+                "title": "【推しの子】(第3期)",
+                "begin": "2026-01-14T14:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["【我推的孩子】 第三季"]},
+                "sites": [{"site": "bangumi", "id": "517057"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "【我推的孩子】", release_date="2026-01-14"
+            )
+        assert result is not None
+        assert result[0] == "517057"
+        assert result[2] is True
+
+    def test_kanojo_okarishimasu_s5_matches_533027(self):
+        """租借女友 S05E01 (2026-04-09) 应匹配到 S5 (ID=533027)"""
+        data = _make_data()
+        data._title_index = {
+            "租借女友": [
+                {
+                    "title": "彼女、お借りします",
+                    "begin": "2020-07-10T16:25:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["租借女友"]},
+                    "sites": [{"site": "bangumi", "id": "296076"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "彼女、お借りします",
+                "begin": "2020-07-10T16:25:00.000Z",
+                "titleTranslate": {"zh-Hans": ["租借女友"]},
+                "sites": [{"site": "bangumi", "id": "296076"}],
+            },
+            {
+                "title": "彼女、お借りします(第2期)",
+                "begin": "2022-07-01T16:25:00.000Z",
+                "titleTranslate": {"zh-Hans": ["租借女友 第二季"]},
+                "sites": [{"site": "bangumi", "id": "315745"}],
+            },
+            {
+                "title": "彼女、お借りします(第3期)",
+                "begin": "2023-07-06T16:23:00.000Z",
+                "titleTranslate": {"zh-Hans": ["租借女友 第三季"]},
+                "sites": [{"site": "bangumi", "id": "401783"}],
+            },
+            {
+                "title": "彼女、お借りします(第4期)",
+                "begin": "2025-07-03T17:23:00.000Z",
+                "titleTranslate": {"zh-Hans": ["租借女友 第四季"]},
+                "sites": [{"site": "bangumi", "id": "503450"}],
+            },
+            {
+                "title": "彼女、お借りします(第5期)",
+                "begin": "2026-04-09T16:53:00.000Z",
+                "titleTranslate": {"zh-Hans": ["租借女友 第五季"]},
+                "sites": [{"site": "bangumi", "id": "533027"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "租借女友", release_date="2026-04-09"
+            )
+        assert result is not None
+        assert result[0] == "533027"
+        assert result[2] is True
+
+    def test_youkoso_jitsuryoku_s4_matches_510710(self):
+        """欢迎来到实力至上主义教室 S04E01 (2026-04-01) 应匹配到 S4 (ID=510710)"""
+        data = _make_data()
+        data._title_index = {
+            "欢迎来到实力至上主义教室": [
+                {
+                    "title": "ようこそ実力至上主義の教室へ",
+                    "begin": "2017-07-12T14:30:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["欢迎来到实力至上主义教室"]},
+                    "sites": [{"site": "bangumi", "id": "214272"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "ようこそ実力至上主義の教室へ",
+                "begin": "2017-07-12T14:30:00.000Z",
+                "titleTranslate": {"zh-Hans": ["欢迎来到实力至上主义教室"]},
+                "sites": [{"site": "bangumi", "id": "214272"}],
+            },
+            {
+                "title": "ようこそ実力至上主義の教室へ 2nd Season",
+                "begin": "2022-07-04T12:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "欢迎来到实力至上主义教室 2nd Season",
+                        "欢迎来到实力至上主义教室 第二季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "371546"}],
+            },
+            {
+                "title": "ようこそ実力至上主義の教室へ 3rd Season",
+                "begin": "2024-01-03T13:30:00.000Z",
+                "titleTranslate": {"zh-Hans": ["欢迎来到实力至上主义教室 第三季"]},
+                "sites": [{"site": "bangumi", "id": "373266"}],
+            },
+            {
+                "title": "ようこそ実力至上主義の教室へ 4th Season 2年生編1学期",
+                "begin": "2026-04-01T13:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["欢迎来到实力至上主义教室 第四季"]},
+                "sites": [{"site": "bangumi", "id": "510710"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "欢迎来到实力至上主义教室", release_date="2026-04-01"
+            )
+        assert result is not None
+        assert result[0] == "510710"
+        assert result[2] is True
+
+    def test_maou_gakuen_s2_matches_455981(self):
+        """魔王学院的不适任者 S2E13 (2024-04-12) 应匹配到 S2 Part 2 (ID=455981)"""
+        data = _make_data()
+        data._title_index = {
+            "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～": [
+                {
+                    "title": "魔王学院の不適合者～史上最強の魔王の始祖、転生して子孫たちの学校へ通う～",
+                    "begin": "2020-07-04T14:30:00.000Z",
+                    "titleTranslate": {
+                        "zh-Hans": [
+                            "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～"
+                        ]
+                    },
+                    "sites": [{"site": "bangumi", "id": "292222"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "魔王学院の不適合者～史上最強の魔王の始祖、転生して子孫たちの学校へ通う～",
+                "begin": "2020-07-04T14:30:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～"
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "292222"}],
+            },
+            {
+                "title": "魔王学院の不適合者II～史上最強の魔王の始祖、転生して子孫たちの学校へ通う～",
+                "begin": "2023-01-07T15:30:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～ Ⅱ",
+                        "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～ 第二季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "330054"}],
+            },
+            {
+                "title": "魔王学院の不適合者II～史上最強の魔王の始祖、転生して子孫たちの学校へ通う～(2ndクール)",
+                "begin": "2024-04-12T13:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～ 第二季 第2部分"
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "455981"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "魔王学院的不适任者～史上最强的魔王始祖，转生就读子孙们的学校～",
+                release_date="2024-04-12",
+            )
+        assert result is not None
+        assert result[0] == "455981"
+        assert result[2] is True
+
+    def test_aharen_san_s2_matches_506922(self):
+        """测不准的阿波连同学 S2E9 (2025-04-07) 应匹配到 S2 (ID=506922)"""
+        data = _make_data()
+        data._title_index = {
+            "测不准的阿波连同学": [
+                {
+                    "title": "阿波連さんははかれない",
+                    "begin": "2022-04-01T17:25:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["测不准的阿波连同学"]},
+                    "sites": [{"site": "bangumi", "id": "343656"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "阿波連さんははかれない",
+                "begin": "2022-04-01T17:25:00.000Z",
+                "titleTranslate": {"zh-Hans": ["测不准的阿波连同学"]},
+                "sites": [{"site": "bangumi", "id": "343656"}],
+            },
+            {
+                "title": "阿波連さんははかれない season2",
+                "begin": "2025-04-07T13:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "测不准的阿波连同学 第二季",
+                        "不会拿捏距离的阿波连同学 第二季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "506922"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "测不准的阿波连同学", release_date="2025-04-07"
+            )
+        assert result is not None
+        assert result[0] == "506922"
+        assert result[2] is True
+
+    def test_akane_banashi_chinese_title_matches_576121(self):
+        """落语朱音 S1E1 (中文标题) 应匹配到 576121"""
+        data = _make_data()
+        data._title_index = {
+            "落语朱音": [
+                {
+                    "title": "あかね噺",
+                    "begin": "2026-04-04T14:30:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["落语朱音", "朱音落语"]},
+                    "sites": [{"site": "bangumi", "id": "576121"}],
+                }
+            ]
+        }
+        with patch.object(data, "_parse_data", return_value=[]):
+            result = data._find_bangumi_id_optimized(
+                "落语朱音", release_date="2026-04-04"
+            )
+        assert result is not None
+        assert result[0] == "576121"
+        assert result[2] is True
+
+    def test_akane_banashi_japanese_title_matches_576121(self):
+        """あかね噺 S1E1 (日文原标题) 应匹配到 576121"""
+        data = _make_data()
+        data._title_index = {
+            "あかね噺": [
+                {
+                    "title": "あかね噺",
+                    "begin": "2026-04-04T14:30:00.000Z",
+                    "titleTranslate": {"zh-Hans": ["落语朱音", "朱音落语"]},
+                    "sites": [{"site": "bangumi", "id": "576121"}],
+                }
+            ]
+        }
+        with patch.object(data, "_parse_data", return_value=[]):
+            result = data._find_bangumi_id_optimized(
+                "あかね噺", release_date="2026-04-04"
+            )
+        assert result is not None
+        assert result[0] == "576121"
+        assert result[2] is True
+
+    # ── 边界测试 ──────────────────────────────────────────
+
+    def test_index_date_diff_exactly_180_returns_directly(self):
+        """标题索引日期差恰好=180天时，应直接返回（<=180边界）"""
+        data = _make_data()
+        data._title_index = {
+            "标题": [
+                {
+                    "title": "标题",
+                    "begin": "2024-01-01",
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        # 2024-01-01 + 180天 = 2024-06-29
+        with patch.object(data, "_parse_data", return_value=[]):
+            result = data._find_bangumi_id_optimized("标题", release_date="2024-06-29")
+        assert result is not None
+        assert result[0] == "100"
+        assert result[2] is True
+
+    def test_index_date_diff_exactly_181_falls_through(self):
+        """标题索引日期差恰好=181天时，应回退线性扫描（>180边界）"""
+        data = _make_data()
+        data._title_index = {
+            "标题": [
+                {
+                    "title": "标题",
+                    "begin": "2024-01-01",
+                    "titleTranslate": {"zh-Hans": ["标题"]},
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        exact_item = {
+            "title": "标题",
+            "begin": "2024-01-01",
+            "titleTranslate": {"zh-Hans": ["标题"]},
+            "sites": [{"site": "bangumi", "id": "100"}],
+        }
+        # 2024-01-01 + 181天 = 2024-06-30
+        with (
+            patch.object(data, "_parse_data", return_value=[exact_item]),
+            patch.object(
+                data,
+                "_calculate_match_info",
+                return_value={
+                    "exact_match": True,
+                    "match_type": "zh-hans",
+                    "score": 1.0,
+                    "best_zh_score": 1.0,
+                    "best_zh_title": "标题",
+                },
+            ),
+        ):
+            result = data._find_bangumi_id_optimized("标题", release_date="2024-06-30")
+        # 回退到线性扫描后，精确匹配日期差181天>180，无部分匹配，返回精确匹配
+        assert result is not None
+        assert result[0] == "100"
+
+    def test_partial_match_date_diff_exactly_90_accepts(self):
+        """部分匹配日期差恰好=90天时，应采纳（<=90边界）"""
+        data = _make_data()
+        data._title_index = {
+            "测试番剧": [
+                {
+                    "title": "テスト",
+                    "begin": "2020-01-01",
+                    "titleTranslate": {"zh-Hans": ["测试番剧"]},
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        exact_item = {
+            "title": "テスト",
+            "begin": "2020-01-01",
+            "titleTranslate": {"zh-Hans": ["测试番剧"]},
+            "sites": [{"site": "bangumi", "id": "100"}],
+        }
+        partial_item = {
+            "title": "テスト2",
+            "begin": "2022-04-11",  # 与搜索日期差90天
+            "titleTranslate": {"zh-Hans": ["测试番剧 第二季"]},
+            "sites": [{"site": "bangumi", "id": "200"}],
+        }
+
+        def fake_match_info(item, title, ori_title=None, release_date=None):
+            zh = item.get("titleTranslate", {}).get("zh-Hans", [""])[0]
+            if zh == "测试番剧":
+                return {
+                    "exact_match": True,
+                    "match_type": "zh-hans",
+                    "score": 1.0,
+                    "best_zh_score": 1.0,
+                    "best_zh_title": zh,
+                }
+            return {
+                "exact_match": False,
+                "match_type": None,
+                "score": 0.7,
+                "best_zh_score": 0.7,
+                "best_zh_title": zh,
+            }
+
+        # 搜索日期 2022-07-10, 精确匹配diff=920天>180, 部分匹配diff=90天
+        with (
+            patch.object(data, "_parse_data", return_value=[exact_item, partial_item]),
+            patch.object(data, "_calculate_match_info", side_effect=fake_match_info),
+        ):
+            result = data._find_bangumi_id_optimized(
+                "测试番剧", release_date="2022-07-10"
+            )
+        assert result is not None
+        assert result[0] == "200"
+        assert result[2] is True
+
+    def test_partial_match_date_diff_exactly_91_rejects(self):
+        """部分匹配日期差恰好=91天时，应拒绝回退精确匹配（>90边界）"""
+        data = _make_data()
+        data._title_index = {
+            "测试番剧": [
+                {
+                    "title": "テスト",
+                    "begin": "2020-01-01",
+                    "titleTranslate": {"zh-Hans": ["测试番剧"]},
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        exact_item = {
+            "title": "テスト",
+            "begin": "2020-01-01",
+            "titleTranslate": {"zh-Hans": ["测试番剧"]},
+            "sites": [{"site": "bangumi", "id": "100"}],
+        }
+        partial_item = {
+            "title": "テスト2",
+            "begin": "2022-04-11",  # 与搜索日期差91天
+            "titleTranslate": {"zh-Hans": ["测试番剧 第二季"]},
+            "sites": [{"site": "bangumi", "id": "200"}],
+        }
+
+        def fake_match_info(item, title, ori_title=None, release_date=None):
+            zh = item.get("titleTranslate", {}).get("zh-Hans", [""])[0]
+            if zh == "测试番剧":
+                return {
+                    "exact_match": True,
+                    "match_type": "zh-hans",
+                    "score": 1.0,
+                    "best_zh_score": 1.0,
+                    "best_zh_title": zh,
+                }
+            return {
+                "exact_match": False,
+                "match_type": None,
+                "score": 0.7,
+                "best_zh_score": 0.7,
+                "best_zh_title": zh,
+            }
+
+        with (
+            patch.object(data, "_parse_data", return_value=[exact_item, partial_item]),
+            patch.object(data, "_calculate_match_info", side_effect=fake_match_info),
+        ):
+            result = data._find_bangumi_id_optimized(
+                "测试番剧", release_date="2022-07-11"
+            )
+        # 91天>90，拒绝部分匹配，回退到精确匹配
+        assert result is not None
+        assert result[0] == "100"
+
+    def test_safety_check_rejects_when_title_not_contained_and_low_score(self):
+        """安全校验：标题不包含且分数<0.8时，应拒绝部分匹配"""
+        data = _make_data()
+        data._title_index = {
+            "测试番剧": [
+                {
+                    "title": "テスト",
+                    "begin": "2020-01-01",
+                    "titleTranslate": {"zh-Hans": ["测试番剧"]},
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        exact_item = {
+            "title": "テスト",
+            "begin": "2020-01-01",
+            "titleTranslate": {"zh-Hans": ["测试番剧"]},
+            "sites": [{"site": "bangumi", "id": "100"}],
+        }
+        # 标题完全不同，不包含搜索词，且分数低
+        partial_item = {
+            "title": "别的动画",
+            "begin": "2022-04-11",
+            "titleTranslate": {"zh-Hans": ["完全不同的作品名"]},
+            "sites": [{"site": "bangumi", "id": "300"}],
+        }
+
+        def fake_match_info(item, title, ori_title=None, release_date=None):
+            zh = item.get("titleTranslate", {}).get("zh-Hans", [""])[0]
+            if zh == "测试番剧":
+                return {
+                    "exact_match": True,
+                    "match_type": "zh-hans",
+                    "score": 1.0,
+                    "best_zh_score": 1.0,
+                    "best_zh_title": zh,
+                }
+            # 低分部分匹配
+            return {
+                "exact_match": False,
+                "match_type": None,
+                "score": 0.5,
+                "best_zh_score": 0.5,
+                "best_zh_title": zh,
+            }
+
+        with (
+            patch.object(data, "_parse_data", return_value=[exact_item, partial_item]),
+            patch.object(data, "_calculate_match_info", side_effect=fake_match_info),
+        ):
+            result = data._find_bangumi_id_optimized(
+                "测试番剧", release_date="2022-07-10"
+            )
+        # 安全校验失败：标题不包含且分数0.5<0.8，回退精确匹配
+        assert result is not None
+        assert result[0] == "100"
+
+    def test_safety_check_passes_when_high_score_despite_no_containment(self):
+        """安全校验：标题不包含但分数>=0.8时，应采纳部分匹配"""
+        data = _make_data()
+        data._title_index = {
+            "测试番剧": [
+                {
+                    "title": "テスト",
+                    "begin": "2020-01-01",
+                    "titleTranslate": {"zh-Hans": ["测试番剧"]},
+                    "sites": [{"site": "bangumi", "id": "100"}],
+                }
+            ]
+        }
+        exact_item = {
+            "title": "テスト",
+            "begin": "2020-01-01",
+            "titleTranslate": {"zh-Hans": ["测试番剧"]},
+            "sites": [{"site": "bangumi", "id": "100"}],
+        }
+        # 标题不包含搜索词，但分数高
+        partial_item = {
+            "title": "テスト2",
+            "begin": "2022-04-11",
+            "titleTranslate": {"zh-Hans": ["测试番外剧集"]},
+            "sites": [{"site": "bangumi", "id": "300"}],
+        }
+
+        def fake_match_info(item, title, ori_title=None, release_date=None):
+            zh = item.get("titleTranslate", {}).get("zh-Hans", [""])[0]
+            if zh == "测试番剧":
+                return {
+                    "exact_match": True,
+                    "match_type": "zh-hans",
+                    "score": 1.0,
+                    "best_zh_score": 1.0,
+                    "best_zh_title": zh,
+                }
+            # 高分部分匹配但标题不包含
+            return {
+                "exact_match": False,
+                "match_type": None,
+                "score": 0.85,
+                "best_zh_score": 0.85,
+                "best_zh_title": zh,
+            }
+
+        with (
+            patch.object(data, "_parse_data", return_value=[exact_item, partial_item]),
+            patch.object(data, "_calculate_match_info", side_effect=fake_match_info),
+        ):
+            result = data._find_bangumi_id_optimized(
+                "测试番剧", release_date="2022-07-10"
+            )
+        # 安全校验通过：分数0.85>=0.8，采纳部分匹配
+        assert result is not None
+        assert result[0] == "300"
+        assert result[2] is True
+
 
 class TestRequestWithRetry:
     """测试带重试的请求"""


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
1. **`app/utils/bangumi_data.py`** — 标题索引命中后增加 180 天日期检查，避免多季度番剧匹配到错误季度

2. **`app/utils/bangumi_api.py`** — 三处修复：
   - `_extract_season_number` 支持中文数字（"第二季"→2）
   - 续集链季度计数用标识去重替代无条件 +1，修复 split-cour 过度计数
   - `is_season_subject_id=True` 直接匹配失败后允许回退 airdate 路径，修复无职转生等多 part 季度

3. **`tests/`** — 23 个新测试（8 个实际番剧 + 6 个边界 + 5 个续集链 + 4 个基础）

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
无

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
