### PR TITLE
feat: 同步记录显示 Bangumi 标题，通知新增 bgm_title 变量

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -46,6 +46,7 @@ class DatabaseManager:
         self._lock = threading.Lock()
         self._conn: Optional[sqlite3.Connection] = None
         self._media_type_migrated = False
+        self._bgm_title_migrated = False
         self._heatmap_cache: Optional[list] = None
         self._heatmap_cache_time: float = 0
         self._init_database()
@@ -107,6 +108,19 @@ class DatabaseManager:
         self._media_type_migrated = True
         logger.info("sync_records 已迁移：增加 media_type 列并回填 episode")
 
+    def _ensure_sync_records_bgm_title(self, cursor) -> None:
+        """旧库迁移：为 sync_records 增加 bgm_title（Bangumi 平台标题）。"""
+        if self._bgm_title_migrated:
+            return
+        cursor.execute("PRAGMA table_info(sync_records)")
+        cols = [row[1] for row in cursor.fetchall()]
+        if "bgm_title" in cols:
+            self._bgm_title_migrated = True
+            return
+        cursor.execute("ALTER TABLE sync_records ADD COLUMN bgm_title TEXT DEFAULT ''")
+        self._bgm_title_migrated = True
+        logger.info("sync_records 已迁移：增加 bgm_title 列")
+
     def _init_database(self) -> None:
         """初始化数据库"""
         conn = self._get_connection()
@@ -127,7 +141,8 @@ class DatabaseManager:
                 status TEXT NOT NULL,
                 message TEXT,
                 source TEXT NOT NULL,
-                media_type TEXT NOT NULL DEFAULT 'episode'
+                media_type TEXT NOT NULL DEFAULT 'episode',
+                bgm_title TEXT DEFAULT ''
             )
         """)
 
@@ -237,18 +252,20 @@ class DatabaseManager:
         message: str = "",
         source: str = "custom",
         media_type: str = "episode",
+        bgm_title: str = "",
     ) -> Optional[int]:
         """记录同步日志到数据库，返回新记录 id（失败时 None）"""
         try:
 
             def _write(conn):
                 self._ensure_sync_records_media_type(conn.cursor())
+                self._ensure_sync_records_bgm_title(conn.cursor())
                 local_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 cursor = conn.execute(
                     """
                     INSERT INTO sync_records
-                    (timestamp, user_name, title, ori_title, season, episode, subject_id, episode_id, status, message, source, media_type)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (timestamp, user_name, title, ori_title, season, episode, subject_id, episode_id, status, message, source, media_type, bgm_title)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                     (
                         local_time,
@@ -263,6 +280,7 @@ class DatabaseManager:
                         message,
                         source,
                         media_type or "episode",
+                        bgm_title or "",
                     ),
                 )
                 record_id = cursor.lastrowid
@@ -310,6 +328,7 @@ class DatabaseManager:
 
             def _read(conn):
                 self._ensure_sync_records_media_type(conn.cursor())
+                self._ensure_sync_records_bgm_title(conn.cursor())
                 cursor = conn.cursor()
 
                 where_conditions = []
@@ -346,7 +365,7 @@ class DatabaseManager:
 
                 query = f"""
                     SELECT id, timestamp, user_name, title, ori_title, season, episode,
-                           subject_id, episode_id, status, message, source, media_type
+                           subject_id, episode_id, status, message, source, media_type, bgm_title
                     FROM sync_records{where_clause}
                     ORDER BY timestamp DESC
                     LIMIT ? OFFSET ?
@@ -370,6 +389,7 @@ class DatabaseManager:
                             "message": row[10],
                             "source": row[11],
                             "media_type": row[12] or "episode",
+                            "bgm_title": row[13] or "",
                         }
                     )
 
@@ -391,11 +411,12 @@ class DatabaseManager:
 
             def _read(conn):
                 self._ensure_sync_records_media_type(conn.cursor())
+                self._ensure_sync_records_bgm_title(conn.cursor())
                 cursor = conn.cursor()
                 cursor.execute(
                     """
                     SELECT id, timestamp, user_name, title, ori_title, season, episode,
-                           subject_id, episode_id, status, message, source, media_type
+                           subject_id, episode_id, status, message, source, media_type, bgm_title
                     FROM sync_records
                     WHERE id = ?
                 """,
@@ -419,6 +440,7 @@ class DatabaseManager:
                     "message": row[10],
                     "source": row[11],
                     "media_type": row[12] or "episode",
+                    "bgm_title": row[13] or "",
                 }
             return None
         except Exception as e:

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -385,13 +385,27 @@ class SyncService:
                 )
                 return SyncResponse(status="error", message="未找到对应的剧集")
 
+            # 通过实例缓存获取 Bangumi 平台标题（无额外 API 调用）
+            subject_info = bgm.get_subject(bgm_se_id)
+            bgm_title = ""
+            if subject_info:
+                bgm_title = (
+                    subject_info.get("name_cn") or subject_info.get("name") or ""
+                )
+
             logger.debug(
-                f"bgm: 查询到 {item.title} (https://bgm.tv/subject/{bgm_se_id}) "
+                f"bgm: 查询到 {bgm_title or item.title} (https://bgm.tv/subject/{bgm_se_id}) "
                 f"S{item.season:02d}E{item.episode:02d} (https://bgm.tv/ep/{bgm_ep_id})"
             )
 
             # 发送匹配成功的通知，使用解析后的正确季度ID
-            send_notify("bangumi_id_found", item, actual_source, subject_id=bgm_se_id)
+            send_notify(
+                "bangumi_id_found",
+                item,
+                actual_source,
+                subject_id=bgm_se_id,
+                bgm_title=bgm_title,
+            )
 
             # 标记为看过
             try:
@@ -408,7 +422,7 @@ class SyncService:
             if mark_status == 0:
                 result_message = "已看过，不再重复标记"
                 logger.info(
-                    f"bgm: {item.title} S{item.season:02d}E{item.episode:02d} {result_message}"
+                    f"bgm: {bgm_title or item.title} S{item.season:02d}E{item.episode:02d} {result_message}"
                 )
 
                 send_notify(
@@ -417,12 +431,13 @@ class SyncService:
                     actual_source,
                     subject_id=bgm_se_id,
                     episode_id=bgm_ep_id,
+                    bgm_title=bgm_title,
                 )
 
             elif mark_status == 1:
                 result_message = "已标记为看过"
                 logger.info(
-                    f"bgm: {item.title} S{item.season:02d}E{item.episode:02d} {result_message} https://bgm.tv/ep/{bgm_ep_id}"
+                    f"bgm: {bgm_title or item.title} S{item.season:02d}E{item.episode:02d} {result_message} https://bgm.tv/ep/{bgm_ep_id}"
                 )
 
                 send_notify(
@@ -431,15 +446,16 @@ class SyncService:
                     actual_source,
                     subject_id=bgm_se_id,
                     episode_id=bgm_ep_id,
+                    bgm_title=bgm_title,
                 )
 
             else:
                 result_message = "已添加到收藏并标记为看过"
                 logger.info(
-                    f"bgm: {item.title} 已添加到收藏 https://bgm.tv/subject/{bgm_se_id}"
+                    f"bgm: {bgm_title or item.title} 已添加到收藏 https://bgm.tv/subject/{bgm_se_id}"
                 )
                 logger.info(
-                    f"bgm: {item.title} S{item.season:02d}E{item.episode:02d} 已标记为看过 https://bgm.tv/ep/{bgm_ep_id}"
+                    f"bgm: {bgm_title or item.title} S{item.season:02d}E{item.episode:02d} 已标记为看过 https://bgm.tv/ep/{bgm_ep_id}"
                 )
 
                 send_notify(
@@ -448,6 +464,7 @@ class SyncService:
                     actual_source,
                     subject_id=bgm_se_id,
                     episode_id=bgm_ep_id,
+                    bgm_title=bgm_title,
                 )
 
             if item.media_type == "movie" and config_manager.get(
@@ -491,7 +508,7 @@ class SyncService:
                                     subject_id=str(bgm_se_id), state=2
                                 )
                                 logger.info(
-                                    f"bgm: {item.title} 所有剧集已看完（已看 {watched_eps}/{total_eps} 集），已自动归档为「看过」"
+                                    f"bgm: {bgm_title or item.title} 所有剧集已看完（已看 {watched_eps}/{total_eps} 集），已自动归档为「看过」"
                                 )
                 except Exception as e:
                     logger.warning(
@@ -511,6 +528,7 @@ class SyncService:
                 message=result_message,
                 source=actual_source,
                 media_type=item.media_type,
+                bgm_title=bgm_title,
             )
 
             return SyncResponse(
@@ -518,6 +536,7 @@ class SyncService:
                 message=result_message,
                 data={
                     "title": item.title,
+                    "bgm_title": bgm_title,
                     "season": item.season,
                     "episode": item.episode,
                     "subject_id": bgm_se_id,

--- a/app/utils/notifier.py
+++ b/app/utils/notifier.py
@@ -1238,7 +1238,7 @@ def send_notify(
         if item is not None:
             data["user_name"] = getattr(item, "user_name", "unknown")
             data["title"] = getattr(item, "title", "unknown")
-            data["ori_title"] = getattr(item, "ori_title", "")
+            data["ori_title"] = getattr(item, "ori_title", "") or ""
             data["season"] = getattr(item, "season", 0)
             data["episode"] = getattr(item, "episode", 0)
             data["source"] = getattr(item, "source", "")

--- a/templates/config.html
+++ b/templates/config.html
@@ -2795,7 +2795,7 @@ function copyWebhookKey() {
                                       rows="5"
                                       placeholder='{"content": "📢 {title} S{season}E{episode} - {notification_type}"}'></textarea>
                             <div class="form-text">
-                                支持 JSON 格式，可用变量：{timestamp}, {user_name}, {title}, {season}, {episode}, {source}, {notification_type}, {error_message}, {subject_id}, {episode_id}
+                                支持 JSON 格式，可用变量：{timestamp}, {user_name}, {title}, {ori_title}, {bgm_title}, {season}, {episode}, {source}, {notification_type}, {error_message}, {subject_id}, {episode_id}
                             </div>
                         </div>
                     </form>
@@ -2955,7 +2955,7 @@ function copyWebhookKey() {
                                    id="email-subject-input"
                                    placeholder="[Bangumi-Syncer] {error_type} - {title} S{season}E{episode}">
                             <div class="form-text">
-                                可用变量：{timestamp}, {user_name}, {title}, {season}, {episode}, {source}, {error_type}, {error_message}, {notification_type}, {subject_id}, {episode_id}
+                                可用变量：{timestamp}, {user_name}, {title}, {ori_title}, {bgm_title}, {season}, {episode}, {source}, {error_type}, {error_message}, {notification_type}, {subject_id}, {episode_id}
                             </div>
                         </div>
                         <div class="mb-3">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -418,12 +418,14 @@ async function showRecordDetail(recordId) {
                 + '</div>'
                 + '<div class="row mt-2">'
                 + '  <div class="col-md-6"><strong>用户:</strong> ' + escapeHtml(record.user_name) + '</div>'
-                + '  <div class="col-md-6"><strong>番剧标题:</strong> ' + escapeHtml(record.title) + '</div>'
+                + '  <div class="col-md-6"><strong>番剧标题:</strong> ' + escapeHtml(record.bgm_title || record.title) + '</div>'
                 + '</div>'
-                + '<details class="mt-2">'
-                + '  <summary style="color: var(--app-text-muted); cursor:pointer; font-size:0.875rem">原始标题（点击展开）</summary>'
-                + '  <div class="mt-1 small">' + (record.ori_title && String(record.ori_title).trim() ? escapeHtml(record.ori_title) : '无') + '</div>'
-                + '</details>'
+                + '<div class="row mt-2">'
+                + '  <div class="col-md-6"><strong>接收标题:</strong> ' + escapeHtml(record.title) + '</div>'
+                + (record.ori_title && String(record.ori_title).trim()
+                    ? '  <div class="col-md-6"><strong>原始标题:</strong> ' + escapeHtml(record.ori_title) + '</div>'
+                    : '')
+                + '</div>'
                 + '<div class="row mt-2">'
                 + '  <div class="col-md-4"><strong>季/集:</strong> ' + epHtml + '</div>'
                 + '  <div class="col-md-4"><strong>状态:</strong> <span class="badge rounded-pill bg-' + getStatusColor(record.status) + '">' + getStatusText(record.status) + '</span></div>'
@@ -535,7 +537,7 @@ function renderTimeline(records) {
         const timeStr = time.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
         const relativeTime = formatRelativeTime(record.timestamp);
 
-        const titleText = escapeHtml(record.title);
+        const titleText = escapeHtml(record.bgm_title || record.title);
 
         const isMovie = record.media_type === 'movie';
         let epHtml;

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -425,7 +425,7 @@ async function testSync() {
                         </div>
                         <div class="mb-3">
                             <span class="text-muted me-2">
-                                <i class="bi bi-film me-1"></i>${result.test_info?.title || title}
+                                <i class="bi bi-film me-1"></i>${result.data?.bgm_title || result.test_info?.title || title}
                             </span>
                             <span class="badge bg-secondary me-2">${result.test_info?.media_type === 'movie' ? '电影' : '剧集'}</span>
                             <span class="badge bg-secondary me-2">${result.test_info?.episode || 'S' + season.toString().padStart(2, '0') + 'E' + episode.toString().padStart(2, '0')}</span>

--- a/templates/records.html
+++ b/templates/records.html
@@ -193,7 +193,7 @@ function displayRecords(records) {
             <td class="col-hide-sm"><span class="badge rounded-pill bg-dark bg-opacity-75">${typeLabel}</span></td>
             <td class="col-hide-sm">${new Date(record.timestamp).toLocaleString()}</td>
             <td class="col-hide-sm">${record.user_name}</td>
-            <td>${record.title}</td>
+            <td>${record.bgm_title || record.title}</td>
             <td>S${record.season.toString().padStart(2, '0')}E${record.episode.toString().padStart(2, '0')}</td>
             <td><span class="badge rounded-pill bg-${getStatusColor(record.status)}">${getStatusText(record.status)}</span></td>
             <td class="col-hide-sm"><span class="badge rounded-pill tl-source--${getSourceTlClass(record.source)}">${record.source}</span></td>
@@ -402,13 +402,18 @@ async function showRecordDetail(recordId) {
                         <strong>用户:</strong> ${record.user_name}
                     </div>
                     <div class="col-md-6">
-                        <strong>番剧标题:</strong> ${record.title}
+                        <strong>番剧标题:</strong> ${record.bgm_title || record.title}
                     </div>
                 </div>
-                <details class="mt-2">
-                    <summary class="text-muted small" style="cursor:pointer">原始标题（点击展开）</summary>
-                    <div class="mt-1 small">${record.ori_title && String(record.ori_title).trim() ? record.ori_title : '无'}</div>
-                </details>
+                <div class="row mt-2">
+                    <div class="col-md-6">
+                        <strong>接收标题:</strong> ${record.title}
+                    </div>
+                    ${record.ori_title && String(record.ori_title).trim() ? `
+                    <div class="col-md-6">
+                        <strong>原始标题:</strong> ${record.ori_title}
+                    </div>` : ''}
+                </div>
                 <div class="row mt-2">
                     <div class="col-md-4">
                         <strong>季/集:</strong> S${record.season.toString().padStart(2, '0')}E${record.episode.toString().padStart(2, '0')}


### PR DESCRIPTION
## 📝 PR 描述

一直觉得`同步记录`的标题还有通知显示的是`接收标题`挺怪的，因为这样只能看到用户发出的标题，不能够看到真正同步的 Bangumi 标题
用户发出的标题是已知的因为用户知道他们正在看什么，但是程序同步的最终 Bangumi 标题（结果）是未知的，这会造成无法判断程序同步是否正确可靠也不方便纠错

<img width="1216" height="549" alt="image" src="https://github.com/user-attachments/assets/74085059-c3e5-40d6-a626-9923b65f4112" />

### 变更类型
✨ 新功能 (feature)

### 变更内容
将前端同步记录、通知消息中的标题从用户请求标题切换为 Bangumi 平台标题。

**后端** (`database.py`, `sync_service.py`, `notifier.py`)
- `sync_custom_item()` 通过实例缓存获取 Bangumi 条目 `name_cn`/`name`，
  传递给 `send_notify(bgm_title=...)` 和 `log_sync_record(bgm_title=...)`
- sync_records 表新增 `bgm_title` 列（自动迁移旧库，不回填历史数据）
- `bgm:` 前缀 info 日志优先展示 Bangumi 标题
- `ori_title` 为 None 时通知数据回退为空字符串

**前端** (`config.html`, `dashboard.html`, `debug.html`, `records.html`)
- 记录详情弹窗拆分标题为三个职责单一字段：
  - **番剧标题**：`bgm_title \|\| title`（Bangumi 平台名称）
  - **接收标题**：`title`（用户/媒体服务器请求标题，始终可见）
  - **原始标题**：`ori_title`（来源原文，仅非空显示）
- 通知配置面板新增 `{bgm_title}` 与 `{ori_title}` 变量说明
- 测试同步结果优先展示 `bgm_title`

### 相关 Issue

## 📋 提交前检查清单

### 规范与静态检查
- [x] `uv run ruff check .` 全部通过
- [x] `uv run ruff format --check .` 164 files already formatted
- [x] `uv run djlint templates/ --check` 0 files updated
- [ ] 无模板新增，不适用

### 测试
- [x] `uv run pytest tests/` 1752 passed
- [x] 现有功能未受影响
- [x] Webhook 接口契约不变，不影响 Plex/Emby/Jellyfin 接入

## 🔍 额外说明

### 修改范围（7 文件）
| 文件 | 改动 |
|------|------|
| `app/core/database.py` | sync_records 新增 bgm_title 列 + 迁移 |
| `app/services/sync_service.py` | bgm_title 获取/传递 + 日志 |
| `app/utils/notifier.py` | ori_title None 修复 |
| `templates/config.html` | 通知变量面板 |
| `templates/dashboard.html` | 记录详情 + 时间线标题 |
| `templates/debug.html` | 测试结果标题 |
| `templates/records.html` | 记录列表 + 详情标题 |

### API 调用
0 次额外请求（BangumiApi 实例缓存命中）。
