### PR TITLE
fix: Trakt同步转换前失败场景增加通知

### DIFF
--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -5,7 +5,7 @@ Trakt 数据同步服务
 import asyncio
 import time
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from app.utils.bangumi_data import bangumi_data
 
@@ -13,6 +13,7 @@ from ...core.database import database_manager
 from ...core.logging import logger
 from ...models.sync import CustomItem
 from ...services.sync_service import sync_service
+from ...utils.notifier import send_notify
 from .auth import trakt_auth_service
 from .client import TraktClient, TraktClientFactory
 from .models import TraktHistoryItem, TraktSyncResult, TraktSyncStats
@@ -217,6 +218,8 @@ class TraktSyncService:
 
             # 过滤：剧集需 episode+show；电影需 movie 且至少有标题或 TMDB（用于匹配 bangumi）
             syncable_items: list[TraktHistoryItem] = []
+            skipped_count = 0
+            error_count = 0
             for item in history_items:
                 if item.type == "episode" and item.episode and item.show:
                     syncable_items.append(item)
@@ -228,9 +231,15 @@ class TraktSyncService:
                         syncable_items.append(item)
                     else:
                         logger.warning(f"跳过缺少标题与 TMDB 的电影记录: {item}")
+                        self._report_preconvert_failure(
+                            user_id,
+                            item,
+                            "电影记录缺少标题与 TMDB ID，无法转为同步条目",
+                        )
+                        error_count += 1
                 else:
                     logger.warning(f"跳过不支持的类型或数据不完整的记录: {item}")
-            skipped_count = len(history_items) - len(syncable_items)
+                    skipped_count += 1
             logger.info(f"过滤后得到 {len(syncable_items)} 条可同步记录（剧集 + 电影）")
 
             # 预先收集 sync/history 不包含 original_title 的节目，
@@ -250,7 +259,6 @@ class TraktSyncService:
 
             # 转换为 CustomItem 并同步
             synced_count = 0
-            error_count = 0
             details = []
 
             for item in syncable_items:
@@ -270,7 +278,12 @@ class TraktSyncService:
                     )
 
                     if not custom_item:
-                        skipped_count += 1
+                        self._report_preconvert_failure(
+                            user_id,
+                            item,
+                            "Trakt 记录缺少可用标题，无法转为同步条目",
+                        )
+                        error_count += 1
                         continue
 
                     # 调用现有同步服务
@@ -347,6 +360,83 @@ class TraktSyncService:
             skipped_count=0,
             error_count=0,
             details={},
+        )
+
+    def _trakt_item_failure_context(
+        self, user_id: str, item: TraktHistoryItem, reason: str
+    ) -> dict[str, Any]:
+        """从 Trakt 历史条目提取失败通知与 sync_records 共用字段。"""
+        title = "unknown"
+        ori_title = ""
+        season = 0
+        episode = 0
+        media_type = "episode"
+
+        if item.type == "episode" and item.show:
+            show = item.show
+            ep = item.episode or {}
+            title = (
+                show.get("title")
+                or show.get("original_title")
+                or show.get("originalTitle")
+                or item.trakt_item_id
+                or "unknown"
+            )
+            ori_raw = show.get("original_title") or show.get("originalTitle") or ""
+            ori_title = ori_raw if str(ori_raw).strip() else ""
+            season = int(ep.get("season") or 0)
+            episode = int(ep.get("number") or 0)
+            media_type = "episode"
+        elif item.type == "movie" and item.movie:
+            movie = item.movie
+            raw_title = (movie.get("title") or "").strip()
+            title = raw_title or item.trakt_item_id or "unknown"
+            ori_raw = movie.get("original_title") or movie.get("originalTitle") or ""
+            ori_title = ori_raw if str(ori_raw).strip() else ""
+            season = 1
+            episode = 1
+            media_type = "movie"
+        else:
+            title = item.trakt_item_id or "unknown"
+
+        return {
+            "user_name": user_id,
+            "title": str(title),
+            "ori_title": ori_title,
+            "season": season,
+            "episode": episode,
+            "media_type": media_type,
+            "source": "trakt",
+            "error_message": reason,
+        }
+
+    def _report_preconvert_failure(
+        self, user_id: str, item: TraktHistoryItem, reason: str
+    ) -> None:
+        """Trakt 转 CustomItem 前失败：webhook/邮件 + 应用内 sync_records。"""
+        ctx = self._trakt_item_failure_context(user_id, item, reason)
+        send_notify(
+            "mark_failed",
+            item=None,
+            source="trakt",
+            error_type="trakt_title_unresolved",
+            user_name=ctx["user_name"],
+            title=ctx["title"],
+            ori_title=ctx["ori_title"],
+            season=ctx["season"],
+            episode=ctx["episode"],
+            error_message=reason,
+        )
+        database_manager.log_sync_record(
+            user_name=ctx["user_name"],
+            title=ctx["title"],
+            ori_title=ctx["ori_title"],
+            season=ctx["season"],
+            episode=ctx["episode"],
+            status="error",
+            message=reason,
+            source="trakt",
+            media_type=ctx["media_type"],
         )
 
     def _record_sync_history(

--- a/app/utils/bangumi_api.py
+++ b/app/utils/bangumi_api.py
@@ -793,12 +793,12 @@ class BangumiApi:
         current_id = subject_id
         max_season, max_episode = self._get_episode_sync_limits()
 
+        if target_season > max_season or (target_ep and target_ep > max_episode):
+            return None, None if target_ep else None
+
         # 获取根条目的 subject type，续集链遍历时仅放行相同媒体类型的条目
         root_info = self.get_subject(subject_id)
         root_type = root_info.get("type") if root_info else None
-
-        if target_season > max_season or (target_ep and target_ep > max_episode):
-            return None, None if target_ep else None
 
         # 如果已经是目标季数的ID，直接尝试匹配集数
         if is_season_subject_id:

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -215,14 +215,15 @@ class TestSyncWatchedHistory:
             assert result.synced_count == 0
 
     @pytest.mark.asyncio
-    async def test_custom_item_none_skip(self):
-        """覆盖 lines 254-255: 转换返回 None"""
+    async def test_custom_item_none_reports_failure(self):
+        """转换返回 None 时应记失败并通知"""
         service = _make_service()
         item = _make_episode_item()
         mock_client = AsyncMock()
         mock_client.get_all_watched_history = AsyncMock(return_value=[item])
         with (
             patch("app.services.trakt.sync_service.database_manager") as mock_db,
+            patch("app.services.trakt.sync_service.send_notify") as mock_notify,
             patch.object(
                 service,
                 "_convert_trakt_history_to_custom_item",
@@ -233,7 +234,39 @@ class TestSyncWatchedHistory:
             result = await service._sync_watched_history(
                 "u", mock_client, MagicMock(), False
             )
-            assert result.skipped_count == 1
+            assert result.skipped_count == 0
+            assert result.error_count == 1
+            mock_notify.assert_called_once()
+            assert mock_notify.call_args.args[0] == "mark_failed"
+            mock_db.log_sync_record.assert_called_once()
+            assert mock_db.log_sync_record.call_args.kwargs["status"] == "error"
+            assert mock_db.log_sync_record.call_args.kwargs["source"] == "trakt"
+
+    @pytest.mark.asyncio
+    async def test_movie_filter_no_title_no_tmdb_reports_failure(self):
+        """电影缺少标题和 TMDB 时应记失败并通知"""
+        service = _make_service()
+        item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-06-01T12:00:00Z",
+            action="watch",
+            type="movie",
+            movie={"title": "", "ids": {}},
+        )
+        mock_client = AsyncMock()
+        mock_client.get_all_watched_history = AsyncMock(return_value=[item])
+        with (
+            patch("app.services.trakt.sync_service.database_manager") as mock_db,
+            patch("app.services.trakt.sync_service.send_notify") as mock_notify,
+        ):
+            mock_db.get_trakt_synced_set.return_value = set()
+            result = await service._sync_watched_history(
+                "u", mock_client, MagicMock(), False
+            )
+            assert result.skipped_count == 0
+            assert result.error_count == 1
+            mock_notify.assert_called_once()
+            mock_db.log_sync_record.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_item_sync_exception(self):
@@ -266,28 +299,8 @@ class TestSyncWatchedHistory:
             assert result.error_count == 1
 
     @pytest.mark.asyncio
-    async def test_movie_filter_no_title_no_tmdb(self):
-        """覆盖 lines 230-232: 电影缺少标题和TMDB"""
-        service = _make_service()
-        item = TraktHistoryItem(
-            id=1,
-            watched_at="2024-06-01T12:00:00Z",
-            action="watch",
-            type="movie",
-            movie={"title": "", "ids": {}},
-        )
-        mock_client = AsyncMock()
-        mock_client.get_all_watched_history = AsyncMock(return_value=[item])
-        with patch("app.services.trakt.sync_service.database_manager") as mock_db:
-            mock_db.get_trakt_synced_set.return_value = set()
-            result = await service._sync_watched_history(
-                "u", mock_client, MagicMock(), False
-            )
-            assert result.skipped_count == 1
-
-    @pytest.mark.asyncio
-    async def test_unsupported_type_skip(self):
-        """覆盖 line 232: 不支持的类型"""
+    async def test_unsupported_type_skip_no_failure_notify(self):
+        """不支持的类型仍 skipped，不发失败通知"""
         service = _make_service()
         item = TraktHistoryItem(
             id=1,
@@ -297,12 +310,18 @@ class TestSyncWatchedHistory:
         )
         mock_client = AsyncMock()
         mock_client.get_all_watched_history = AsyncMock(return_value=[item])
-        with patch("app.services.trakt.sync_service.database_manager") as mock_db:
+        with (
+            patch("app.services.trakt.sync_service.database_manager") as mock_db,
+            patch("app.services.trakt.sync_service.send_notify") as mock_notify,
+        ):
             mock_db.get_trakt_synced_set.return_value = set()
             result = await service._sync_watched_history(
                 "u", mock_client, MagicMock(), False
             )
             assert result.skipped_count == 1
+            assert result.error_count == 0
+            mock_notify.assert_not_called()
+            mock_db.log_sync_record.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_outer_exception(self):
@@ -511,6 +530,76 @@ class TestTraktMovieHistoryToCustomItem:
             result = service._trakt_movie_history_to_custom_item("u", item)
             assert result is not None
             assert result.ori_title == "Original"
+
+
+class TestTraktPreconvertFailure:
+    """转 CustomItem 前失败上下文与上报"""
+
+    def test_failure_context_episode(self):
+        service = _make_service()
+        item = _make_episode_item(ep_season=2, ep_number=5)
+        ctx = service._trakt_item_failure_context("uid", item, "reason")
+        assert ctx["user_name"] == "uid"
+        assert ctx["title"] == "Test Show"
+        assert ctx["season"] == 2
+        assert ctx["episode"] == 5
+        assert ctx["media_type"] == "episode"
+        assert ctx["error_message"] == "reason"
+
+    def test_failure_context_movie(self):
+        service = _make_service()
+        item = _make_movie_item(title="Film", original_title="Orig")
+        ctx = service._trakt_item_failure_context("uid", item, "reason")
+        assert ctx["title"] == "Film"
+        assert ctx["ori_title"] == "Orig"
+        assert ctx["season"] == 1
+        assert ctx["episode"] == 1
+        assert ctx["media_type"] == "movie"
+
+    def test_report_preconvert_failure(self):
+        service = _make_service()
+        item = _make_episode_item()
+        with (
+            patch("app.services.trakt.sync_service.send_notify") as mock_notify,
+            patch("app.services.trakt.sync_service.database_manager") as mock_db,
+        ):
+            service._report_preconvert_failure("uid", item, "测试失败")
+            mock_notify.assert_called_once()
+            kwargs = mock_notify.call_args.kwargs
+            assert kwargs["error_type"] == "trakt_title_unresolved"
+            assert kwargs["error_message"] == "测试失败"
+            mock_db.log_sync_record.assert_called_once()
+            assert mock_db.log_sync_record.call_args.kwargs["message"] == "测试失败"
+
+    @pytest.mark.asyncio
+    async def test_convert_all_titles_empty_reports_failure(self):
+        """真实转换路径：标题全空时 error_count"""
+        service = _make_service()
+        item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T00:00:00Z",
+            action="scrobble",
+            type="episode",
+            movie=None,
+            show={"ids": {}, "title": ""},
+            episode={"ids": {"trakt": 9}, "season": 1, "number": 1},
+        )
+        mock_client = AsyncMock()
+        mock_client.get_all_watched_history = AsyncMock(return_value=[item])
+        with (
+            patch("app.services.trakt.sync_service.bangumi_data") as mock_bd,
+            patch("app.services.trakt.sync_service.database_manager") as mock_db,
+            patch("app.services.trakt.sync_service.send_notify") as mock_notify,
+        ):
+            mock_bd.get_title_by_tmdb_id.return_value = None
+            mock_db.get_trakt_synced_set.return_value = set()
+            result = await service._sync_watched_history(
+                "u", mock_client, MagicMock(), False
+            )
+            assert result.error_count == 1
+            assert result.skipped_count == 0
+            mock_notify.assert_called_once()
+            mock_db.log_sync_record.assert_called_once()
 
 
 class TestRecordSyncHistory:

--- a/tests/utils/test_bangumi_api.py
+++ b/tests/utils/test_bangumi_api.py
@@ -988,6 +988,8 @@ class TestGetMovieMainEpisodeId:
 class TestGetTargetSeasonEpisodeId:
     """测试 get_target_season_episode_id"""
 
+    _MOCK_SUBJECT = {"id": 123, "type": 2, "name": "test", "name_cn": ""}
+
     def test_season_gt_limit_returns_none(self):
         api = BangumiApi()
         with patch.object(api, "_get_episode_sync_limits", return_value=(100, 9999)):
@@ -1002,28 +1004,35 @@ class TestGetTargetSeasonEpisodeId:
 
     def test_ep_100_season1_uses_long_series_path(self):
         api = BangumiApi()
-        with patch.object(
-            api,
-            "_find_episode_by_sort",
-            return_value={"id": "ep100", "sort": 100},
-        ) as mock_find:
+        with (
+            patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT),
+            patch.object(
+                api,
+                "_find_episode_by_sort",
+                return_value={"id": "ep100", "sort": 100},
+            ) as mock_find,
+        ):
             result = api.get_target_season_episode_id("899", 1, 100)
         mock_find.assert_called_once_with("899", 100)
         assert result == ("899", "ep100")
 
     def test_is_season_subject_id_no_target_ep(self):
         api = BangumiApi()
-        result = api.get_target_season_episode_id(
-            "123", 1, 0, is_season_subject_id=True
-        )
+        with patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT):
+            result = api.get_target_season_episode_id(
+                "123", 1, 0, is_season_subject_id=True
+            )
         assert result == "123"
 
     def test_is_season_subject_id_match_sort(self):
         api = BangumiApi()
-        with patch.object(
-            api,
-            "get_episodes",
-            return_value={"data": [{"sort": 3, "id": "ep3"}, {"sort": 1, "id": "ep1"}]},
+        with (
+            patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT),
+            patch.object(
+                api,
+                "_find_episode_by_sort",
+                return_value={"sort": 3, "id": "ep3"},
+            ),
         ):
             result = api.get_target_season_episode_id(
                 "123", 1, 3, is_season_subject_id=True
@@ -1032,10 +1041,13 @@ class TestGetTargetSeasonEpisodeId:
 
     def test_is_season_subject_id_match_ep(self):
         api = BangumiApi()
-        with patch.object(
-            api,
-            "get_episodes",
-            return_value={"data": [{"ep": 3, "sort": 3, "id": "ep3"}]},
+        with (
+            patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT),
+            patch.object(
+                api,
+                "_find_episode_by_sort",
+                return_value={"ep": 3, "sort": 3, "id": "ep3"},
+            ),
         ):
             result = api.get_target_season_episode_id(
                 "123", 1, 3, is_season_subject_id=True
@@ -1045,10 +1057,11 @@ class TestGetTargetSeasonEpisodeId:
     def test_is_season_subject_id_no_match_fallback(self):
         """指定季度ID未匹配到集数，回退到传统方法"""
         api = BangumiApi()
-        with patch.object(
-            api,
-            "get_episodes",
-            return_value={"data": []},
+        with (
+            patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT),
+            patch.object(api, "_find_episode_by_sort", return_value=None),
+            patch.object(api, "get_episodes", return_value={"data": []}),
+            patch.object(api, "get_related_subjects", return_value=[]),
         ):
             result = api.get_target_season_episode_id(
                 "123", 1, 5, is_season_subject_id=True
@@ -1058,7 +1071,8 @@ class TestGetTargetSeasonEpisodeId:
 
     def test_season1_no_ep(self):
         api = BangumiApi()
-        result = api.get_target_season_episode_id("123", 1, 0)
+        with patch.object(api, "get_subject", return_value=self._MOCK_SUBJECT):
+            result = api.get_target_season_episode_id("123", 1, 0)
         assert result == "123"
 
 
@@ -1360,6 +1374,11 @@ class TestLongSeriesEpisodeSync:
     def test_tvdb_multi_season_airdate_fallback(self):
         api = BangumiApi()
         with (
+            patch.object(
+                api,
+                "get_subject",
+                return_value={"id": 899, "type": 2, "name": "test", "name_cn": ""},
+            ),
             patch.object(api, "get_related_subjects", return_value=[]),
             patch.object(
                 api,

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -170,6 +170,7 @@ class TestGetTargetSeasonEpisodeIdAirdate:
     def test_direct_match_succeeds_skips_airdate(self):
         """is_season_subject_id=True 且直接匹配成功时，不走 airdate 路径"""
         api = BangumiApi()
+        api.get_subject = MagicMock(return_value={"type": 2, "name_cn": ""})
         api.get_related_subjects = MagicMock()
         api.get_episodes = MagicMock(
             return_value={


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
本次修复 Trakt 同步在**转为 CustomItem 之前**失败时无任何通知的问题：此前电影缺标题/TMDB、或剧集标题解析失败会被静默计入 `skipped`，现在会写入失败记录并发送 `mark_failed` 通知。

**Trakt 同步（[`app/services/trakt/sync_service.py`](app/services/trakt/sync_service.py)）**
- 新增 `_trakt_item_failure_context` / `_report_preconvert_failure`，统一提取展示字段并调用 `send_notify("mark_failed", error_type="trakt_title_unresolved")` + `log_sync_record(status="error")`
- **预过滤**：电影无 `title` 且无 TMDB → `error_count++`（不再 bulk skipped）
- **转换**：`_convert_trakt_history_to_custom_item` 返回 `None` → 同上
- 已在 `synced_set`、不支持类型等合理跳过路径保持不变

**Bangumi API（[`app/utils/bangumi_api.py`](app/utils/bangumi_api.py)）**
- 将季/集上限检查提前到 `get_subject()` 之前，超限时直接返回，避免多余 API 请求

**测试**
- 补充/更新 [`tests/services/test_trakt_sync_service.py`](tests/services/test_trakt_sync_service.py) 中预转换失败与通知相关用例
- 修复 [`tests/utils/test_bangumi_api.py`](tests/utils/test_bangumi_api.py)、[`tests/utils/test_bangumi_api_extended.py`](tests/utils/test_bangumi_api_extended.py) 中 `get_target_season_episode_id` 相关用例未 mock `get_subject` 导致全量测试卡住的问题
### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
Closes #166 

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
