### PR TITLE
feature: 新增对超长篇动画的兼容

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -444,6 +444,20 @@ class ConfigManager:
 
         return out
 
+    def get_episode_sync_limits(self) -> tuple[int, int]:
+        """季/集同步上限，用于超长连载番（默认 season≤100、episode≤9999）。"""
+        max_season = self.get("sync", "max_sync_season", fallback=100)
+        max_episode = self.get("sync", "max_sync_episode", fallback=9999)
+        try:
+            max_season = int(max_season)
+        except (TypeError, ValueError):
+            max_season = 100
+        try:
+            max_episode = int(max_episode)
+        except (TypeError, ValueError):
+            max_episode = 9999
+        return max_season, max_episode
+
     def get_all_config(self) -> dict[str, dict[str, Any]]:
         """获取所有配置"""
         config = self.get_config_parser()

--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -14,6 +14,9 @@ from ..core.logging import logger
 
 # 使用全局logger实例
 
+_EPISODES_PAGE_LIMIT = 200
+_LONG_SERIES_AIRDATE_MIN_TOTAL = 100
+
 
 class BangumiApi:
     def __init__(
@@ -469,40 +472,159 @@ class BangumiApi:
         self._put_cache("get_related_subjects", subject_id, res)
         return res
 
-    def get_episodes(self, subject_id, _type=0):
-        # 使用实例缓存避免内存泄漏
-        cache_key = (subject_id, _type)
-        if cache_key in self._cache["get_episodes"]:
-            return self._cache["get_episodes"][cache_key]
+    @staticmethod
+    def _get_episode_sync_limits() -> tuple[int, int]:
+        try:
+            from ..core.config import config_manager
 
+            return config_manager.get_episode_sync_limits()
+        except Exception:
+            return 100, 9999
+
+    def _fetch_episodes_page(
+        self,
+        subject_id,
+        _type: int = 0,
+        *,
+        limit: int = _EPISODES_PAGE_LIMIT,
+        offset: int = 0,
+    ) -> dict:
+        """单次分页请求章节列表（不写入实例缓存）。"""
         res = self.get(
             "episodes",
             params={
                 "subject_id": subject_id,
                 "type": _type,
+                "limit": limit,
+                "offset": offset,
             },
         )
         try:
-            res = res.json()
-            # 确保返回的是字典类型
-            if not isinstance(res, dict):
+            payload = res.json()
+            if not isinstance(payload, dict):
                 logger.error(
-                    f"get_episodes API返回非字典类型: {type(res)}, 内容: {res}"
+                    f"get_episodes API返回非字典类型: {type(payload)}, 内容: {payload}"
                 )
-                res = {"data": [], "total": 0}
+                return {"data": [], "total": 0}
+            return payload
         except Exception as e:
             logger.error(f"get_episodes JSON解析失败: {e}")
-            res = {"data": [], "total": 0}
+            return {"data": [], "total": 0}
 
-        self._put_cache("get_episodes", cache_key, res)
-        return res
+    def get_episodes(self, subject_id, _type=0, fetch_all: bool = False):
+        # 使用实例缓存避免内存泄漏
+        cache_key = (subject_id, _type, fetch_all)
+        if cache_key in self._cache["get_episodes"]:
+            return self._cache["get_episodes"][cache_key]
+
+        if not fetch_all:
+            result = self._fetch_episodes_page(subject_id, _type)
+        else:
+            all_data: list = []
+            offset = 0
+            total = 0
+            while True:
+                page = self._fetch_episodes_page(
+                    subject_id, _type, limit=_EPISODES_PAGE_LIMIT, offset=offset
+                )
+                batch = page.get("data") or []
+                all_data.extend(batch)
+                total = int(page.get("total") or len(all_data))
+                if len(batch) < _EPISODES_PAGE_LIMIT or len(all_data) >= total:
+                    break
+                offset += _EPISODES_PAGE_LIMIT
+            result = {"data": all_data, "total": total}
+
+        self._put_cache("get_episodes", cache_key, result)
+        return result
+
+    def _find_episode_by_sort(
+        self, subject_id, target_sort: int, _type: int = 0
+    ) -> Optional[dict]:
+        """在 subject 内按 sort/ep 规则查找章节；ep>99 时优先 offset 快速路径。"""
+        if target_sort > 99:
+            page = self._fetch_episodes_page(
+                subject_id, _type, limit=1, offset=target_sort - 1
+            )
+            data = page.get("data") or []
+            if data and data[0].get("sort") == target_sort:
+                logger.debug(
+                    f"offset 快速路径命中 sort={target_sort} subject_id={subject_id}"
+                )
+                return data[0]
+
+        episodes = self.get_episodes(subject_id, _type, fetch_all=target_sort > 99)
+        ep_info = episodes.get("data") or []
+        rows = self._match_target_ep_rows(ep_info, target_sort)
+        return rows[0] if rows else None
+
+    def _resolve_episode_by_airdate_in_subject(
+        self,
+        subject_id: Union[str, int],
+        release_date: str,
+        max_days_diff: int = 120,
+        min_total: int = _LONG_SERIES_AIRDATE_MIN_TOTAL,
+    ) -> Optional[tuple[Union[str, int], Union[str, int]]]:
+        """
+        在同一 Bangumi subject 内按 airdate 与 release_date 择优（TVDB 多季 + Bangumi 单条目）。
+        仅在条目章节总数达到 min_total 时启用，避免误用于普通季番。
+        """
+        target_day = self._parse_iso_date_ymd(release_date)
+        if not target_day:
+            return None
+
+        episodes = self.get_episodes(subject_id, fetch_all=True)
+        total = int(episodes.get("total") or 0)
+        if total < min_total:
+            return None
+
+        ep_info = episodes.get("data") or []
+        candidates: list[tuple[dict, int]] = []
+        for ep in ep_info:
+            if ep.get("type", 0) != 0 and "type" in ep:
+                continue
+            air_raw = (ep.get("airdate") or "").strip()
+            ep_day = self._parse_iso_date_ymd(air_raw)
+            if not ep_day:
+                continue
+            diff_days = abs((ep_day - target_day).days)
+            if diff_days <= max_days_diff:
+                candidates.append((ep, diff_days))
+
+        if not candidates:
+            return None
+
+        best_ep, best_diff = min(candidates, key=lambda x: x[1])
+        logger.debug(
+            f"单条目 airdate 择优: subject_id={subject_id} ep_id={best_ep['id']} "
+            f"与播出日相差 {best_diff} 天"
+        )
+        return subject_id, best_ep["id"]
+
+    def _episode_lookup_failed(
+        self,
+        subject_id,
+        target_ep: int,
+        release_date: Optional[str],
+    ):
+        """季集匹配失败后的统一回退：单条目 airdate 择优。"""
+        if release_date and target_ep:
+            air_pick = self._resolve_episode_by_airdate_in_subject(
+                subject_id, release_date
+            )
+            if air_pick is not None:
+                return air_pick
+        return None, None if target_ep else None
 
     @staticmethod
     def _parse_iso_date_ymd(value: Optional[str]) -> Optional[datetime.date]:
-        if not value or len(value) < 10:
+        if not value:
+            return None
+        m = re.match(r"(\d{4})-(\d{1,2})-(\d{1,2})", value.strip())
+        if not m:
             return None
         try:
-            return datetime.datetime.strptime(value[:10], "%Y-%m-%d").date()
+            return datetime.date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
         except ValueError:
             return None
 
@@ -666,8 +788,9 @@ class BangumiApi:
     ):
         season_num = 1
         current_id = subject_id
+        max_season, max_episode = self._get_episode_sync_limits()
 
-        if target_season > 10 or (target_ep and target_ep > 99):
+        if target_season > max_season or (target_ep and target_ep > max_episode):
             return None, None if target_ep else None
 
         # 如果已经是目标季数的ID，直接尝试匹配集数
@@ -678,33 +801,14 @@ class BangumiApi:
             if not target_ep:
                 return current_id
 
-            episodes = self.get_episodes(current_id)
-            ep_info = episodes.get("data", [])
-            logger.debug(ep_info)
+            found = self._find_episode_by_sort(current_id, target_ep)
+            if found:
+                return current_id, found["id"]
 
-            if not ep_info:
-                logger.debug(f"未获取到剧集信息: {subject_id}")
-                return None, None if target_ep else None
-
-            # 先尝试完全匹配sort字段
-            _target_ep = [i for i in ep_info if i.get("sort") == target_ep]
-
-            # 如果完全匹配失败，尝试匹配ep字段
-            if not _target_ep:
-                _target_ep = [
-                    i
-                    for i in ep_info
-                    if i.get("ep") == target_ep and i.get("ep", 0) <= i.get("sort", 0)
-                ]
-
-            if _target_ep:
-                return current_id, _target_ep[0]["id"]
-            else:
-                logger.debug(
-                    f"在指定季度ID中未找到匹配的集数: {subject_id}, 目标集数: {target_ep}"
-                )
-                # 失败后回退到传统方法
-                logger.debug("回退到传统方式查找集数")
+            logger.debug(
+                f"在指定季度ID中未找到匹配的集数: {subject_id}, 目标集数: {target_ep}"
+            )
+            logger.debug("回退到传统方式查找集数")
 
         if target_season == 1:
             if not target_ep:
@@ -715,15 +819,14 @@ class BangumiApi:
                     current_info = self.get_subject(current_id)
                     if not current_info or current_info.get("platform") != "TV":
                         continue
+                found = self._find_episode_by_sort(current_id, target_ep)
+                if found:
+                    return current_id, found["id"]
                 episodes = self.get_episodes(current_id)
                 ep_info = episodes.get("data", [])
                 if not ep_info:
                     logger.debug(f"未获取到剧集信息: {current_id}")
-                    # 修复死循环：如果获取不到剧集信息，应该跳出循环而不是继续
                     break
-                _target_ep = [i for i in ep_info if i.get("sort") == target_ep]
-                if _target_ep:
-                    return current_id, _target_ep[0]["id"]
                 normal_season = (
                     True
                     if episodes.get("total", 0) > 3 and ep_info[0].get("sort", 0) <= 1
@@ -732,11 +835,9 @@ class BangumiApi:
                 if not fist_part and normal_season:
                     break
                 related = self.get_related_subjects(current_id)
-                # 处理related可能是列表或字典的情况
                 if isinstance(related, list):
                     next_id = [i for i in related if i.get("relation") == "续集"]
                 elif isinstance(related, dict):
-                    # 如果是字典，可能包含data字段
                     related_list = related.get("data", [])
                     next_id = [i for i in related_list if i.get("relation") == "续集"]
                 else:
@@ -745,10 +846,9 @@ class BangumiApi:
                     break
                 current_id = next_id[0]["id"]
                 fist_part = False
-            return None, None if target_ep else None
+            return self._episode_lookup_failed(subject_id, target_ep, release_date)
 
         # Plex 季数与 Bangumi 多期/续集计数不一致时，用播出日 + 章节 airdate 择优
-        # is_season_subject_id=True 但直接匹配失败时（如多 part 季度），也应回退到 airdate
         if release_date and target_season > 1 and target_ep:
             air_pick = self._try_resolve_sequel_by_airdate(
                 subject_id, target_ep, release_date
@@ -759,11 +859,9 @@ class BangumiApi:
         last_season_num = None
         while True:
             related = self.get_related_subjects(current_id)
-            # 处理related可能是列表或字典的情况
             if isinstance(related, list):
                 next_id = [i for i in related if i.get("relation") == "续集"]
             elif isinstance(related, dict):
-                # 如果是字典，可能包含data字段
                 related_list = related.get("data", [])
                 next_id = [i for i in related_list if i.get("relation") == "续集"]
             else:
@@ -778,7 +876,6 @@ class BangumiApi:
             ep_info = episodes.get("data", [])
             if not ep_info:
                 logger.debug(f"未获取到剧集信息: {current_id}")
-                # 修复死循环：如果获取不到剧集信息，应该跳出循环而不是继续
                 break
             logger.debug(ep_info)
             sort_rows = [i for i in ep_info if i.get("sort") == target_ep]
@@ -786,7 +883,6 @@ class BangumiApi:
             logger.debug(_target_ep)
             ep_found = True if target_ep and _target_ep else False
 
-            # 通过季度标识去重计数，避免 split-cour 被重复计数
             sn = self._extract_season_number(
                 current_info.get("name", ""), current_info.get("name_cn", "")
             )
@@ -794,7 +890,6 @@ class BangumiApi:
                 season_num += 1
                 last_season_num = sn
             elif sn is None:
-                # 兼容 sort 不从 1 开始的续集（如无职转生 S1 sort=0，S2 sort 从 12 开始）
                 if not sort_rows:
                     if (
                         target_ep
@@ -810,10 +905,14 @@ class BangumiApi:
             if season_num == target_season:
                 if not target_ep:
                     return current_id
+                if target_ep > 99:
+                    found = self._find_episode_by_sort(current_id, target_ep)
+                    if found:
+                        return current_id, found["id"]
                 if not ep_found:
                     continue
                 return current_id, _target_ep[0]["id"]
-        return None, None if target_ep else None
+        return self._episode_lookup_failed(subject_id, target_ep, release_date)
 
     def get_subject_collection(self, subject_id):
         res = self.get(f"users/{self.username}/collections/{subject_id}")

--- a/tests/utils/test_bangumi_api.py
+++ b/tests/utils/test_bangumi_api.py
@@ -663,8 +663,29 @@ class TestGetEpisodes:
 
     def test_cache_hit(self):
         api = BangumiApi()
-        api._cache["get_episodes"][("123", 0)] = {"data": []}
+        api._cache["get_episodes"][("123", 0, False)] = {"data": []}
         assert api.get_episodes("123") == {"data": []}
+
+    def test_fetch_all_pagination(self):
+        api = BangumiApi()
+        page1 = {
+            "data": [{"id": i, "sort": i} for i in range(1, 201)],
+            "total": 250,
+        }
+        page2 = {
+            "data": [{"id": i, "sort": i} for i in range(201, 251)],
+            "total": 250,
+        }
+
+        with patch.object(
+            api, "_fetch_episodes_page", side_effect=[page1, page2]
+        ) as mock_fetch:
+            result = api.get_episodes("899", fetch_all=True)
+
+        assert mock_fetch.call_count == 2
+        assert result["total"] == 250
+        assert len(result["data"]) == 250
+        assert result["data"][-1]["sort"] == 250
 
     def test_non_dict_response(self):
         api = BangumiApi()
@@ -967,15 +988,28 @@ class TestGetMovieMainEpisodeId:
 class TestGetTargetSeasonEpisodeId:
     """测试 get_target_season_episode_id"""
 
-    def test_season_gt_5_returns_none(self):
+    def test_season_gt_limit_returns_none(self):
         api = BangumiApi()
-        result = api.get_target_season_episode_id("123", 6, 1)
+        with patch.object(api, "_get_episode_sync_limits", return_value=(100, 9999)):
+            result = api.get_target_season_episode_id("123", 101, 1)
         assert result == (None, None)
 
-    def test_ep_gt_99_returns_none(self):
+    def test_ep_gt_limit_returns_none(self):
         api = BangumiApi()
-        result = api.get_target_season_episode_id("123", 1, 100)
+        with patch.object(api, "_get_episode_sync_limits", return_value=(100, 9999)):
+            result = api.get_target_season_episode_id("123", 1, 10000)
         assert result == (None, None)
+
+    def test_ep_100_season1_uses_long_series_path(self):
+        api = BangumiApi()
+        with patch.object(
+            api,
+            "_find_episode_by_sort",
+            return_value={"id": "ep100", "sort": 100},
+        ) as mock_find:
+            result = api.get_target_season_episode_id("899", 1, 100)
+        mock_find.assert_called_once_with("899", 100)
+        assert result == ("899", "ep100")
 
     def test_is_season_subject_id_no_target_ep(self):
         api = BangumiApi()
@@ -1199,6 +1233,16 @@ class TestParseIsoDateYmd:
     def test_invalid_format(self):
         assert BangumiApi._parse_iso_date_ymd("2024-13-01") is None
 
+    def test_bangumi_unpadded_month_day(self):
+        d = BangumiApi._parse_iso_date_ymd("1996-01-8")
+        assert d.year == 1996 and d.month == 1 and d.day == 8
+        d2 = BangumiApi._parse_iso_date_ymd("2008-3-17")
+        assert d2.year == 2008 and d2.month == 3 and d2.day == 17
+
+    def test_iso_datetime_prefix(self):
+        d = BangumiApi._parse_iso_date_ymd("2024-06-15T12:00:00")
+        assert d.year == 2024 and d.month == 6 and d.day == 15
+
 
 class TestTryResolveSequelByAirdate:
     """测试 _try_resolve_sequel_by_airdate"""
@@ -1262,3 +1306,72 @@ class TestTryResolveSequelByAirdate:
         ):
             result = api._try_resolve_sequel_by_airdate("123", 1, "2024-01-15")
             assert result is None
+
+
+class TestLongSeriesEpisodeSync:
+    """超长连载番剧章节匹配"""
+
+    def test_find_episode_by_sort_offset_fast_path(self):
+        api = BangumiApi()
+        page = {"data": [{"id": 20606, "sort": 500, "ep": 500}], "total": 1328}
+        with patch.object(api, "_fetch_episodes_page", return_value=page):
+            found = api._find_episode_by_sort("899", 500)
+        assert found is not None
+        assert found["id"] == 20606
+
+    def test_find_episode_by_sort_offset_mismatch_falls_back(self):
+        api = BangumiApi()
+        bad_page = {"data": [{"id": 1, "sort": 12, "ep": 12}], "total": 1328}
+        full_eps = {
+            "data": [{"id": 999, "sort": 500, "ep": 500}],
+            "total": 1328,
+        }
+        with (
+            patch.object(api, "_fetch_episodes_page", return_value=bad_page),
+            patch.object(api, "get_episodes", return_value=full_eps),
+        ):
+            found = api._find_episode_by_sort("899", 500)
+        assert found is not None
+        assert found["id"] == 999
+
+    def test_resolve_episode_by_airdate_in_subject(self):
+        api = BangumiApi()
+        episodes = {
+            "total": 1328,
+            "data": [
+                {"id": 1, "sort": 1, "type": 0, "airdate": "1996-01-8"},
+                {"id": 350, "sort": 350, "type": 0, "airdate": "2008-3-17"},
+            ],
+        }
+        with patch.object(api, "get_episodes", return_value=episodes):
+            result = api._resolve_episode_by_airdate_in_subject("899", "2008-03-17")
+        assert result == ("899", 350)
+
+    def test_resolve_episode_by_airdate_skips_short_series(self):
+        api = BangumiApi()
+        episodes = {
+            "total": 12,
+            "data": [{"id": 1, "sort": 1, "airdate": "2024-01-01"}],
+        }
+        with patch.object(api, "get_episodes", return_value=episodes):
+            result = api._resolve_episode_by_airdate_in_subject("123", "2024-01-01")
+        assert result is None
+
+    def test_tvdb_multi_season_airdate_fallback(self):
+        api = BangumiApi()
+        with (
+            patch.object(api, "get_related_subjects", return_value=[]),
+            patch.object(
+                api,
+                "_resolve_episode_by_airdate_in_subject",
+                return_value=("899", 350),
+            ) as mock_air,
+        ):
+            result = api.get_target_season_episode_id(
+                "899",
+                15,
+                12,
+                release_date="2008-05-20",
+            )
+        mock_air.assert_called_once_with("899", "2008-05-20")
+        assert result == ("899", 350)


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
✨ 新功能 (feature)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
支持超长连载番剧（柯南、海贼等）的 Bangumi 同步，修复原先季数 >10、集数 >99 硬拒绝，以及章节列表仅拉第一页导致高集号无法匹配的问题。

**核心逻辑（`app/utils/bangumi_api.py`）**
- 将季/集上限改为可配置（默认 season≤100、episode≤9999），替代原 10/99 硬限制
- `get_episodes` 支持分页拉取（`fetch_all=True`，每页 200 条）
- 新增 `_find_episode_by_sort`：集数 >99 时优先用 API `offset` 快速命中 `sort`，校验失败则全量扫描回退
- 新增单条目 airdate 择优回退：TVDB 多季 + Bangumi 单条目（如 S15E12）在季集匹配失败后，按播出日匹配章节
- 修复 `_parse_iso_date_ymd`：兼容 Bangumi 非补零日期（如 `1996-01-8`、`2008-3-17`）

**测试**
- 更新并补充 `tests/utils/test_bangumi_api.py`（分页、offset 快速路径、airdate 回退、日期解析等用例）


普通季番（≤99 集/季）仍走原有匹配路径，行为不变。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
