### PR TITLE
fix: 修复无职转生第三季匹配错误

### DIFF
--- a/app/utils/bangumi_data.py
+++ b/app/utils/bangumi_data.py
@@ -456,9 +456,14 @@ class BangumiData:
                             pm_item.get("title", "")
                         ] + self._get_zh_hans_titles(pm_item)
 
-                        # 安全校验：搜索词必须被包含在候选名的其中之一里，或者模糊匹配相似度 > 0.8
-                        is_safe_to_override = pm_score >= 0.8 or any(
-                            title in name for name in pm_all_names
+                        # 安全校验：搜索词必须被包含在候选名的其中之一里，模糊匹配相似度 > 0.8，或关键字符一致
+                        is_safe_to_override = (
+                            pm_score >= 0.8
+                            or any(title in name for name in pm_all_names)
+                            or any(
+                                self._check_key_characters(title, name)
+                                for name in pm_all_names
+                            )
                         )
 
                         if is_safe_to_override:
@@ -478,7 +483,7 @@ class BangumiData:
                         f"从多个完全匹配中择优: {best_exact_match[0].get('title', '')}, 日期差距: {min_exact_diff}天"
                     )
                     matched_title = self._get_best_matched_title(best_exact_match[0])
-                    date_matched = season > 1
+                    date_matched = season > 1 and min_exact_diff <= 180
                     return (best_exact_match[1], matched_title, date_matched)
 
             # 返回最高优先级的匹配结果

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -1073,6 +1073,72 @@ class TestFindBangumiIdOptimizedTitleIndex:
         assert result[0] == "444557"
         assert result[2] is True  # date_matched=True
 
+    def test_mushoku_tensei_s3_episode_1_returns_correct_id(self):
+        """无职转生 S03E01 (2026-07-04) Plex 冒号标题应匹配到 S3 (ID=501963)"""
+        data = _make_data()
+        data._title_index = {
+            "无职转生：到了异世界就拿出真本事": [
+                {
+                    "title": "無職転生～異世界行ったら本気だす～",
+                    "begin": "2021-01-10T15:00:00.000Z",
+                    "titleTranslate": {
+                        "zh-Hans": ["无职转生～到了异世界就拿出真本事～"]
+                    },
+                    "sites": [{"site": "bangumi", "id": "277554"}],
+                }
+            ]
+        }
+        all_items = [
+            {
+                "title": "無職転生～異世界行ったら本気だす～",
+                "begin": "2021-01-10T15:00:00.000Z",
+                "titleTranslate": {"zh-Hans": ["无职转生～到了异世界就拿出真本事～"]},
+                "sites": [{"site": "bangumi", "id": "277554"}],
+            },
+            {
+                "title": "無職転生Ⅱ ～異世界行ったら本気だす～",
+                "begin": "2023-07-02T15:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "无职转生Ⅱ ～到了异世界就拿出真本事～",
+                        "无职转生 ～在异世界认真地活下去～ 第二季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "373247"}],
+            },
+            {
+                "title": "無職転生Ⅱ ～異世界行ったら本気だす～(第2クール)",
+                "begin": "2024-04-07T15:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "无职转生Ⅱ ～到了异世界就拿出真本事～ 第2部分",
+                        "无职转生 ～在异世界认真地活下去～ 第二季 第2部分",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "444557"}],
+            },
+            {
+                "title": "無職転生Ⅲ ～異世界行ったら本気だす～",
+                "begin": "2026-07-04T15:00:00.000Z",
+                "titleTranslate": {
+                    "zh-Hans": [
+                        "无职转生Ⅲ ～到了异世界就拿出真本事～",
+                        "无职转生 ～在异世界认真地活下去～ 第三季",
+                    ]
+                },
+                "sites": [{"site": "bangumi", "id": "501963"}],
+            },
+        ]
+        with patch.object(data, "_parse_data", return_value=all_items):
+            result = data._find_bangumi_id_optimized(
+                "无职转生：到了异世界就拿出真本事",
+                release_date="2026-07-04",
+                season=3,
+            )
+        assert result is not None
+        assert result[0] == "501963"
+        assert result[2] is True
+
     def test_oshi_no_ko_s3_matches_517057(self):
         """【我推的孩子】 S03E01 (2026-01-14) 应匹配到 S3 (ID=517057)"""
         data = _make_data()


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
修复 [#182](https://github.com/SanaeMio/Bangumi-syncer/issues/182)：Plex 播放无职转生 S03E01 时，bangumi-data 误匹配到第二季（325585）而非第三季（501963）。

**`app/utils/bangumi_data.py`**

1. **收紧 `date_matched` 判定**：多精确匹配择优时，仅在 `season > 1` 且日期差 `<= 180` 天才标记为日期匹配可信，避免日期相差很远时仍被下游当作当季 subject 直接使用。
2. **放宽日期择优安全校验**：在精确匹配日期差 `> 180` 天触发日期择优时，除原有子串包含与高分模糊匹配外，追加 `_check_key_characters` 条件，使 Plex 冒号标题（`无职转生：到了异世界就拿出真本事`）能与 bangumi-data 波浪号标题正确关联。

**`tests/utils/test_bangumi_data.py`**

- 新增 `test_mushoku_tensei_s3_episode_1_returns_correct_id` 回归测试，验证 S03E01 + `2026-07-04` 返回 `501963`。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
Closes #182 

## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
