### PR TITLE
fix: 修复 bangumi-data 对纯英文查询词的误匹配

### DIFF
--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -399,7 +399,9 @@ class BangumiData:
                     # 如果找到完全匹配，可以提前退出（除非需要检查日期）
                     if not release_date or len(exact_matches) >= 3:
                         break
-            elif match_info["score"] > 0.4:
+            elif match_info["score"] > (
+                0.7 if match_info.get("english_cjk_match") else 0.4
+            ):
                 # 部分匹配
                 bangumi_id = self._extract_bangumi_id(item)
                 if bangumi_id:
@@ -689,6 +691,38 @@ class BangumiData:
 
         return False
 
+    @staticmethod
+    def _contains_cjk(item: dict) -> bool:
+        """检查条目标题或中文翻译是否包含 CJK 字符"""
+        if "title" in item and re.search(
+            r"[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff]", item["title"]
+        ):
+            return True
+        if "titleTranslate" in item and "zh-Hans" in item["titleTranslate"]:
+            for zh in item["titleTranslate"]["zh-Hans"]:
+                if re.search(r"[\u4e00-\u9fff]", zh):
+                    return True
+        return False
+
+    @staticmethod
+    def _is_token_contained(query: str, item: dict) -> bool:
+        """检查查询词是否作为独立 token（非粘附在 CJK 字符后）出现在条目标题中"""
+        q = query.lower()
+        targets: list[str] = []
+        if "titleTranslate" in item and "zh-Hans" in item["titleTranslate"]:
+            targets.extend(item["titleTranslate"]["zh-Hans"])
+        if "title" in item:
+            targets.append(item["title"])
+        for t in targets:
+            idx = t.lower().find(q)
+            if idx == -1:
+                continue
+            before_ok = idx == 0 or not t[idx - 1].isalpha()
+            after_ok = (idx + len(q)) == len(t) or not t[idx + len(q)].isalpha()
+            if before_ok and after_ok:
+                return True
+        return False
+
     def _date_diff(self, date1: str, date2: str) -> int:
         """计算两个日期之间的天数差"""
         try:
@@ -751,6 +785,20 @@ class BangumiData:
 
         # 如果没有完全匹配，计算模糊匹配分数
         score = 0.0
+
+        # 纯英文/数字搜索词对含 CJK 字符的标题做模糊匹配时，
+        # 仅因子串出现就会被包含检查和 fuzz.ratio 误判为匹配——
+        # 例如 "Friends" 是 "偶像活动Friends" 的粘附子串。
+        # 要求查询词作为独立 token（前后为非字母字符或起止位置）出现，
+        # 才能继续模糊匹配；否则返回 score=0 交由 API 搜索处理。
+        title_is_alphanumeric = bool(
+            re.fullmatch(r"[a-zA-Z0-9 ]+", (title or "").strip())
+        )
+        if title_is_alphanumeric and self._contains_cjk(item):
+            if not self._is_token_contained(title, item):
+                result["score"] = 0.0
+                return result
+            result["english_cjk_match"] = True
 
         # 中文翻译匹配得分
         if result["best_zh_score"] > 0:

--- a/tests/utils/test_bangumi_data_comprehensive.py
+++ b/tests/utils/test_bangumi_data_comprehensive.py
@@ -168,6 +168,61 @@ class TestBangumiDataMatching:
         assert result[0] == "123456"
         assert result[1] == "劇場版サンプル映画"
 
+    def test_contains_cjk_zh_hans(self):
+        """zh-Hans 包含中文时返回 True"""
+        item = {"titleTranslate": {"zh-Hans": ["偶像活动Friends"]}}
+        assert BangumiData._contains_cjk(item) is True
+
+    def test_contains_cjk_title(self):
+        """title 包含日文假名时返回 True"""
+        item = {"title": "たまゆら～hitotose～"}
+        assert BangumiData._contains_cjk(item) is True
+
+    def test_contains_cjk_pure_english(self):
+        """纯英文标题返回 False"""
+        item = {"title": "Friends"}
+        assert BangumiData._contains_cjk(item) is False
+
+    def test_is_token_contained_cjk_attached_rejected(self):
+        """CJK 字符粘附在查询词前时拒绝匹配"""
+        item = {"titleTranslate": {"zh-Hans": ["偶像活动Friends"]}}
+        assert BangumiData._is_token_contained("Friends", item) is False
+
+    def test_is_token_contained_space_separated_accepted(self):
+        """空格分隔时通过匹配"""
+        item = {"titleTranslate": {"zh-Hans": ["Aikatsu Friends!"]}}
+        assert BangumiData._is_token_contained("Friends", item) is True
+
+    def test_is_token_contained_exact_match_accepted(self):
+        """完全相同时通过匹配"""
+        item = {"titleTranslate": {"zh-Hans": ["Friends"]}}
+        assert BangumiData._is_token_contained("Friends", item) is True
+
+    def test_is_token_contained_symbol_separated_accepted(self):
+        """符号分隔时通过匹配"""
+        item = {"titleTranslate": {"zh-Hans": ["Surgical Friends～"]}}
+        assert BangumiData._is_token_contained("Friends", item) is True
+
+    def test_is_token_contained_slash_separated_accepted(self):
+        """斜杠分隔时通过匹配"""
+        item = {"title": "Fate/stay night"}
+        assert BangumiData._is_token_contained("Fate", item) is True
+
+    def test_is_token_contained_mid_word_rejected(self):
+        """嵌在单词中间时拒绝匹配"""
+        item = {"titleTranslate": {"zh-Hans": ["SchoolGirl"]}}
+        assert BangumiData._is_token_contained("Girl", item) is False
+
+    def test_is_token_contained_not_found(self):
+        """不包含查询词时返回 False"""
+        item = {"titleTranslate": {"zh-Hans": ["進撃の巨人"]}}
+        assert BangumiData._is_token_contained("Attack", item) is False
+
+    def test_is_token_contained_item_title(self):
+        """查询词作为独立 token 出现在 item.title 中"""
+        item = {"title": "Sword Art Online"}
+        assert BangumiData._is_token_contained("Sword", item) is True
+
 
 class TestBangumiDataTitle:
     """标题处理测试"""


### PR DESCRIPTION
## 📝 PR 描述

一个将问题复杂化的修复，待考量，可能不如直接将bangumi-data、bgm_search匹配阈值直接提高到0.7简单，但主要不知道提这么高会不会有极端情况被这样不小心过滤掉

遇到的问题主要是我在观看[老友记](https://bgm.tv/subject/3864)的时候，注意到使用Trakt同步如果不写映射规则，Trakt发送的title`Friends`会意外匹配上[漫研部～Surgical Friends～](https://bgm.tv/subject/196188)

这种标题包含匹配问题还真比较难修，Friends还是个通用单词🌿。目前是使用的下列方法，有点复杂化了

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
纯英文搜索词（如 Trakt 返回的 `Friends`）在 bangumi-data 中做模糊匹配时，
rapidfuzz.ratio 和字符串包含检查均会因子串同名而误判——

- `偶像活动Friends`（粘附子串）→ 得分 0.62
- `Surgical Friends～`（独立 token）→ 得分 0.65
- `拓麻歌子！ Miracle Friends` → 得分 0.45

导致 "Friends" 错误匹配到上述条目并被标记为看过。

新增双重防护，仅对纯英文 + CJK 标题场景生效：

1. **token 边界检查** — 查询词必须作为独立 token（前后为非字母字符或
   起止位置）出现在条目标题中。CJK 字符在 Unicode 中为字母类，因此
   `偶像活动Friends` 中 `Friends` 前邻 `动`（isalpha=True）被拒绝。

2. **阈值 0.4 → 0.7** — token 检查通过后，部分匹配分数须超过 0.7
   才采纳。`Surgical Friends～` 得分 0.65 < 0.7 被过滤。

### 相关 Issue


## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更（本次无，不适用）

### 测试
- [x] `uv run pytest tests/ -k "bangumi_data"` — 160 passed
- [x] 新增 11 个单元测试覆盖 `_contains_cjk` 与 `_is_token_contained`

## 🔍 额外说明

### 修改范围（2 文件）

**`app/utils/bangumi_data.py`** — 核心逻辑 (+49, -1)
- 新增 `_contains_cjk` 静态方法：判断条目是否含 CJK 字符
- 新增 `_is_token_contained` 静态方法：token 边界检查
- `_calculate_match_info`：模糊评分前添加 token 边界防护，通过后标记 `english_cjk_match`
- `_find_bangumi_id_optimized`：标记为 True 时阈值 0.4 → 0.7

**`tests/utils/test_bangumi_data_comprehensive.py`** — 测试 (+55)
- 3 个 `_contains_cjk` 测试
- 8 个 `_is_token_contained` 测试

### 三条防线

  token 边界（粘附子串）→ 拒绝
  ↓ 通过
  阈值 0.7（同名 token）→ 仅 0.65 → 拒绝
  ↓ 通过
  正常模糊匹配 → 原有逻辑