### PR TITLE
fix: trakt全量同步不再检查“已同步列表”

### DIFF
--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -241,7 +241,11 @@ class TraktSyncService:
             for item in syncable_items:
                 try:
                     # O(1) 查找：使用预加载的集合代替每条查库
-                    if (item.trakt_item_id, item.watched_timestamp) in synced_set:
+                    if (
+                        # 全量同步忽略历史记录
+                        not full_sync
+                        and (item.trakt_item_id, item.watched_timestamp) in synced_set
+                    ):
                         skipped_count += 1
                         continue
 


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)


### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
全量同步时，忽略 trakt 同步的历史记录。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
#149 
1. **主要考虑到上报失败场景使用全量同步兜底，避免用户手动删表。**
2. 增量同步的场景还是会使用 trakt_sync_history 来避免重复上报。


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
