### PR TITLE
fix: Trakt 同步时 bangumi_data 未收录条目降级使用 Trakt 自带标题，并改善同步体验

### DIFF
--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -80,6 +80,22 @@ async def trakt_auth_callback(
         )
 
         if callback_response.success:
+            # 授权成功后自动将用户 ID 写入 media_server_username，
+            # 避免因漏填导致 Trakt 同步被用户名过滤拦截
+            existing = config_manager.get(
+                "bangumi", "media_server_username", fallback=""
+            ).strip()
+            if not existing:
+                config_manager.set("bangumi", "media_server_username", user_id)
+            else:
+                existing_users = {u.strip() for u in existing.split(",") if u.strip()}
+                if user_id not in existing_users:
+                    config_manager.set(
+                        "bangumi",
+                        "media_server_username",
+                        f"{existing},{user_id}",
+                    )
+            config_manager.save_config()
             return redirect_public("/trakt/auth/success")
 
         return redirect_public(

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -563,7 +563,7 @@ class SyncService:
                 )
                 return False
             if user_name not in allowed:
-                logger.debug(f"非配置同步用户：{user_name}，跳过")
+                logger.warning(f"非配置同步用户：{user_name}，跳过")
                 return False
         elif mode == "multi":
             # 多用户模式，检查用户是否在映射配置中

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -563,7 +563,7 @@ class SyncService:
                 )
                 return False
             if user_name not in allowed:
-                logger.warning(f"非配置同步用户：{user_name}，跳过")
+                logger.debug(f"非配置同步用户：{user_name}，跳过")
                 return False
         elif mode == "multi":
             # 多用户模式，检查用户是否在映射配置中

--- a/app/services/trakt/client.py
+++ b/app/services/trakt/client.py
@@ -399,6 +399,24 @@ class TraktClient:
             logger.error(f"测试 Trakt 连接失败: {e}")
             return False
 
+    async def get_show_details(self, trakt_id: str) -> Optional[dict]:
+        """获取节目完整元数据（包含 original_title 等精简接口不返回的字段）
+
+        Args:
+            trakt_id: Trakt 节目 ID 或 slug
+
+        Returns:
+            节目详情 dict，失败时返回 None
+        """
+        try:
+            endpoint = f"/shows/{trakt_id}"
+            params = {"extended": "full"}
+            data = await self._make_request("GET", endpoint, params)
+            return data if isinstance(data, dict) else None
+        except Exception as e:
+            logger.debug(f"获取节目 {trakt_id} 详情失败: {e}")
+            return None
+
 
 # ===== 客户端工厂 =====
 

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -373,21 +373,26 @@ class TraktSyncService:
             episode = item.episode
 
             # 获取剧集标题
-            # 由于 Trakt 返回 title 名默认为英文, 通过 tmdb id 从 bangumi_data 获取更准确的标题
+            # 优先从 bangumi_data 获取中文标题；未收录时降级使用 Trakt 自带标题
             title: Optional[str] = None
 
             show_tmdb = show.get("ids", {}).get("tmdb")
-            if show_tmdb is None:
-                logger.warning(f"查询TMDB ID为空: {item.trakt_item_id}")
-                return None
-            tmdb_id = f"tv/{show_tmdb}"
+            if show_tmdb is not None:
+                title = bangumi_data.get_title_by_tmdb_id(f"tv/{show_tmdb}")
 
-            title = bangumi_data.get_title_by_tmdb_id(tmdb_id)
+            if not title:
+                # bangumi_data 未收录时，按日文原名 → 英文标题顺序降级
+                title = (
+                    show.get("original_title")
+                    or show.get("originalTitle")
+                    or show.get("title")
+                )
+
             if not title:
                 logger.warning(f"剧集标题为空: {item.trakt_item_id}")
                 return None
 
-            # 获取原始标题
+            # 获取原始标题，优先使用 Trakt 返回的日文原名
             ori_title = show.get("original_title") or show.get("originalTitle") or title
 
             # 获取季和集数

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -233,6 +233,21 @@ class TraktSyncService:
             skipped_count = len(history_items) - len(syncable_items)
             logger.info(f"过滤后得到 {len(syncable_items)} 条可同步记录（剧集 + 电影）")
 
+            # 预先收集 sync/history 不包含 original_title 的节目，
+            # 通过 /shows/:id?extended=full 获取日语原名
+            show_original_titles: dict[str, str] = {}
+            for item in syncable_items:
+                if item.type == "episode" and item.show:
+                    show = item.show
+                    if not show.get("original_title") and not show.get("originalTitle"):
+                        trakt_id = show.get("ids", {}).get("trakt")
+                        if trakt_id and trakt_id not in show_original_titles:
+                            details_resp = await client.get_show_details(str(trakt_id))
+                            if details_resp:
+                                ot = details_resp.get("original_title")
+                                if ot:
+                                    show_original_titles[str(trakt_id)] = ot
+
             # 转换为 CustomItem 并同步
             synced_count = 0
             error_count = 0
@@ -251,7 +266,7 @@ class TraktSyncService:
 
                     # 转换为 CustomItem
                     custom_item = self._convert_trakt_history_to_custom_item(
-                        user_id, item
+                        user_id, item, show_original_titles
                     )
 
                     if not custom_item:
@@ -357,7 +372,10 @@ class TraktSyncService:
             logger.error(f"记录同步历史失败: {e}")
 
     def _convert_trakt_history_to_custom_item(
-        self, user_id: str, item: TraktHistoryItem
+        self,
+        user_id: str,
+        item: TraktHistoryItem,
+        show_original_titles: Optional[dict[str, str]] = None,
     ) -> Optional[CustomItem]:
         """将 Trakt 观看历史转换为 CustomItem"""
         try:
@@ -381,10 +399,13 @@ class TraktSyncService:
                 title = bangumi_data.get_title_by_tmdb_id(f"tv/{show_tmdb}")
 
             if not title:
-                # bangumi_data 未收录时，按日文原名 → 英文标题顺序降级
+                # bangumi_data 未收录时，按日文原名 → 预取原文 → 英文标题顺序降级
                 title = (
                     show.get("original_title")
                     or show.get("originalTitle")
+                    or (show_original_titles or {}).get(
+                        str(show.get("ids", {}).get("trakt", ""))
+                    )
                     or show.get("title")
                 )
 

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -360,7 +360,7 @@ class TestConvertTraktHistoryToCustomItem:
         assert result is None
 
     def test_episode_no_tmdb(self):
-        """episode show 无 TMDB ID"""
+        """episode show 无 TMDB ID 时降级使用 Trakt 自带标题"""
         service = _make_service()
         item = TraktHistoryItem(
             id=1,
@@ -371,16 +371,18 @@ class TestConvertTraktHistoryToCustomItem:
             episode={"season": 1, "number": 1},
         )
         result = service._convert_trakt_history_to_custom_item("u", item)
-        assert result is None
+        assert result is not None
+        assert result.title == "S"
 
     def test_episode_no_title_in_bangumi(self):
-        """TMDB 查不到标题"""
+        """bangumi_data 未收录时降级使用 Trakt 自带标题"""
         service = _make_service()
         item = _make_episode_item()
         with patch("app.services.trakt.sync_service.bangumi_data") as mock_bd:
             mock_bd.get_title_by_tmdb_id.return_value = None
             result = service._convert_trakt_history_to_custom_item("u", item)
-            assert result is None
+            assert result is not None
+            assert result.title == "Test Show"
 
     def test_episode_with_first_aired(self):
         """覆盖 line 396: episode.first_aired"""

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -453,3 +453,68 @@ def test_get_active_sync_tasks_running_only():
     assert svc.get_active_sync_tasks() == {"a": "running"}
     t.done.return_value = True
     assert svc.get_active_sync_tasks() == {}
+
+
+def test_convert_trakt_history_uses_show_original_titles_cache():
+    """预取的 show_original_titles 缓存应被用于 original_title 降级"""
+    svc = TraktSyncService()
+    item = TraktHistoryItem(
+        id=1,
+        watched_at="2024-01-01T00:00:00Z",
+        action="scrobble",
+        type="episode",
+        movie=None,
+        show={"ids": {"trakt": 200000}, "title": "English Title"},
+        episode={"ids": {"trakt": 9}, "season": 1, "number": 1},
+    )
+    cache = {"200000": "日本語タイトル"}
+    result = svc._convert_trakt_history_to_custom_item("u", item, cache)
+    assert result is not None
+    assert result.title == "日本語タイトル"
+
+
+def test_convert_trakt_history_all_fallback_fail_returns_none():
+    """所有标题来源均不可用时返回 None"""
+    svc = TraktSyncService()
+    item = TraktHistoryItem(
+        id=1,
+        watched_at="2024-01-01T00:00:00Z",
+        action="scrobble",
+        type="episode",
+        movie=None,
+        show={"ids": {}, "title": ""},
+        episode={"ids": {"trakt": 9}, "season": 1, "number": 1},
+    )
+    with patch("app.services.trakt.sync_service.bangumi_data") as bd:
+        bd.get_title_by_tmdb_id.return_value = None
+        result = svc._convert_trakt_history_to_custom_item("u", item)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_show_details_returns_original_title():
+    """get_show_details 应返回包含 original_title 的完整节目数据"""
+    from app.services.trakt.client import TraktClient
+
+    client = TraktClient("fake_token")
+    mock_resp = {
+        "title": "Attack on Titan",
+        "year": 2013,
+        "ids": {"trakt": 1396},
+        "original_title": "進撃の巨人",
+    }
+    with patch.object(client, "_make_request", new=AsyncMock(return_value=mock_resp)):
+        result = await client.get_show_details("1396")
+        assert result is not None
+        assert result["original_title"] == "進撃の巨人"
+
+
+@pytest.mark.asyncio
+async def test_get_show_details_returns_none_on_failure():
+    """get_show_details 在请求失败时应返回 None"""
+    from app.services.trakt.client import TraktClient
+
+    client = TraktClient("fake_token")
+    with patch.object(client, "_make_request", new=AsyncMock(return_value=None)):
+        result = await client.get_show_details("999999")
+        assert result is None

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -355,6 +355,7 @@ def test_convert_trakt_history_movie_prefers_bangumi_title():
 
 
 def test_convert_trakt_history_missing_tmdb_returns_none():
+    """无 TMDB ID 时降级使用 Trakt 自带标题并成功返回"""
     svc = TraktSyncService()
     item = TraktHistoryItem(
         id=1,
@@ -365,10 +366,13 @@ def test_convert_trakt_history_missing_tmdb_returns_none():
         show={"ids": {}, "title": "S"},
         episode={"ids": {"trakt": 9}, "season": 1, "number": 1},
     )
-    assert svc._convert_trakt_history_to_custom_item("u", item) is None
+    result = svc._convert_trakt_history_to_custom_item("u", item)
+    assert result is not None
+    assert result.title == "S"
 
 
 def test_convert_trakt_history_no_bangumi_title_returns_none():
+    """bangumi_data 未收录时降级使用 Trakt 自带标题并成功返回"""
     with patch("app.services.trakt.sync_service.bangumi_data") as bd:
         bd.get_title_by_tmdb_id.return_value = None
         svc = TraktSyncService()
@@ -381,7 +385,9 @@ def test_convert_trakt_history_no_bangumi_title_returns_none():
             show={"ids": {"tmdb": 42}, "title": "S", "original_title": "S"},
             episode={"ids": {"trakt": 9}, "season": 1, "number": 1},
         )
-        assert svc._convert_trakt_history_to_custom_item("u", item) is None
+        result = svc._convert_trakt_history_to_custom_item("u", item)
+        assert result is not None
+        assert result.title == "S"
 
 
 def test_convert_trakt_history_success():


### PR DESCRIPTION
## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容

本次 PR 修复 Trakt 同步的几个问题，分为两个方向：

**① 标题获取降级链**（`_convert_trakt_history_to_custom_item`）

bangumi_data 未收录的条目原本直接跳过。改为四级降级链：
1. bangumi_data 中文标题（首选）
2. `/shows/:trakt_id?extended=full` 预取的日语原名
3. Trakt `/sync/history` 返回的 `show.title`（英文）
4. 全部不可用则跳过

预取在同步循环开始前批量完成，以 Trakt show ID 去重，仅对 sync 响应中缺少
`original_title` 的节目发起 `/shows/:id?extended=full` 请求（Client ID 鉴权，
不消耗用户 OAuth 配额）。

**② 授权后自动配置用户名**（`trakt_auth_callback`）

Trakt OAuth 回调成功时自动将用户 ID 填入 `media_server_username` 配置。
为空直接写入，非空且不含当前用户时逗号分隔追加。
避免用户漏填导致同步被 `_check_user_permission` 拦截。

### 相关 Issue
Related to #164

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat`（本次无模板变更，不适用）

### 测试
- [x] 已运行 `uv run pytest tests/` 且全部通过（339 trakt 测试）
- [x] 新增 4 个单元测试覆盖降级链与 `get_show_details` 方法
- [x] 现有功能未受影响

## 🔍 额外说明

### 修改文件（5 个）
| 文件 | 改动 |
|------|------|
| `app/api/trakt.py` | OAuth 回调自动写 `media_server_username` |
| `app/services/trakt/client.py` | 新增 `get_show_details()` 方法 |
| `app/services/trakt/sync_service.py` | 标题降级链 + 预取逻辑 + 缓存传递 |
| `tests/services/test_trakt_sync_service.py` | 2 个测试用例更新 |
| `tests/trakt/test_sync_service_comprehensive.py` | 4 个测试用例更新 + 4 个新增 |

### 降级链示意图

bangumi_data.find(tmdb_id)
  │
  ├─ 命中 ──→ 返回中文标题
  │
  └─ 未命中
       │
       ├─ show.original_title
       │     （/sync/history 不含此字段，通常为空）
       │
       ├─ show_original_titles 缓存
       │     （预取自 GET /shows/:trakt_id?extended=full）
       │
       ├─ show.title
       │     （英文标题，兜底）
       │
       └─ 全部不可用 ──→ 跳过（return None）
