### PR TITLE
perf: 优化版本信息展示

### DIFF
--- a/app/api/app_release.py
+++ b/app/api/app_release.py
@@ -16,9 +16,11 @@ from pydantic import BaseModel, Field
 from ..core.app_version import get_display_version, get_version
 from ..services.upgrade_service import upgrade_service
 from ..utils.github_release import (
+    LatestReleaseResult,
     ReleaseListItem,
     fetch_latest_release,
     fetch_newer_releases_than,
+    fetch_releases_in_minor_line,
     strip_tag_for_semver,
 )
 from ..utils.release_markdown import markdown_to_safe_html
@@ -91,7 +93,7 @@ class ReleaseInfoResponse(BaseModel):
 
     release_history: list[NewerReleaseItem] = Field(
         default_factory=list,
-        description="当 newer_releases 为空（已是最新）时，仅含远端 latest 一条发行说明",
+        description="当 newer_releases 为空（已是最新）时，含同 minor 线（如 3.11.x）全部发行说明",
     )
 
     releases_fetch_error: Optional[str] = Field(
@@ -146,6 +148,79 @@ def _merge_latest_if_missing(
             published_at=gh_published,
         )
     )
+
+
+def _to_newer_models(items: list[ReleaseListItem]) -> list[NewerReleaseItem]:
+    return [
+        NewerReleaseItem(
+            semver=it.semver,
+            version_display=get_display_version(it.semver),
+            tag_name=it.tag_name,
+            title=it.name,
+            body_html=markdown_to_safe_html(it.body),
+            html_url=it.html_url,
+            published_at=it.published_at,
+        )
+        for it in items
+    ]
+
+
+def _ensure_latest_in_list(
+    items: list[ReleaseListItem],
+    *,
+    latest_sem: str,
+    gh_tag: str | None,
+    gh_html: str | None,
+    gh_name: str | None,
+    gh_body: str | None,
+    gh_published: str | None,
+) -> None:
+    """当 minor 线列表分页未包含 latest 时，用 releases/latest 补一条。"""
+
+    if not latest_sem or not gh_tag:
+        return
+
+    if any(x.semver == latest_sem for x in items):
+        return
+
+    items.append(
+        ReleaseListItem(
+            tag_name=gh_tag,
+            semver=latest_sem,
+            html_url=gh_html,
+            name=gh_name,
+            body=gh_body,
+            published_at=gh_published,
+        )
+    )
+    items.sort(key=lambda x: version_sort_key(x.semver), reverse=True)
+
+
+def _single_latest_history_item(
+    gh: LatestReleaseResult,
+    *,
+    latest: str,
+    latest_disp: str | None,
+) -> list[NewerReleaseItem]:
+    tag_name = gh.tag_name or ""
+    if not tag_name.strip():
+        return []
+
+    sem = (latest or "").strip() or strip_tag_for_semver(tag_name)
+    if not sem:
+        sem = tag_name.strip().lstrip("vV") or "unknown"
+    disp = latest_disp or get_display_version(sem)
+    return [
+        NewerReleaseItem(
+            semver=sem,
+            version_display=disp,
+            tag_name=tag_name.strip(),
+            title=gh.name,
+            body_html=markdown_to_safe_html(gh.body),
+            html_url=gh.html_url,
+            published_at=gh.published_at,
+        )
+    ]
 
 
 @router.get("/app/release-info", response_model=ReleaseInfoResponse)
@@ -212,36 +287,36 @@ async def release_info(
 
     newer_raw.sort(key=lambda x: version_sort_key(x.semver), reverse=True)
 
-    newer_models = [
-        NewerReleaseItem(
-            semver=it.semver,
-            version_display=get_display_version(it.semver),
-            tag_name=it.tag_name,
-            title=it.name,
-            body_html=markdown_to_safe_html(it.body),
-            html_url=it.html_url,
-            published_at=it.published_at,
-        )
-        for it in newer_raw
-    ]
+    newer_models = _to_newer_models(newer_raw)
 
     release_history_models: list[NewerReleaseItem] = []
+    history_fetch_err: str | None = None
     if not newer_models and (gh.tag_name or "").strip():
-        sem = (latest or "").strip() or strip_tag_for_semver(gh.tag_name or "")
-        if not sem:
-            sem = (gh.tag_name or "").strip().lstrip("vV") or "unknown"
-        disp = latest_disp or get_display_version(sem)
-        release_history_models = [
-            NewerReleaseItem(
-                semver=sem,
-                version_display=disp,
-                tag_name=(gh.tag_name or "").strip(),
-                title=gh.name,
-                body_html=markdown_to_safe_html(gh.body),
-                html_url=gh.html_url,
-                published_at=gh.published_at,
+        reference = (latest or "").strip() or current_cmp
+        history_raw: list[ReleaseListItem] = []
+        if reference:
+            history_raw, history_fetch_err = await fetch_releases_in_minor_line(
+                reference
             )
-        ]
+            _ensure_latest_in_list(
+                history_raw,
+                latest_sem=latest,
+                gh_tag=gh.tag_name,
+                gh_html=gh.html_url,
+                gh_name=gh.name,
+                gh_body=gh.body,
+                gh_published=gh.published_at,
+            )
+        if history_raw:
+            release_history_models = _to_newer_models(history_raw)
+        else:
+            release_history_models = _single_latest_history_item(
+                gh, latest=latest, latest_disp=latest_disp
+            )
+
+    releases_fetch_error = (
+        history_fetch_err or list_err if not newer_models else list_err
+    )
 
     return ReleaseInfoResponse(
         current_version=current,
@@ -258,7 +333,7 @@ async def release_info(
         updates_behind=len(newer_models),
         newer_releases=newer_models,
         release_history=release_history_models,
-        releases_fetch_error=list_err,
+        releases_fetch_error=releases_fetch_error,
         environment=env,
         upgrade_available=upgrade_service.is_upgrade_capable(),
     )

--- a/app/utils/github_release.py
+++ b/app/utils/github_release.py
@@ -11,7 +11,12 @@ from typing import Any
 import httpx
 
 from ..core.logging import logger
-from .semver_util import is_strictly_newer, version_sort_key
+from .semver_util import (
+    is_strictly_newer,
+    minor_version_line,
+    same_minor_line,
+    version_sort_key,
+)
 
 GITHUB_LATEST_URL = (
     "https://api.github.com/repos/SanaeMio/Bangumi-syncer/releases/latest"
@@ -32,6 +37,11 @@ _cache_etag: str | None = None
 _releases_cache_key: str | None = None
 _releases_cache_data: tuple[list[ReleaseListItem], str | None] | None = None
 _releases_cache_expires: float = 0.0
+
+# fetch_releases_in_minor_line 缓存
+_minor_line_cache_key: str | None = None
+_minor_line_cache_data: tuple[list[ReleaseListItem], str | None] | None = None
+_minor_line_cache_expires: float = 0.0
 
 
 @dataclass
@@ -162,12 +172,16 @@ def clear_github_release_cache() -> None:
     """测试用。"""
     global _cache_body, _cache_expires_monotonic, _cache_etag
     global _releases_cache_key, _releases_cache_data, _releases_cache_expires
+    global _minor_line_cache_key, _minor_line_cache_data, _minor_line_cache_expires
     _cache_body = None
     _cache_expires_monotonic = 0.0
     _cache_etag = None
     _releases_cache_key = None
     _releases_cache_data = None
     _releases_cache_expires = 0.0
+    _minor_line_cache_key = None
+    _minor_line_cache_data = None
+    _minor_line_cache_expires = 0.0
 
 
 def strip_tag_for_semver(tag_name: str) -> str:
@@ -274,4 +288,92 @@ async def fetch_newer_releases_than(
     _releases_cache_key = current_semver
     _releases_cache_data = result
     _releases_cache_expires = time.monotonic() + CACHE_TTL_SEC
+    return result
+
+
+def _minor_line_cache_storage_key(reference_semver: str) -> str:
+    maj, mino = minor_version_line(reference_semver)
+    return f"minor:{maj}.{mino}"
+
+
+def _dedupe_and_sort_releases(items: list[ReleaseListItem]) -> list[ReleaseListItem]:
+    by_sem: dict[str, ReleaseListItem] = {}
+    for it in items:
+        by_sem[it.semver] = it
+    uniq = list(by_sem.values())
+    uniq.sort(key=lambda x: version_sort_key(x.semver), reverse=True)
+    return uniq
+
+
+async def fetch_releases_in_minor_line(
+    reference_semver: str,
+    *,
+    max_pages: int = 5,
+    per_page: int = 30,
+) -> tuple[list[ReleaseListItem], str | None]:
+    """
+    拉取 GitHub releases 分页列表，返回与 reference 同 minor 线（如 3.11.x）的条目，
+    按版本号从新到旧排序。
+    """
+    global _minor_line_cache_key, _minor_line_cache_data, _minor_line_cache_expires
+    cache_key = _minor_line_cache_storage_key(reference_semver)
+    now = time.monotonic()
+    if (
+        _minor_line_cache_key == cache_key
+        and _minor_line_cache_data is not None
+        and now < _minor_line_cache_expires
+    ):
+        return _minor_line_cache_data
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": GITHUB_USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    collected: list[ReleaseListItem] = []
+    try:
+        async with httpx.AsyncClient(timeout=RELEASES_LIST_TIMEOUT) as client:
+            for page in range(1, max_pages + 1):
+                r = await client.get(
+                    GITHUB_RELEASES_URL,
+                    headers=headers,
+                    params={"page": page, "per_page": per_page},
+                )
+                if r.status_code == 403:
+                    return (
+                        collected,
+                        "无法拉取发行列表（可能触发 GitHub API 限流）",
+                    )
+                if r.status_code != 200:
+                    return (
+                        collected,
+                        f"发行列表请求失败（HTTP {r.status_code}）",
+                    )
+                try:
+                    arr = r.json()
+                except ValueError:
+                    return collected, "发行列表响应不是合法 JSON"
+                if not isinstance(arr, list) or not arr:
+                    break
+                for row in arr:
+                    item = _parse_release_row(row)
+                    if item is None:
+                        continue
+                    try:
+                        if same_minor_line(item.semver, reference_semver):
+                            collected.append(item)
+                    except Exception:
+                        continue
+                if len(arr) < per_page:
+                    break
+    except httpx.TimeoutException:
+        return collected, "拉取发行列表超时"
+    except httpx.RequestError as e:
+        return collected, f"拉取发行列表网络错误: {e}"
+
+    uniq = _dedupe_and_sort_releases(collected)
+    result = (uniq, None)
+    _minor_line_cache_key = cache_key
+    _minor_line_cache_data = result
+    _minor_line_cache_expires = time.monotonic() + CACHE_TTL_SEC
     return result

--- a/app/utils/semver_util.py
+++ b/app/utils/semver_util.py
@@ -95,3 +95,14 @@ def is_less_than(a: str, b: str) -> bool:
 def is_strictly_newer(remote: str, base: str) -> bool:
     """若 remote 严格晚于 base（即 base < remote）。"""
     return is_less_than(base, remote)
+
+
+def minor_version_line(v: str) -> tuple[int, int]:
+    """主.次 号段，用于判断同 minor 线（如 3.11.x）。"""
+    maj, mino, _ = version_tuple(v)
+    return (maj, mino)
+
+
+def same_minor_line(a: str, b: str) -> bool:
+    """两版本是否处于同一 minor 线（忽略 patch 与预发布）。"""
+    return minor_version_line(a) == minor_version_line(b)

--- a/tests/api/test_app_release_api.py
+++ b/tests/api/test_app_release_api.py
@@ -1,10 +1,14 @@
-"""release-info：已是最新时 release_history 仅含 latest 一条。"""
+"""release-info：已是最新时 release_history 含同 minor 线全部发行说明。"""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.api.app_release import _merge_latest_if_missing, release_info
+from app.api.app_release import (
+    _ensure_latest_in_list,
+    _merge_latest_if_missing,
+    release_info,
+)
 from app.utils.github_release import LatestReleaseResult, ReleaseListItem
 
 
@@ -33,7 +37,62 @@ async def test_release_info_github_latest_failed():
 
 
 @pytest.mark.asyncio
-async def test_release_history_single_latest_when_no_newer():
+async def test_release_history_minor_line_when_no_newer():
+    gh = LatestReleaseResult(
+        ok=True,
+        tag_name="v3.11.1",
+        html_url="https://github.com/example/r",
+        name="Release 3.11.1",
+        body="## 3.11.1\npatch",
+        published_at="2024-02-01T00:00:00Z",
+    )
+    minor_rows = [
+        ReleaseListItem(
+            tag_name="v3.11.1",
+            semver="3.11.1",
+            html_url="https://github.com/example/3111",
+            name="Release 3.11.1",
+            body="## 3.11.1\npatch",
+            published_at="2024-02-01T00:00:00Z",
+        ),
+        ReleaseListItem(
+            tag_name="v3.11.0",
+            semver="3.11.0",
+            html_url="https://github.com/example/3110",
+            name="Release 3.11.0",
+            body="## 3.11.0\nbase",
+            published_at="2024-01-01T00:00:00Z",
+        ),
+    ]
+
+    with patch("app.api.app_release.get_version", return_value="3.11.1"):
+        with patch(
+            "app.api.app_release.fetch_latest_release",
+            new_callable=AsyncMock,
+            return_value=gh,
+        ):
+            with patch(
+                "app.api.app_release.fetch_newer_releases_than",
+                new_callable=AsyncMock,
+                return_value=([], None),
+            ):
+                with patch(
+                    "app.api.app_release.fetch_releases_in_minor_line",
+                    new_callable=AsyncMock,
+                    return_value=(minor_rows, None),
+                ):
+                    out = await release_info(user={"username": "u"})
+
+    assert out.remote_loaded is True
+    assert out.newer_releases == []
+    assert len(out.release_history) == 2
+    assert [x.semver for x in out.release_history] == ["3.11.1", "3.11.0"]
+    assert "patch" in out.release_history[0].body_html
+    assert "base" in out.release_history[1].body_html
+
+
+@pytest.mark.asyncio
+async def test_release_history_fallback_single_latest_when_minor_fetch_empty():
     gh = LatestReleaseResult(
         ok=True,
         tag_name="v2.0.0",
@@ -54,13 +113,19 @@ async def test_release_history_single_latest_when_no_newer():
                 new_callable=AsyncMock,
                 return_value=([], None),
             ):
-                out = await release_info(user={"username": "u"})
+                with patch(
+                    "app.api.app_release.fetch_releases_in_minor_line",
+                    new_callable=AsyncMock,
+                    return_value=([], "拉取发行列表超时"),
+                ):
+                    out = await release_info(user={"username": "u"})
 
     assert out.remote_loaded is True
     assert out.newer_releases == []
     assert len(out.release_history) == 1
     assert out.release_history[0].tag_name == "v2.0.0"
     assert "b" in out.release_history[0].body_html
+    assert out.releases_fetch_error == "拉取发行列表超时"
 
 
 @pytest.mark.asyncio
@@ -82,7 +147,7 @@ async def test_release_history_empty_when_newer_exists():
         published_at=None,
     )
 
-    with patch("app.api.app_release.get_version", return_value="1.0.0"):
+    with patch("app.api.app_release.get_version", return_value="2.0.0"):
         with patch(
             "app.api.app_release.fetch_latest_release",
             new_callable=AsyncMock,
@@ -93,10 +158,15 @@ async def test_release_history_empty_when_newer_exists():
                 new_callable=AsyncMock,
                 return_value=([row], None),
             ):
-                out = await release_info(user={"username": "u"})
+                with patch(
+                    "app.api.app_release.fetch_releases_in_minor_line",
+                    new_callable=AsyncMock,
+                ) as minor_mock:
+                    out = await release_info(user={"username": "u"})
 
     assert len(out.newer_releases) == 1
     assert out.release_history == []
+    minor_mock.assert_not_called()
 
 
 def test_merge_latest_if_missing_noop_when_latest_sem_or_tag_empty():
@@ -198,6 +268,52 @@ def test_merge_latest_if_missing_appends_when_absent():
     assert items[0].tag_name == "v2.0.0"
 
 
+def test_ensure_latest_in_list_appends_when_absent():
+    items = [
+        ReleaseListItem(
+            tag_name="v3.11.0",
+            semver="3.11.0",
+            html_url=None,
+            name=None,
+            body=None,
+            published_at=None,
+        )
+    ]
+    _ensure_latest_in_list(
+        items,
+        latest_sem="3.11.1",
+        gh_tag="v3.11.1",
+        gh_html="https://r",
+        gh_name="T",
+        gh_body="## Hi",
+        gh_published="2026-01-01T00:00:00Z",
+    )
+    assert [x.semver for x in items] == ["3.11.1", "3.11.0"]
+
+
+def test_ensure_latest_in_list_noop_when_present():
+    items = [
+        ReleaseListItem(
+            tag_name="v3.11.1",
+            semver="3.11.1",
+            html_url=None,
+            name=None,
+            body=None,
+            published_at=None,
+        )
+    ]
+    _ensure_latest_in_list(
+        items,
+        latest_sem="3.11.1",
+        gh_tag="v3.11.1",
+        gh_html=None,
+        gh_name=None,
+        gh_body=None,
+        gh_published=None,
+    )
+    assert len(items) == 1
+
+
 @pytest.mark.asyncio
 async def test_release_info_update_available_none_when_compare_raises():
     gh = LatestReleaseResult(
@@ -250,7 +366,12 @@ async def test_release_history_unknown_semver_when_tag_is_only_v_prefix():
                 new_callable=AsyncMock,
                 return_value=([], None),
             ):
-                out = await release_info(user={"username": "u"})
+                with patch(
+                    "app.api.app_release.fetch_releases_in_minor_line",
+                    new_callable=AsyncMock,
+                    return_value=([], None),
+                ):
+                    out = await release_info(user={"username": "u"})
 
     assert len(out.release_history) == 1
     assert out.release_history[0].semver == "unknown"

--- a/tests/utils/test_github_release_respx.py
+++ b/tests/utils/test_github_release_respx.py
@@ -405,3 +405,95 @@ async def test_fetch_newer_releases_than_connect_error():
     items, err = await github_release.fetch_newer_releases_than("1.0.0")
     assert items == []
     assert err and "网络错误" in err
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_releases_in_minor_line_filters_and_orders():
+    rel_json = [
+        {
+            "tag_name": "v3.12.0",
+            "draft": False,
+            "html_url": "https://example.com/3120",
+            "name": "3120",
+            "body": "",
+            "published_at": None,
+        },
+        {
+            "tag_name": "v3.11.1",
+            "draft": False,
+            "html_url": "https://example.com/3111",
+            "name": "3111",
+            "body": "",
+            "published_at": None,
+        },
+        {
+            "tag_name": "v3.11.0",
+            "draft": False,
+            "html_url": "https://example.com/3110",
+            "name": "3110",
+            "body": "",
+            "published_at": None,
+        },
+        {
+            "tag_name": "v3.10.5",
+            "draft": False,
+            "html_url": "https://example.com/3105",
+            "name": "3105",
+            "body": "",
+            "published_at": None,
+        },
+    ]
+    respx.get(url=re.compile(r".*/Bangumi-syncer/releases\?.*")).mock(
+        return_value=httpx.Response(200, json=rel_json)
+    )
+    items, err = await github_release.fetch_releases_in_minor_line("3.11.1")
+    assert err is None
+    assert [x.semver for x in items] == ["3.11.1", "3.11.0"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_releases_in_minor_line_403_returns_partial_error():
+    respx.get(url=re.compile(r".*/Bangumi-syncer/releases\?.*")).mock(
+        return_value=httpx.Response(403)
+    )
+    items, err = await github_release.fetch_releases_in_minor_line("3.11.1")
+    assert items == []
+    assert err and "限流" in err
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_releases_in_minor_line_timeout():
+    respx.get(url=re.compile(r".*/Bangumi-syncer/releases\?.*")).mock(
+        side_effect=httpx.TimeoutException("t")
+    )
+    items, err = await github_release.fetch_releases_in_minor_line("3.11.1")
+    assert items == []
+    assert err and "超时" in err
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_releases_in_minor_line_second_call_uses_cache():
+    route = respx.get(url=re.compile(r".*/Bangumi-syncer/releases\?.*")).mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "tag_name": "v3.11.1",
+                    "draft": False,
+                    "html_url": "https://example.com/a",
+                    "name": "a",
+                    "body": "",
+                    "published_at": None,
+                }
+            ],
+        )
+    )
+    r1, _ = await github_release.fetch_releases_in_minor_line("3.11.1")
+    r2, _ = await github_release.fetch_releases_in_minor_line("3.11.0")
+    assert len(r1) == 1
+    assert len(r2) == 1
+    assert route.call_count == 1

--- a/tests/utils/test_semver_util.py
+++ b/tests/utils/test_semver_util.py
@@ -98,3 +98,11 @@ def test_split_core_prerelease_trailing_hyphen_returns_full_string():
 
 def test_prerelease_segment_key_empty_segment():
     assert semver_util._prerelease_segment_key("") == (1, "")
+
+
+def test_minor_version_line_and_same_minor_line():
+    assert semver_util.minor_version_line("3.11.1") == (3, 11)
+    assert semver_util.minor_version_line("v3.11.0-rc.1") == (3, 11)
+    assert semver_util.same_minor_line("3.11.1", "3.11.0") is True
+    assert semver_util.same_minor_line("3.11.1", "3.10.5") is False
+    assert semver_util.same_minor_line("3.11.1", "3.12.0") is False


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化 (perf)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
当用户已运行远端 latest 版本时，发行说明 Modal 不再只展示一条 latest Release，而是展示**同一 minor 线**（如 v3.11.x）下的全部 GitHub Release 说明（含补丁与预发布），按版本从新到旧排列。

- **后端**：新增 `fetch_releases_in_minor_line`，在 `release-info` 接口的 `release_history` 中返回同 minor 线列表；拉取失败或结果为空时仍回退为仅展示 latest 一条
- **semver**：新增 `minor_version_line` / `same_minor_line` 用于 minor 线判断
- **前端**：无需改动，沿用现有 `release_history` fallback 与卡片渲染逻辑
- **测试**：补充 API、GitHub 拉取与 semver 相关单测

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
