### PR TITLE
fix: Trakt 剧集同步的 release_date 回退链缺失 show.year 导致始终无法获取准确的播出年份

### DIFF
--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -510,16 +510,16 @@ class TraktSyncService:
             season = episode.get("season", 1)
             episode_num = episode.get("number", 1)
 
-            # 获取发行日期（从剧集或剧中获取）
+            # 获取发行日期（优先剧集/剧集首播日期，其次播出年份，最后用户观看日期）
             release_date = ""
             if episode.get("first_aired"):
                 release_date = episode["first_aired"]
             elif show.get("first_aired"):
                 release_date = show["first_aired"]
+            elif show.get("year"):
+                release_date = f"{show['year']}-01-01"
 
-            # 如果没有发行日期，使用观看日期
             if not release_date and item.watched_at:
-                # 从 ISO 格式中提取日期部分
                 try:
                     release_date = item.watched_at.split("T")[0]
                 except Exception:


### PR DESCRIPTION
## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
Trakt `/sync/history` 返回的 show 和 episode 对象不含 `first_aired` 字段，
剧集同步的 `release_date` 回退链直接掉到 `item.watched_at`（用户观看时间戳），
导致 `bgm_search` 使用观看日期（如 `2026-06-13`）做日期范围搜索。

以电影处理器已有的回退链为参照（`movie.released → movie.year → watched_at`），
为剧集在 `watched_at` 之前插入 `show.year` 作为中间回退：

### 相关 Issue

Related to #164 

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更（本次无，不适用）

### 测试
- [x] `uv run pytest tests/ -k "trakt"` — 343 passed
- [x] 现有功能未受影响

## 🔍 额外说明

### 修改范围
`app/services/trakt/sync_service.py` — 3 行，在剧集 release_date 回退链中
插入 `elif show.get("year"): release_date = f"{show['year']}-01-01"`。