### PR TITLE
fix: 修复 Trakt 同步自定义映射需要同时映射原名与英文名，并优化增量同步 API 请求数

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -122,7 +122,7 @@ class Logger:
         try:
             log_path.parent.mkdir(parents=True, exist_ok=True)
             mode = "a"
-            if log_path.exists() and log_path.stat().st_size >= 10 * 1024 * 1024:
+            if log_path.exists() and log_path.stat().st_size >= 2 * 1024 * 1024:
                 mode = "w"
             self.log_file = open(log_path, mode, encoding="utf-8", buffering=1)
             self._log_file_path = log_path.resolve()

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -667,7 +667,9 @@ class SyncService:
         """
         # 获取自定义映射
         custom_mappings = self._load_custom_mappings()
-        mapping_subject_id = custom_mappings.get(item.title, "")
+        mapping_subject_id = custom_mappings.get(item.title, "") or custom_mappings.get(
+            item.ori_title or "", ""
+        )
 
         if mapping_subject_id:
             logger.debug(f"匹配到自定义映射：{item.title}={mapping_subject_id}")

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -243,6 +243,18 @@ class TraktSyncService:
                     skipped_count += 1
             logger.info(f"过滤后得到 {len(syncable_items)} 条可同步记录（剧集 + 电影）")
 
+            # 增量同步时先过滤已同步记录，减少后续 API 请求
+            pending_items: list[TraktHistoryItem] = []
+            for item in syncable_items:
+                if (
+                    not full_sync
+                    and (item.trakt_item_id, item.watched_timestamp) in synced_set
+                ):
+                    skipped_count += 1
+                else:
+                    pending_items.append(item)
+            logger.info(f"去重后剩余 {len(pending_items)} 条待同步记录")
+
             # 预先收集 sync/history 不包含 original_title 的节目，
             # 通过 /shows/:id?extended=full 获取日语原名；
             # 同时收集 genre 用于类型过滤
@@ -253,7 +265,7 @@ class TraktSyncService:
                 mapping_service.load_custom_mappings() if sync_filter_enabled else {}
             )
 
-            for item in syncable_items:
+            for item in pending_items:
                 trakt_id = None
                 need_details = sync_filter_enabled
                 if item.type == "episode" and item.show:
@@ -288,17 +300,8 @@ class TraktSyncService:
             synced_count = 0
             details = []
 
-            for item in syncable_items:
+            for item in pending_items:
                 try:
-                    # O(1) 查找：使用预加载的集合代替每条查库
-                    if (
-                        # 全量同步忽略历史记录
-                        not full_sync
-                        and (item.trakt_item_id, item.watched_timestamp) in synced_set
-                    ):
-                        skipped_count += 1
-                        continue
-
                     # 类型过滤：仅同步动画类型，除非命中映射
                     if sync_filter_enabled:
                         if item.type == "episode":

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -277,8 +277,12 @@ class TraktSyncService:
                                 show_genres[tid] = details_resp.get("genres", [])
                     elif item.type == "movie":
                         details_resp = await client.get_movie_info(trakt_id)
-                        if details_resp and sync_filter_enabled:
-                            show_genres[tid] = details_resp.get("genres", [])
+                        if details_resp:
+                            ot = details_resp.get("original_title")
+                            if ot:
+                                show_original_titles[tid] = ot
+                            if sync_filter_enabled:
+                                show_genres[tid] = details_resp.get("genres", [])
 
             # 转换为 CustomItem 并同步
             synced_count = 0
@@ -307,9 +311,11 @@ class TraktSyncService:
                             trakt_id = m.get("ids", {}).get("trakt")
                         tid = str(trakt_id) if trakt_id else ""
                         genres = show_genres.get(tid, []) if tid else []
+                        ori_title = show_original_titles.get(tid, "")
                         if genres and not (
                             any(g in genres for g in ("anime", "donghua", "animation"))
                             or item_title in custom_mappings
+                            or ori_title in custom_mappings
                         ):
                             logger.debug(
                                 f"Trakt 类型过滤——跳过非动画条目: {item_title} "
@@ -549,8 +555,8 @@ class TraktSyncService:
                 logger.warning(f"剧集标题为空: {item.trakt_item_id}")
                 return None
 
-            # 获取原始标题，优先使用 Trakt 返回的日文原名
-            ori_title = show.get("original_title") or show.get("originalTitle") or title
+            # 获取原始标题，填入 Trakt 英文标题供自定义映射与 bangumi-data 备选匹配
+            ori_title = show.get("title") or title
 
             # 获取季和集数
             season = episode.get("season", 1)
@@ -609,8 +615,7 @@ class TraktSyncService:
             logger.warning(f"电影标题为空: {item.trakt_item_id}")
             return None
 
-        ori_raw = movie.get("original_title") or movie.get("originalTitle") or title
-        ori_title = ori_raw if str(ori_raw).strip() else None
+        ori_title = movie.get("title") or title
 
         release_date = ""
         if movie.get("released"):

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -521,15 +521,17 @@ class TestTraktMovieHistoryToCustomItem:
             assert result is not None
             assert "2024-08-20" in result.release_date
 
-    def test_movie_original_title(self):
-        """original_title 被保留"""
+    def test_movie_ori_title_uses_trakt_english_title(self):
+        """电影转换时 ori_title 填入 Trakt 英文标题"""
         service = _make_service()
-        item = _make_movie_item(original_title="Original")
+        item = _make_movie_item(
+            title="Kamen Rider ZEZTZ", original_title="仮面ライダーゼッツ"
+        )
         with patch("app.services.trakt.sync_service.bangumi_data") as mock_bd:
             mock_bd.get_title_by_tmdb_id.return_value = "标题"
             result = service._trakt_movie_history_to_custom_item("u", item)
             assert result is not None
-            assert result.ori_title == "Original"
+            assert result.ori_title == "Kamen Rider ZEZTZ"
 
 
 class TestTraktPreconvertFailure:

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -830,3 +830,47 @@ async def test_genre_filter_mapping_bypass_movie_original_title():
         assert r.success
         assert r.synced_count == 1
         assert r.skipped_count == 0
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_skips_prefetch_for_synced_items():
+    """增量同步时已同步记录不应触发 get_show_info 请求"""
+    with (
+        patch("app.services.trakt.sync_service.bangumi_data") as bd,
+        patch("app.services.trakt.sync_service.sync_service") as ss,
+        patch("app.services.trakt.sync_service.database_manager") as mock_db,
+        patch("app.services.trakt.sync_service.mapping_service") as mock_mapping,
+    ):
+        bd.get_title_by_tmdb_id.return_value = None
+        ss.sync_custom_item_async = AsyncMock(return_value="task-1")
+        mock_mapping.load_custom_mappings.return_value = {}
+
+        episode_item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T00:00:00Z",
+            action="scrobble",
+            type="episode",
+            show={
+                "title": "Test Show",
+                "ids": {"trakt": 100, "tmdb": 200},
+            },
+            episode={"season": 1, "number": 1},
+            movie=None,
+        )
+        synced_key = (episode_item.trakt_item_id, episode_item.watched_timestamp)
+        mock_db.get_trakt_synced_set.return_value = {synced_key}
+        mock_db.save_trakt_sync_history.return_value = True
+
+        client = MagicMock()
+        client.get_all_watched_history = AsyncMock(return_value=[episode_item])
+        client.get_show_info = AsyncMock()
+        cfg = MagicMock()
+        cfg.last_sync_time = None
+        cfg.sync_filter_enabled = False
+
+        svc = TraktSyncService()
+        r = await svc._sync_watched_history("user1", client, cfg, False)
+        assert r.success
+        assert r.synced_count == 0
+        assert r.skipped_count == 1
+        client.get_show_info.assert_not_called()

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -739,3 +739,94 @@ async def test_genre_filter_empty_genres_passes():
         assert r.success
         assert r.synced_count == 1
         assert r.skipped_count == 0
+
+
+@pytest.mark.asyncio
+async def test_genre_filter_mapping_bypass_original_title():
+    """genre 过滤开启时，命中自定义映射的剧集原名应放行"""
+    with (
+        patch("app.services.trakt.sync_service.bangumi_data") as bd,
+        patch("app.services.trakt.sync_service.sync_service") as ss,
+        patch("app.services.trakt.sync_service.database_manager") as mock_db,
+        patch("app.services.trakt.sync_service.mapping_service") as mock_mapping,
+    ):
+        bd.get_title_by_tmdb_id.return_value = None
+        ss.sync_custom_item_async = AsyncMock(return_value="task-1")
+        mock_db.get_trakt_synced_set.return_value = set()
+        mock_db.save_trakt_sync_history.return_value = True
+        mock_mapping.load_custom_mappings.return_value = {
+            "仮面ライダーゼッツ": "123456"
+        }
+
+        episode_item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T00:00:00Z",
+            action="scrobble",
+            type="episode",
+            show={
+                "title": "Kamen Rider ZEZTZ",
+                "ids": {"trakt": 100, "tmdb": 200},
+            },
+            episode={"season": 1, "number": 40},
+            movie=None,
+        )
+        client = MagicMock()
+        client.get_all_watched_history = AsyncMock(return_value=[episode_item])
+        client.get_show_info = AsyncMock(
+            return_value={
+                "genres": ["superhero", "action"],
+                "original_title": "仮面ライダーゼッツ",
+            }
+        )
+        cfg = MagicMock()
+        cfg.last_sync_time = None
+        cfg.sync_filter_enabled = True
+
+        svc = TraktSyncService()
+        r = await svc._sync_watched_history("user1", client, cfg, True)
+        assert r.success
+        assert r.synced_count == 1
+        assert r.skipped_count == 0
+
+
+@pytest.mark.asyncio
+async def test_genre_filter_mapping_bypass_movie_original_title():
+    """genre 过滤开启时，命中自定义映射的电影原名应放行"""
+    with (
+        patch("app.services.trakt.sync_service.bangumi_data") as bd,
+        patch("app.services.trakt.sync_service.sync_service") as ss,
+        patch("app.services.trakt.sync_service.database_manager") as mock_db,
+        patch("app.services.trakt.sync_service.mapping_service") as mock_mapping,
+    ):
+        bd.get_title_by_tmdb_id.return_value = None
+        ss.sync_custom_item_async = AsyncMock(return_value="task-1")
+        mock_db.get_trakt_synced_set.return_value = set()
+        mock_db.save_trakt_sync_history.return_value = True
+        mock_mapping.load_custom_mappings.return_value = {"君の名は。": "654321"}
+
+        movie_item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T00:00:00Z",
+            action="scrobble",
+            type="movie",
+            show=None,
+            episode=None,
+            movie={"title": "Your Name.", "ids": {"tmdb": 100, "trakt": 10}},
+        )
+        client = MagicMock()
+        client.get_all_watched_history = AsyncMock(return_value=[movie_item])
+        client.get_movie_info = AsyncMock(
+            return_value={
+                "genres": ["drama", "romance"],
+                "original_title": "君の名は。",
+            }
+        )
+        cfg = MagicMock()
+        cfg.last_sync_time = None
+        cfg.sync_filter_enabled = True
+
+        svc = TraktSyncService()
+        r = await svc._sync_watched_history("user1", client, cfg, True)
+        assert r.success
+        assert r.synced_count == 1
+        assert r.skipped_count == 0


### PR DESCRIPTION
## 📝 PR 描述

主要修复了
自定义映射[仮面ライダーゼッツ](https://bangumi.one/subject/545304)时，因为当前类型过滤检查使用的是英文名导致被跳过
```
[2026/06/22 03:18:02.254] [DEBUG] Trakt 类型过滤——跳过非动画条目: Kamen Rider ZEZTZ (genres=['superhero', 'action', 'adventure', 'fantasy', 'science-fiction', 'comedy', 'drama'])
```
转而映射[Kamen Rider ZEZTZ](https://bangumi.one/subject/545304)时又因`title`、`ori_title`全都是日语原名导致未命中
```
[2026/06/22 03:19:37.449] [INFO] 接收到同步请求：media_type='episode' title='仮面ライダーゼッツ' ori_title='仮面ライダーゼッツ' season=1 episode=40 release_date='2025-01-01' user_name='root' source='trakt' sync_action=None
```

又碰上了发版后（）昨晚发现这个问题但是今天这个点才有时间看，应该在今天那个PR合之前说一声的😇

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复 Trakt 同步几个问题：

1. **过滤时原名映射未检查**：genre 过滤仅检查 Trakt 英文 title，
   用户若用日文原名做映射 key 则无法命中。改为同时检查预取的
   `original_title`，零额外 API 请求。覆盖剧集与电影。

2. **Trakt 英文名无法命中映射**：Trakt 转换后 `ori_title` 原为日文原名，
   改为填入 Trakt 英文标题。`_find_subject_id` 自定义映射查找同时检查
   `title` 与 `ori_title`，用户映射日文原名或英文译名均可命中。

3. **增量同步重复请求 API**：`synced_set` 去重在 `get_show_info` 预取之后，
   已同步记录仍触发 API 请求。将去重提前到预取前，已有分集不再调用。
   新增测试验证已同步记录不触发 `get_show_info`。


并调整了日志文件上限大小，在将 Trakt 定时间隔拉短之后日志刷的很快还蛮容易膨胀
1. **日志文件上限过大**：触发截断阈值从 10MB 降至 2MB。

### 相关 Issue

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 无页面模板变更

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过（1782）
- [x] 新增 3 个测试：剧集原名映射、电影原名映射、增量跳过已同步记录不请求 API
- [x] 现有功能未受影响

## 🔍 额外说明

### 修改范围（5 文件）
| 文件 | 改动 |
|------|------|
| `app/services/trakt/sync_service.py` | filter 增加原名映射检查；ori_title 改英文；去重提前 |
| `app/services/sync_service.py` | _find_subject_id 查 title + ori_title |
| `app/core/logging.py` | 日志阈值 10MB→2MB |
| `tests/trakt/test_sync_service_comprehensive.py` | 剧集+电影原名映射测试；增量跳过已同步测试 |
| `tests/services/test_trakt_sync_service.py` | 适配 ori_title 新语义 |
