### PR TITLE
fix: 修复无法同步自定义映射的三次元条目续集

### DIFF
--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -794,7 +794,6 @@ class BangumiApi:
         max_season, max_episode = self._get_episode_sync_limits()
 
         # 获取根条目的 subject type，续集链遍历时仅放行相同媒体类型的条目
-        # type=2 动画与 type=6 三次元电视剧互不为续集，可避免跨界匹配
         root_info = self.get_subject(subject_id)
         root_type = root_info.get("type") if root_info else None
 

--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -731,6 +731,7 @@ class BangumiApi:
         release_date: str,
         max_hops: int = 15,
         max_days_diff: int = 120,
+        root_type: Optional[int] = None,
     ) -> Optional[tuple[Union[str, int], Union[str, int]]]:
         """
         沿「续集」链查找与 release_date 最接近的 target_ep 章节（用于 Plex 季数与 Bangumi 分段不一致）。
@@ -750,7 +751,9 @@ class BangumiApi:
                 break
             current_id = nxt
             current_info = self.get_subject(current_id)
-            if not current_info or current_info.get("platform") != "TV":
+            if not current_info:
+                continue
+            if root_type is not None and current_info.get("type") != root_type:
                 continue
             episodes = self.get_episodes(current_id)
             ep_info = episodes.get("data", [])
@@ -790,6 +793,11 @@ class BangumiApi:
         current_id = subject_id
         max_season, max_episode = self._get_episode_sync_limits()
 
+        # 获取根条目的 subject type，续集链遍历时仅放行相同媒体类型的条目
+        # type=2 动画与 type=6 三次元电视剧互不为续集，可避免跨界匹配
+        root_info = self.get_subject(subject_id)
+        root_type = root_info.get("type") if root_info else None
+
         if target_season > max_season or (target_ep and target_ep > max_episode):
             return None, None if target_ep else None
 
@@ -817,7 +825,9 @@ class BangumiApi:
             while True:
                 if not fist_part:
                     current_info = self.get_subject(current_id)
-                    if not current_info or current_info.get("platform") != "TV":
+                    if not current_info:
+                        continue
+                    if root_type is not None and current_info.get("type") != root_type:
                         continue
                 found = self._find_episode_by_sort(current_id, target_ep)
                 if found:
@@ -851,7 +861,7 @@ class BangumiApi:
         # Plex 季数与 Bangumi 多期/续集计数不一致时，用播出日 + 章节 airdate 择优
         if release_date and target_season > 1 and target_ep:
             air_pick = self._try_resolve_sequel_by_airdate(
-                subject_id, target_ep, release_date
+                subject_id, target_ep, release_date, root_type=root_type
             )
             if air_pick is not None:
                 return air_pick[0], air_pick[1]
@@ -870,7 +880,9 @@ class BangumiApi:
                 break
             current_id = next_id[0]["id"]
             current_info = self.get_subject(current_id)
-            if not current_info or current_info.get("platform") != "TV":
+            if not current_info:
+                continue
+            if root_type is not None and current_info.get("type") != root_type:
                 continue
             episodes = self.get_episodes(current_id)
             ep_info = episodes.get("data", [])

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -453,3 +453,112 @@ class TestGetTargetSeasonEpisodeIdSplitCour:
         )
         assert sid == 200
         assert eid == 2001
+
+    def test_type6_subject_sequel_chain(self):
+        """根条目 type=6（三次元电视剧）时续集链仅放行同 type 条目"""
+        api = BangumiApi()
+        api._get_episode_sync_limits = MagicMock(return_value=(10, 9999))
+
+        related = {
+            1: [{"relation": "续集", "id": 100}],
+            100: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        subjects = {
+            1: {
+                "type": 6,
+                "platform": "欧美剧",
+                "name": "Friends: Season 1",
+                "name_cn": "老友记 第一季",
+            },
+            100: {
+                "type": 6,
+                "platform": "欧美剧",
+                "name": "Friends: Season 2",
+                "name_cn": "老友记 第二季",
+            },
+        }
+
+        def get_subject(sid):
+            return subjects.get(int(sid))
+
+        episodes = {
+            100: {"data": [self._tv_ep(2, 2, 49497)], "total": 24},
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=1,
+            target_season=2,
+            target_ep=2,
+            is_season_subject_id=False,
+        )
+        assert sid == 100
+        assert eid == 49497
+
+    def test_type2_root_skips_type6_in_sequel_chain(self):
+        """根条目 type=2 时续集链中的 type=6 条目被跳过"""
+        api = BangumiApi()
+        api._get_episode_sync_limits = MagicMock(return_value=(10, 9999))
+
+        related = {
+            1: [{"relation": "续集", "id": 100}],
+            100: [{"relation": "续集", "id": 200}],
+            200: [],
+        }
+
+        def get_related(sid):
+            return related.get(int(sid), [])
+
+        subjects = {
+            1: {
+                "type": 2,
+                "platform": "TV",
+                "name": "Anime S1",
+                "name_cn": "动画 第一季",
+            },
+            100: {
+                "type": 6,
+                "platform": "电影",
+                "name": "Anime Movie",
+                "name_cn": "动画 真人版",
+            },
+            200: {
+                "type": 2,
+                "platform": "TV",
+                "name": "Anime S2",
+                "name_cn": "动画 第二季",
+            },
+        }
+
+        def get_subject(sid):
+            return subjects.get(int(sid))
+
+        episodes = {
+            200: {"data": [self._tv_ep(1, 1, 20001)], "total": 12},
+        }
+
+        def get_ep(sid):
+            return episodes.get(int(sid), {"data": [], "total": 0})
+
+        api.get_related_subjects = MagicMock(side_effect=get_related)
+        api.get_subject = MagicMock(side_effect=get_subject)
+        api.get_episodes = MagicMock(side_effect=get_ep)
+
+        sid, eid = api.get_target_season_episode_id(
+            subject_id=1,
+            target_season=2,
+            target_ep=1,
+            is_season_subject_id=False,
+        )
+        assert sid == 200
+        assert eid == 20001


### PR DESCRIPTION
## 📝 PR 描述

不好意思常常在发版之后发现问题（）不过我自己使用是写了个脚本定时git拉取更新的，发不发版对我来说都行hhh

这次主要是修复了我自己在使用时，映射了[老友记](https://bgm.tv/subject/3864)，同步第一季正常但到了第二季就无法同步的问题，因为当前爬续集链写死了platform != "TV"，现在改为动态匹配根 subject 自身的 type

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复通过自定义映射同步三次元电视剧（如 `platform="欧美剧"`）时第二季及以上无法标记的问题。

`get_target_season_episode_id()` 与 `_try_resolve_sequel_by_airdate()`
在续集链遍历时使用 `platform != "TV"` 过滤，导致 type=6 条目
（三次元电视剧）在 target_season >= 2 路径上被错误跳过。

改为以根条目的 subject type 作为续集链的过滤基准：函数入口读取根条目
type（已有实例缓存，无额外 API 开销），续集链遍历仅放行同 type 条目。

### 相关 Issue
无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过（新增2个针对 type=6 场景的单元测试）
- [x] 现有功能未受影响（bangumi_api + sync_service 共 236 个测试全部通过）

## 🔍 额外说明

### 修改范围（2 文件）

**`app/utils/bangumi_api.py`** (16+ / 4-):
- `get_target_season_episode_id()`: 入口读取 `root_type`，3 处检查改为 `type != root_type`
- `_try_resolve_sequel_by_airdate()`: 新增 `root_type` 参数，1 处检查改为 `type != root_type`
- `get_movie_main_episode_id()`: 不受影响（独立路径）

**`tests/utils/test_bangumi_api_extended.py`** (109+):
- 新增 `test_type6_subject_sequel_chain`: type=6 正向测试
- 新增 `test_type2_root_skips_type6_in_sequel_chain`: 跨 type 过滤测试

### 安全分析
- type=2（动画）与 type=6（三次元）在 Bangumi 数据模型中互不为续集关系，
  真人改编使用「不同演绎」relation 而非「续集」，
  按根条目 type 过滤不会错误放行跨媒体类型条目。
- 若无法获取根条目 type（API 异常），回退为不按 type 过滤，行为安全。
