### PR TITLE
perf: Trakt 同步命中 bangumi_data 的 TMDB 时跳过详情请求

### DIFF
--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -279,6 +279,28 @@ class TraktSyncService:
                     continue
                 tid = str(trakt_id)
                 if need_details and tid not in show_original_titles:
+                    # bangumi_data 仅收录动画条目，TMDB 命中则确认为动画，跳过 Trakt 详情请求
+                    if sync_filter_enabled:
+                        if item.type == "episode" and item.show:
+                            tmdb_id = item.show.get("ids", {}).get("tmdb")
+                            if tmdb_id and bangumi_data.get_title_by_tmdb_id(
+                                f"tv/{tmdb_id}"
+                            ):
+                                logger.debug(
+                                    f"命中 bangumi_data 中 TMDB ID，跳过 Trakt 详情请求: tv/{tmdb_id}"
+                                )
+                                show_genres[tid] = ["anime"]
+                                continue
+                        elif item.type == "movie" and item.movie:
+                            tmdb_id = item.movie.get("ids", {}).get("tmdb")
+                            if tmdb_id and bangumi_data.get_title_by_tmdb_id(
+                                f"movie/{tmdb_id}"
+                            ):
+                                logger.debug(
+                                    f"命中 bangumi_data 中 TMDB ID，跳过 Trakt 详情请求: movie/{tmdb_id}"
+                                )
+                                show_genres[tid] = ["anime"]
+                                continue
                     if item.type == "episode":
                         details_resp = await client.get_show_info(tid)
                         if details_resp:

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -874,3 +874,45 @@ async def test_incremental_sync_skips_prefetch_for_synced_items():
         assert r.synced_count == 0
         assert r.skipped_count == 1
         client.get_show_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bangumidata_hit_skips_trakt_detail_request():
+    """bangumi_data 命中 TMDB 时跳过 get_show_info / get_movie_info 请求"""
+    with (
+        patch("app.services.trakt.sync_service.bangumi_data") as bd,
+        patch("app.services.trakt.sync_service.sync_service") as ss,
+        patch("app.services.trakt.sync_service.database_manager") as mock_db,
+        patch("app.services.trakt.sync_service.mapping_service") as mock_mapping,
+    ):
+        bd.get_title_by_tmdb_id.return_value = "攻殻機動隊"
+        ss.sync_custom_item_async = AsyncMock(return_value="task-1")
+        mock_db.get_trakt_synced_set.return_value = set()
+        mock_db.save_trakt_sync_history.return_value = True
+        mock_mapping.load_custom_mappings.return_value = {}
+
+        episode_item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T00:00:00Z",
+            action="scrobble",
+            type="episode",
+            show={
+                "title": "Ghost in the Shell",
+                "ids": {"trakt": 100, "tmdb": 200},
+            },
+            episode={"season": 1, "number": 1},
+            movie=None,
+        )
+        client = MagicMock()
+        client.get_all_watched_history = AsyncMock(return_value=[episode_item])
+        client.get_show_info = AsyncMock()
+        cfg = MagicMock()
+        cfg.last_sync_time = None
+        cfg.sync_filter_enabled = True
+
+        svc = TraktSyncService()
+        r = await svc._sync_watched_history("user1", client, cfg, True)
+        assert r.success
+        assert r.synced_count == 1
+        assert r.skipped_count == 0
+        client.get_show_info.assert_not_called()


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
🚀 优化/重构 (perf/refactor)

### 变更内容
类型过滤需要 genres 数据，此前对每条不重复的节目均需请求
`get_show_info` / `get_movie_info`。但 bangumi_data 仅收录动画条目，
TMDB ID 命中即可确认是动画，无需额外的 Trakt 详情请求。

命中时以 `["anime"]` 标记绕过 API 调用，未命中时照常请求详情
进行类型过滤。剧集与电影均覆盖。

### 相关 Issue

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 无页面模板变更

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过（1783）
- [x] 新增测试验证 bangumi_data 命中时跳过 API 请求
- [x] 现有功能未受影响

## 🔍 额外说明

### 效果对比

| 场景 | 优化前 | 优化后 |
|------|:---:|:---:|
| bangumi_data 命中（动画） | `get_show_info` 请求 | 跳过 |
| bangumi_data 未命中 | `get_show_info` 请求 | 照常 |

### 修改范围（2 文件）
| 文件 | 改动 |
|------|------|
| `app/services/trakt/sync_service.py` | 预取循环新增 bangumi_data 命中检查，命中时跳过 Trakt 详情请求 |
| `tests/trakt/test_sync_service_comprehensive.py` | 新增 `test_bangumidata_hit_skips_trakt_detail_request` |
