### PR TITLE
fix: 修复windows存在多py环境时一键升级后可能无法启动的问题

### DIFF
--- a/app/services/upgrade_service.py
+++ b/app/services/upgrade_service.py
@@ -519,6 +519,14 @@ class UpgradeService:
 
     def _install_deps(self):
         """安装 Python 依赖"""
+        from ..utils.runtime_python import persist_runtime_python
+
+        # 写入当前解释器路径，供 start.bat 在升级重启时使用同一 Python
+        try:
+            persist_runtime_python()
+        except Exception as e:
+            logger.warning(f"[升级] 记录运行时 Python 路径失败: {e}")
+
         proxy = self._get_proxy()
         cmd = [
             sys.executable,
@@ -626,8 +634,8 @@ class UpgradeService:
 def restart_application():
     """重启应用进程
 
-    Windows 优先使用 start.bat（保留用户自定义端口等配置），
-    不存在时回退到 python -m uvicorn。
+    Windows 优先使用 start.bat（与手动启动一致），
+    依赖 data/runtime_python.txt 确保与 pip 安装使用同一解释器。
     Linux/macOS 使用 os.execv 替换当前进程。
     """
     logger.info("正在重启应用...")

--- a/app/utils/runtime_python.py
+++ b/app/utils/runtime_python.py
@@ -1,0 +1,14 @@
+"""记录直装模式下实际运行应用的 Python 解释器路径。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+RUNTIME_PYTHON_FILE = Path("data/runtime_python.txt")
+
+
+def persist_runtime_python() -> None:
+    """将当前解释器路径写入 data/runtime_python.txt，供 start.bat 复用。"""
+    RUNTIME_PYTHON_FILE.parent.mkdir(parents=True, exist_ok=True)
+    RUNTIME_PYTHON_FILE.write_text(sys.executable, encoding="utf-8")

--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,10 @@
 @echo off
 chcp 65001 >nul
-py -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-access-log
-if errorlevel 1 pause 
+if exist "data\runtime_python.txt" goto use_runtime
+python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-access-log
+goto done
+:use_runtime
+set /p RUNTIME_PY=<data\runtime_python.txt
+"%RUNTIME_PY%" -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-access-log
+:done
+if errorlevel 1 pause

--- a/tests/services/test_upgrade_service.py
+++ b/tests/services/test_upgrade_service.py
@@ -677,19 +677,21 @@ class TestInstallDeps:
     """_install_deps 测试"""
 
     def test_install_deps_success(self, upgrade_service, tmp_path, monkeypatch):
-        """依赖安装成功"""
+        """依赖安装成功，并记录运行时 Python 路径"""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "requirements.txt").write_text("fastapi")
 
         with (
             patch("app.services.upgrade_service.subprocess.run") as mock_run,
             patch("app.services.upgrade_service.config_manager") as mock_config,
+            patch("app.utils.runtime_python.persist_runtime_python") as mock_persist,
         ):
             mock_run.return_value = MagicMock(returncode=0, stderr="")
             mock_config.get.return_value = ""
 
-            # 不应抛出异常
             upgrade_service._install_deps()
+
+        mock_persist.assert_called_once()
 
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
@@ -853,7 +855,9 @@ class TestRestartApplication:
     ):
         """Windows 下有 start.bat 时应优先使用"""
         monkeypatch.chdir(tmp_path)
-        (tmp_path / "start.bat").write_text("uvicorn app.main:app --port 9000\npause")
+        (tmp_path / "start.bat").write_text(
+            "python -m uvicorn app.main:app --port 9000\npause"
+        )
 
         with (
             patch("app.services.upgrade_service.database_manager") as mock_db,


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
修复 Windows 直装下一键升级后重启报 `ModuleNotFoundError` 的问题：升级时用当前服务进程的 Python 安装依赖，但 `start.bat` 通过 `py -m` 启动可能选中另一个解释器，导致新依赖（如 `bleach`）未安装到实际启动环境中。

- 升级装依赖前将当前解释器路径写入 `data/runtime_python.txt`
- `start.bat` 优先读取该文件启动，否则回退为 `python -m uvicorn`（不再使用 `py -m`）

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
