### PR TITLE
fix: Trakt 同步因 get_movie_info 缺少 extended=full 导致电影类型过滤失效

### DIFF
--- a/app/services/trakt/client.py
+++ b/app/services/trakt/client.py
@@ -353,26 +353,32 @@ class TraktClient:
         """获取电影详细信息"""
         try:
             endpoint = f"/movies/{trakt_id}"
-
-            data = await self._make_request("GET", endpoint)
+            params = {"extended": "full"}
+            data = await self._make_request("GET", endpoint, params)
 
             return data if isinstance(data, dict) else None
 
         except Exception as e:
-            logger.error(f"获取电影信息失败: {e}")
+            logger.error(f"获取电影 {trakt_id} 信息失败: {e}")
             return None
 
-    async def get_show_info(self, trakt_id: int) -> Optional[dict]:
-        """获取剧集详细信息"""
+    async def get_show_info(self, trakt_id: str) -> Optional[dict]:
+        """获取剧集完整元数据（包含 original_title、genres 等精简接口不返回的字段）
+
+        Args:
+            trakt_id: Trakt 剧集 ID 或 slug
+
+        Returns:
+            剧集详情 dict，失败时返回 None
+        """
         try:
             endpoint = f"/shows/{trakt_id}"
-
-            data = await self._make_request("GET", endpoint)
+            params = {"extended": "full"}
+            data = await self._make_request("GET", endpoint, params)
 
             return data if isinstance(data, dict) else None
-
         except Exception as e:
-            logger.error(f"获取剧集信息失败: {e}")
+            logger.error(f"获取剧集 {trakt_id} 信息失败: {e}")
             return None
 
     async def get_episode_info(
@@ -398,24 +404,6 @@ class TraktClient:
         except Exception as e:
             logger.error(f"测试 Trakt 连接失败: {e}")
             return False
-
-    async def get_show_details(self, trakt_id: str) -> Optional[dict]:
-        """获取节目完整元数据（包含 original_title 等精简接口不返回的字段）
-
-        Args:
-            trakt_id: Trakt 节目 ID 或 slug
-
-        Returns:
-            节目详情 dict，失败时返回 None
-        """
-        try:
-            endpoint = f"/shows/{trakt_id}"
-            params = {"extended": "full"}
-            data = await self._make_request("GET", endpoint, params)
-            return data if isinstance(data, dict) else None
-        except Exception as e:
-            logger.debug(f"获取节目 {trakt_id} 详情失败: {e}")
-            return None
 
 
 # ===== 客户端工厂 =====

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -268,7 +268,7 @@ class TraktSyncService:
                 tid = str(trakt_id)
                 if need_details and tid not in show_original_titles:
                     if item.type == "episode":
-                        details_resp = await client.get_show_details(tid)
+                        details_resp = await client.get_show_info(tid)
                         if details_resp:
                             ot = details_resp.get("original_title")
                             if ot:

--- a/tests/trakt/test_client_http.py
+++ b/tests/trakt/test_client_http.py
@@ -151,7 +151,7 @@ async def test_get_collection(mock_config):
 @respx.mock
 async def test_get_movie_info(mock_config):
     """测试获取电影信息"""
-    mock_route = respx.get("https://api.trakt.tv/movies/123").mock(
+    mock_route = respx.get("https://api.trakt.tv/movies/123?extended=full").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -179,8 +179,8 @@ async def test_get_movie_info(mock_config):
 @pytest.mark.asyncio
 @respx.mock
 async def test_get_show_info(mock_config):
-    """测试获取剧集信息"""
-    mock_route = respx.get("https://api.trakt.tv/shows/123").mock(
+    """测试获取剧集完整信息"""
+    mock_route = respx.get("https://api.trakt.tv/shows/123?extended=full").mock(
         return_value=httpx.Response(
             200,
             json={

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -495,8 +495,8 @@ def test_convert_trakt_history_all_fallback_fail_returns_none():
 
 
 @pytest.mark.asyncio
-async def test_get_show_details_returns_original_title():
-    """get_show_details 应返回包含 original_title 的完整节目数据"""
+async def test_get_show_info_returns_original_title():
+    """get_show_info 应返回包含 original_title 的完整节目数据"""
     from app.services.trakt.client import TraktClient
 
     client = TraktClient("fake_token")
@@ -507,19 +507,19 @@ async def test_get_show_details_returns_original_title():
         "original_title": "進撃の巨人",
     }
     with patch.object(client, "_make_request", new=AsyncMock(return_value=mock_resp)):
-        result = await client.get_show_details("1396")
+        result = await client.get_show_info("1396")
         assert result is not None
         assert result["original_title"] == "進撃の巨人"
 
 
 @pytest.mark.asyncio
-async def test_get_show_details_returns_none_on_failure():
-    """get_show_details 在请求失败时应返回 None"""
+async def test_get_show_info_returns_none_on_failure():
+    """get_show_info 在请求失败时应返回 None"""
     from app.services.trakt.client import TraktClient
 
     client = TraktClient("fake_token")
     with patch.object(client, "_make_request", new=AsyncMock(return_value=None)):
-        result = await client.get_show_details("999999")
+        result = await client.get_show_info("999999")
         assert result is None
 
 
@@ -555,8 +555,8 @@ async def test_genre_filter_skips_non_anime_episode():
         )
         client = MagicMock()
         client.get_all_watched_history = AsyncMock(return_value=[episode_item])
-        # get_show_details 返回非动画 genre
-        client.get_show_details = AsyncMock(
+        # get_show_info 返回非动画 genre
+        client.get_show_info = AsyncMock(
             return_value={"genres": ["science-fiction", "mystery", "drama"]}
         )
         cfg = MagicMock()
@@ -600,7 +600,7 @@ async def test_genre_filter_allows_anime_episode():
         )
         client = MagicMock()
         client.get_all_watched_history = AsyncMock(return_value=[episode_item])
-        client.get_show_details = AsyncMock(
+        client.get_show_info = AsyncMock(
             return_value={
                 "genres": ["anime", "action", "fantasy"],
                 "original_title": "進撃の巨人",
@@ -647,7 +647,7 @@ async def test_genre_filter_disabled_allows_non_anime():
         )
         client = MagicMock()
         client.get_all_watched_history = AsyncMock(return_value=[episode_item])
-        client.get_show_details = AsyncMock(return_value=None)
+        client.get_show_info = AsyncMock(return_value=None)
         cfg = MagicMock()
         cfg.last_sync_time = None
         cfg.sync_filter_enabled = False
@@ -688,7 +688,7 @@ async def test_genre_filter_mapping_bypass():
         )
         client = MagicMock()
         client.get_all_watched_history = AsyncMock(return_value=[episode_item])
-        client.get_show_details = AsyncMock(
+        client.get_show_info = AsyncMock(
             return_value={"genres": ["science-fiction", "mystery"]}
         )
         cfg = MagicMock()


### PR DESCRIPTION

## 📝 PR 描述

我是笨b还是审查少了（）
- 类型过滤之前只验证了剧集，没想到电影是坏的因为请求的时候没有携带`?extended=full`导致拿不到类型字段

- PR #165 
新增了多余的`get_show_details()`方法，造成原本同业务方法变成死代码，本次整理了下


### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
`get_movie_info` 缺少 `?extended=full`，导致电影路径无 `genres` 数据，
Trakt 类型过滤对电影始终失效（`genres` 为空列表，`if genres` 跳过过滤）。

修复同时清理了 `client.py` 中的死代码：
- `get_show_info`（旧，无 `extended`，零调用方）与 `get_show_details`（含 `extended`，
  被 `sync_service` 调用）是同一 `/shows/{id}` 端点的重复实现。将后者功能合并到前者，
  删除废弃方法，统一为 `get_show_info` + `get_movie_info` 对称命名。
- 两者均使用 `params={"extended": "full"}` 获取完整元数据。

### 相关 Issue

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 无页面模板变更，无需运行 `djlint`

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过
- [x] 新功能已在本地 API 验证（对比 `/shows/{id}` 与 `/shows/{id}?extended=full` 返回值确认纯增量无字段丢失）
- [x] 现有功能未受影响

## 🔍 额外说明

### 修改范围（4 文件）
| 文件 | 改动 |
|------|------|
| `app/services/trakt/client.py` | 删除死代码 `get_show_details`，`get_show_info` 继承 `extended=full`，`get_movie_info` 补上 `extended=full` |
| `app/services/trakt/sync_service.py` | `get_show_details` → `get_show_info` |
| `tests/trakt/test_client_http.py` | 更新 mock URL 适配 `extended=full` |
| `tests/trakt/test_sync_service_comprehensive.py` | 重命名测试函数，更新方法引用 |

### API 验证
`?extended=full` 为纯增量参数：剧集基础接口返回 4 字段，加 `extended` 后返回 29 字段（+25），
零字段丢失。电影同理（+24）。所有调用方仅从 dict 按 key 取值，不受额外字段影响。
