### PR TITLE
perf: 优化移动端仪表盘布局

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1810,6 +1810,16 @@ main.app-main > *:nth-child(12) {
     display: flex;
 }
 
+@media (max-width: 767.98px) {
+    .header-theme-colors {
+        right: 0;
+        left: auto;
+        flex-wrap: wrap;
+        width: min(9.25rem, calc(100vw - 1.5rem));
+        max-width: calc(100vw - 1.5rem);
+    }
+}
+
 .theme-color-dot {
     width: 20px;
     height: 20px;
@@ -2461,6 +2471,248 @@ main.app-main > *:nth-child(12) {
     min-width: 1.05rem;
     padding: 0.18em 0.38em;
     line-height: 1.1;
+}
+
+/* 仪表盘顶栏：统一控件高度与胶囊风格（PC / 移动共用基础） */
+.btn-toolbar:has(.header-theme-switcher) {
+    --dashboard-control-h: 2rem;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .header-theme-switcher {
+    display: flex;
+    align-items: center;
+    gap: 0.4375rem;
+    flex-shrink: 0;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__track {
+    --theme-toggle-h: var(--dashboard-control-h);
+    --theme-toggle-w: 3.25rem;
+    --theme-toggle-pad: 0.1875rem;
+    --theme-toggle-thumb: calc(var(--theme-toggle-h) - var(--theme-toggle-pad) * 2);
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: var(--theme-toggle-w);
+    height: var(--theme-toggle-h);
+    padding: var(--theme-toggle-pad);
+    border-radius: 999px;
+    background: var(--app-bg-card-header);
+    border: 1px solid var(--app-border);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+    box-sizing: border-box;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__icon {
+    font-size: 0.75rem;
+    top: 50%;
+    z-index: 1;
+    transition: opacity 0.22s ease, color 0.22s ease;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__icon--sun {
+    left: calc(var(--theme-toggle-pad) + var(--theme-toggle-thumb) / 2);
+    transform: translate(-50%, -50%);
+    color: #f59e0b;
+    opacity: 1;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__icon--moon {
+    right: calc(var(--theme-toggle-pad) + var(--theme-toggle-thumb) / 2);
+    left: auto;
+    transform: translate(50%, -50%);
+    color: #94a3b8;
+    opacity: 0;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule--dark .theme-toggle-capsule__icon--sun {
+    opacity: 0;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule--dark .theme-toggle-capsule__icon--moon {
+    opacity: 1;
+    color: #cbd5e1;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__thumb {
+    width: var(--theme-toggle-thumb);
+    height: var(--theme-toggle-thumb);
+    top: var(--theme-toggle-pad);
+    left: var(--theme-toggle-pad);
+    background: var(--app-bg-card);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12), 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule--dark .theme-toggle-capsule__thumb {
+    transform: translateX(calc(var(--theme-toggle-w) - var(--theme-toggle-pad) * 2 - var(--theme-toggle-thumb)));
+}
+
+.btn-toolbar:has(.header-theme-switcher) .header-theme-color-btn {
+    width: var(--dashboard-control-h);
+    height: var(--dashboard-control-h);
+    padding: 0;
+    border-radius: 999px;
+    border: 1px solid var(--app-border);
+    background: var(--app-bg-card-header);
+    justify-content: center;
+    box-shadow: none;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .header-theme-color-indicator {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .inbox-header-chip__track {
+    height: var(--dashboard-control-h);
+    min-height: var(--dashboard-control-h);
+    box-sizing: border-box;
+    gap: 0.4rem;
+    padding: 0 0.65rem 0 0.35rem;
+    align-items: center;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .inbox-header-chip__icon {
+    width: 1.375rem;
+    height: 1.375rem;
+    font-size: 0.8125rem;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-track {
+    height: var(--dashboard-control-h);
+    min-height: var(--dashboard-control-h);
+    box-sizing: border-box;
+    padding: 0 0.65rem 0 0.35rem;
+    gap: 0.4rem 0.5rem;
+    flex-wrap: nowrap;
+    border-radius: 999px;
+    box-shadow: none;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-icon {
+    width: 1.375rem;
+    height: 1.375rem;
+    font-size: 0.8125rem;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-version {
+    font-size: 0.8125rem;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-divider {
+    min-height: 0.875rem;
+    align-self: center;
+}
+
+.btn-toolbar:has(.header-theme-switcher) .app-version-banner__update--header-chip {
+    font-size: 0.6875rem;
+    padding: 0.15rem 0.5rem;
+    line-height: 1.2;
+}
+
+@media (max-width: 767.98px) {
+    main.app-main > .d-flex:has(.header-theme-switcher) {
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) auto auto auto;
+        grid-template-areas:
+            "pageTitle chipTheme chipColor chipInbox"
+            "pageVersion pageVersion pageVersion pageVersion";
+        gap: 0.75rem 0.4375rem;
+        align-items: center;
+        padding-bottom: 0.875rem;
+        margin-bottom: 1rem !important;
+        border-bottom: 1px solid var(--app-border);
+    }
+
+    main.app-main > .d-flex:has(.header-theme-switcher) > h1 {
+        grid-area: pageTitle;
+        margin-bottom: 0;
+        font-size: 1.5rem;
+        line-height: 1.25;
+        letter-spacing: -0.02em;
+    }
+
+    main.app-main > .d-flex:has(.header-theme-switcher) > .btn-toolbar {
+        display: contents;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .header-theme-switcher {
+        display: contents;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) {
+        --dashboard-control-h: 2.25rem;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule__track {
+        --theme-toggle-w: 3.625rem;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .theme-toggle-capsule {
+        grid-area: chipTheme;
+        justify-self: end;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .header-theme-palette-wrap {
+        grid-area: chipColor;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .inbox-dropdown {
+        grid-area: chipInbox;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .inbox-header-chip__track {
+        position: relative;
+        width: var(--dashboard-control-h);
+        gap: 0;
+        padding: 0;
+        justify-content: center;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .inbox-header-chip:hover .inbox-header-chip__track,
+    .btn-toolbar:has(.header-theme-switcher) .inbox-header-chip.show .inbox-header-chip__track {
+        transform: none;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .inbox-header-chip__badge {
+        position: absolute;
+        top: -0.15rem;
+        right: -0.15rem;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .app-version-banner--header-chip {
+        grid-area: pageVersion;
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-track {
+        display: flex;
+        width: 100%;
+        max-width: 100%;
+        height: auto;
+        min-height: var(--dashboard-control-h);
+        padding: 0.4375rem 0.75rem;
+        border-radius: 10px;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-track:hover {
+        transform: none;
+        box-shadow: none;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .app-version-banner__header-chip-label {
+        font-size: 0.625rem;
+    }
+
+    .btn-toolbar:has(.header-theme-switcher) .app-version-banner__update--header-chip {
+        margin-left: auto;
+        flex-shrink: 0;
+        padding: 0.2rem 0.55rem;
+    }
 }
 
 .inbox-panel__alert {

--- a/templates/base.html
+++ b/templates/base.html
@@ -397,9 +397,34 @@
             document.documentElement.style.colorScheme = theme === 'dark' ? 'dark' : 'light';
         }
 
+        function resetThemeColorsPosition() {
+            var el = document.getElementById('headerThemeColors');
+            if (el) el.style.transform = '';
+        }
+
         function toggleThemeColors() {
             var el = document.getElementById('headerThemeColors');
-            if (el) el.classList.toggle('show');
+            var btn = document.getElementById('themeColorBtn');
+            if (!el) return;
+            var willShow = !el.classList.contains('show');
+            el.classList.toggle('show');
+            resetThemeColorsPosition();
+            if (willShow && btn && window.matchMedia('(max-width: 767.98px)').matches) {
+                requestAnimationFrame(function () {
+                    var pad = 12;
+                    var panelRect = el.getBoundingClientRect();
+                    var shift = 0;
+                    if (panelRect.right > window.innerWidth - pad) {
+                        shift += window.innerWidth - pad - panelRect.right;
+                    }
+                    if (panelRect.left + shift < pad) {
+                        shift += pad - (panelRect.left + shift);
+                    }
+                    if (shift !== 0) {
+                        el.style.transform = 'translateX(' + shift + 'px)';
+                    }
+                });
+            }
         }
 
         // 点击外部关闭色盘
@@ -408,6 +433,7 @@
             var btn = document.getElementById('themeColorBtn');
             if (colors && btn && !colors.contains(e.target) && !btn.contains(e.target)) {
                 colors.classList.remove('show');
+                resetThemeColorsPosition();
             }
         });
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,12 +9,13 @@
                 data-bs-toggle="dropdown"
                 data-bs-auto-close="outside"
                 aria-expanded="false"
+                aria-label="收件箱"
                 title="公告与通知">
             <span class="inbox-header-chip__track">
                 <span class="inbox-header-chip__icon" aria-hidden="true">
                     <i class="bi bi-bell"></i>
                 </span>
-                <span class="inbox-header-chip__label">收件箱</span>
+                <span class="inbox-header-chip__label d-none d-md-inline">收件箱</span>
                 <span class="inbox-header-chip__badge badge rounded-pill bg-danger d-none"
                       id="inboxBadge">0</span>
             </span>


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化 (perf)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
优化仪表盘顶栏在移动端的布局与视觉一致性，解决新增收件箱后标题行横向溢出、控件高度不齐等问题。

- **移动端布局**：顶栏改为 Grid 两行结构——第一行标题 + 明暗切换 / 主题色 / 铃铛，第二行版本信息全宽展示
- **收件箱**：窄屏仅显示铃铛图标（`d-none d-md-inline`），补充 `aria-label`；角标绝对定位在图标右上角
- **控件统一**：明暗滑动胶囊、主题色按钮、收件箱、版本 chip 共用 `--dashboard-control-h`，PC 与移动端风格一致
- **明暗胶囊**：用 CSS 变量重算滑块行程与图标位置，滑动更自然
- **主题色盘**：移动端支持换行与视口宽度限制；打开时用 JS 钳制位置，避免超出屏幕左右边缘

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
