### PR TITLE
perf: 优化封面加载机制，减少首页等待时间

### DIFF
--- a/app/api/bgm_poster.py
+++ b/app/api/bgm_poster.py
@@ -2,21 +2,11 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from ..core.config import config_manager
 from ..core.logging import logger
-from ..utils.bangumi_api import BangumiApi
-from ..utils.bgm_image_url import extract_poster_url, rewrite_bgm_image_url
+from ..utils.bgm_poster_service import get_poster_urls
 from .deps import get_current_user_flexible
 
 router = APIRouter(prefix="/api/bgm", tags=["bgm"])
-
-
-def _get_public_bangumi_api() -> BangumiApi:
-    return BangumiApi(
-        http_proxy=config_manager.get("dev", "script_proxy", fallback=""),
-        ssl_verify=config_manager.get("dev", "ssl_verify", fallback=True),
-        bgm_api_proxy=config_manager.get("dev", "bgm_api_proxy", fallback=""),
-    )
 
 
 @router.get("/subjects/{subject_id}/poster")
@@ -28,21 +18,14 @@ async def get_subject_poster(
     if subject_id < 1:
         raise HTTPException(status_code=400, detail="无效的条目 ID")
 
-    bgm = _get_public_bangumi_api()
     try:
-        subject = bgm.get_subject(subject_id)
+        urls = await get_poster_urls([subject_id])
     except Exception as e:
         logger.warning("获取条目 %s 封面失败: %s", subject_id, e)
         raise HTTPException(status_code=502, detail="获取条目信息失败") from e
 
-    if not subject or not subject.get("id"):
-        raise HTTPException(status_code=404, detail="条目不存在")
-
-    poster_url = extract_poster_url(subject)
+    poster_url = urls.get(subject_id)
     if not poster_url:
         raise HTTPException(status_code=404, detail="该条目无封面图")
-
-    image_proxy = config_manager.get("dev", "bgm_image_proxy", fallback="").strip()
-    poster_url = rewrite_bgm_image_url(poster_url, image_proxy)
 
     return {"status": "success", "url": poster_url}

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -218,6 +218,7 @@ async def get_sync_records(
     source: Optional[str] = None,
     source_prefix: Optional[str] = None,
     skip_count: bool = Query(False),
+    include_poster: bool = Query(False),
     current_user: dict = Depends(get_current_user_flexible),
 ):
     """获取同步记录"""
@@ -231,6 +232,19 @@ async def get_sync_records(
             source_prefix=source_prefix,
             skip_count=skip_count,
         )
+
+        if include_poster and result.get("records"):
+            from ..utils.bgm_poster_service import get_poster_urls, normalize_subject_id
+
+            subject_ids = [
+                sid
+                for r in result["records"]
+                if (sid := normalize_subject_id(r.get("subject_id"))) is not None
+            ]
+            poster_map = await get_poster_urls(subject_ids)
+            for record in result["records"]:
+                sid = normalize_subject_id(record.get("subject_id"))
+                record["poster_url"] = poster_map.get(sid) if sid else None
 
         return {"status": "success", "data": result}
     except Exception as e:

--- a/app/utils/bgm_image_url.py
+++ b/app/utils/bgm_image_url.py
@@ -7,7 +7,8 @@ from typing import Any
 
 LAIN_BGM_TV_PREFIX = "https://lain.bgm.tv"
 
-_POSTER_SIZE_ORDER = ("large", "medium", "common", "small", "grid")
+_DEFAULT_POSTER_SIZE_ORDER = ("large", "medium", "common", "small", "grid")
+_TIMELINE_POSTER_SIZE_ORDER = ("small", "grid", "medium", "common", "large")
 
 
 def build_poster_cache_namespace(
@@ -18,16 +19,25 @@ def build_poster_cache_namespace(
     return hashlib.md5(raw.encode(), usedforsecurity=False).hexdigest()[:12]
 
 
-def extract_poster_url(subject: dict[str, Any]) -> str | None:
+def extract_poster_url(
+    subject: dict[str, Any],
+    prefer_sizes: tuple[str, ...] | None = None,
+) -> str | None:
     """从 get_subject 响应中选取最佳可用封面 URL。"""
     images = subject.get("images")
     if not isinstance(images, dict):
         return None
-    for key in _POSTER_SIZE_ORDER:
+    size_order = prefer_sizes or _DEFAULT_POSTER_SIZE_ORDER
+    for key in size_order:
         url = images.get(key)
         if url:
             return str(url)
     return None
+
+
+def timeline_poster_size_order() -> tuple[str, ...]:
+    """仪表板时间线缩略图尺寸优先级（small 优先于 grid）。"""
+    return _TIMELINE_POSTER_SIZE_ORDER
 
 
 def rewrite_bgm_image_url(url: str, image_proxy: str) -> str:

--- a/app/utils/bgm_poster_service.py
+++ b/app/utils/bgm_poster_service.py
@@ -1,0 +1,147 @@
+"""Bangumi 条目封面 URL 批量解析（共享 API 客户端与进程级缓存）。"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from ..core.config import config_manager
+from ..core.logging import logger
+from ..utils.bangumi_api import BangumiApi
+from .bgm_image_url import (
+    build_poster_cache_namespace,
+    extract_poster_url,
+    rewrite_bgm_image_url,
+    timeline_poster_size_order,
+)
+
+_POSTER_URL_TTL_SECONDS = 24 * 60 * 60
+
+_bgm_api_instances: dict[tuple[str, bool, str], BangumiApi] = {}
+_poster_url_cache: dict[tuple[str, int], tuple[str, float]] = {}
+
+
+def _dev_config(key: str, fallback: Any = "") -> Any:
+    return config_manager.get("dev", key, fallback=fallback)
+
+
+def _bangumi_api_config_key() -> tuple[str, bool, str]:
+    return (
+        str(_dev_config("script_proxy", "") or ""),
+        bool(_dev_config("ssl_verify", True)),
+        str(_dev_config("bgm_api_proxy", "") or ""),
+    )
+
+
+def _poster_cache_namespace() -> str:
+    return build_poster_cache_namespace(
+        str(_dev_config("bgm_api_proxy", "") or ""),
+        str(_dev_config("bgm_image_proxy", "") or "").strip(),
+    )
+
+
+def get_shared_bangumi_api() -> BangumiApi:
+    """按 dev 代理配置复用 BangumiApi 实例，使 get_subject LRU 跨请求命中。"""
+    key = _bangumi_api_config_key()
+    api = _bgm_api_instances.get(key)
+    if api is None:
+        http_proxy, ssl_verify, bgm_api_proxy = key
+        api = BangumiApi(
+            http_proxy=http_proxy,
+            ssl_verify=ssl_verify,
+            bgm_api_proxy=bgm_api_proxy,
+        )
+        _bgm_api_instances[key] = api
+    return api
+
+
+def clear_poster_service_caches() -> None:
+    """清空进程级 poster URL 缓存（主要用于测试）。"""
+    _poster_url_cache.clear()
+    _bgm_api_instances.clear()
+
+
+def normalize_subject_id(value: Any) -> int | None:
+    """将数据库/请求中的 subject_id 规范为 int；无效则返回 None。"""
+    if value is None or value == "":
+        return None
+    try:
+        sid = int(value)
+    except (TypeError, ValueError):
+        return None
+    return sid if sid >= 1 else None
+
+
+def _get_cached_poster_url(subject_id: int, namespace: str) -> str | None:
+    entry = _poster_url_cache.get((namespace, subject_id))
+    if not entry:
+        return None
+    url, expires_at = entry
+    if time.monotonic() >= expires_at:
+        _poster_url_cache.pop((namespace, subject_id), None)
+        return None
+    return url
+
+
+def _set_cached_poster_url(subject_id: int, namespace: str, url: str) -> None:
+    _poster_url_cache[(namespace, subject_id)] = (
+        url,
+        time.monotonic() + _POSTER_URL_TTL_SECONDS,
+    )
+
+
+def _resolve_poster_url_sync(
+    subject_id: int,
+    prefer_sizes: tuple[str, ...] | None = None,
+) -> str | None:
+    namespace = _poster_cache_namespace()
+    cached = _get_cached_poster_url(subject_id, namespace)
+    if cached:
+        return cached
+
+    bgm = get_shared_bangumi_api()
+    try:
+        subject = bgm.get_subject(subject_id)
+    except Exception as e:
+        logger.warning("获取条目 %s 封面失败: %s", subject_id, e)
+        return None
+
+    if not subject or not subject.get("id"):
+        return None
+
+    raw_url = extract_poster_url(subject, prefer_sizes=prefer_sizes)
+    if not raw_url:
+        return None
+
+    image_proxy = str(_dev_config("bgm_image_proxy", "") or "").strip()
+    poster_url = rewrite_bgm_image_url(raw_url, image_proxy)
+    _set_cached_poster_url(subject_id, namespace, poster_url)
+    return poster_url
+
+
+def get_poster_urls_sync(
+    subject_ids: list[Any],
+    prefer_sizes: tuple[str, ...] | None = None,
+) -> dict[int, str]:
+    """同步批量解析封面 URL；失败条目跳过。"""
+    sizes = prefer_sizes if prefer_sizes is not None else timeline_poster_size_order()
+    result: dict[int, str] = {}
+    seen: set[int] = set()
+    for raw_id in subject_ids:
+        subject_id = normalize_subject_id(raw_id)
+        if subject_id is None or subject_id in seen:
+            continue
+        seen.add(subject_id)
+        url = _resolve_poster_url_sync(subject_id, prefer_sizes=sizes)
+        if url:
+            result[subject_id] = url
+    return result
+
+
+async def get_poster_urls(
+    subject_ids: list[Any],
+    prefer_sizes: tuple[str, ...] | None = None,
+) -> dict[int, str]:
+    """异步批量解析封面 URL（Bangumi API 调用在线程池中执行）。"""
+    return await asyncio.to_thread(get_poster_urls_sync, subject_ids, prefer_sizes)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -475,39 +475,50 @@ async function showRecordDetail(recordId) {
 }
 
 async function loadDashboardData() {
-    try {
-        const [statsRes, recordsRes, heatmapRes] = await Promise.all([
-            fetch(appUrl('/api/stats'), { credentials: 'include' }),
-            fetch(appUrl('/api/records?limit=6&skip_count=true'), { credentials: 'include' }),
-            fetch(appUrl('/api/stats/heatmap'), { credentials: 'include' })
-        ]);
+    const fetchOpts = { credentials: 'include' };
 
-        const statsData = await statsRes.json();
-        const recordsData = await recordsRes.json();
-        const heatmapData = await heatmapRes.json();
+    fetch(appUrl('/api/stats'), fetchOpts)
+        .then(function(res) { return res.json(); })
+        .then(function(statsData) {
+            if (statsData.status === 'success') {
+                const stats = statsData.data;
+                document.getElementById('total-syncs').textContent = stats.total_syncs;
+                document.getElementById('success-rate').textContent = stats.success_rate + '%';
+                document.getElementById('today-syncs').textContent = stats.today_syncs;
+                document.getElementById('error-syncs').textContent = stats.error_syncs;
+                cachedDailyStats = stats.daily_stats;
+                drawDailyChart(cachedDailyStats);
+            }
+        })
+        .catch(function(error) {
+            console.error('加载统计数据失败:', error);
+            showAlert('加载数据失败', 'danger');
+        });
 
-        if (statsData.status === 'success') {
-            const stats = statsData.data;
-            document.getElementById('total-syncs').textContent = stats.total_syncs;
-            document.getElementById('success-rate').textContent = stats.success_rate + '%';
-            document.getElementById('today-syncs').textContent = stats.today_syncs;
-            document.getElementById('error-syncs').textContent = stats.error_syncs;
-            cachedDailyStats = stats.daily_stats;
-            drawDailyChart(cachedDailyStats);
-        }
+    fetch(appUrl('/api/records?limit=6&skip_count=true&include_poster=true'), fetchOpts)
+        .then(function(res) { return res.json(); })
+        .then(function(recordsData) {
+            if (recordsData.status === 'success') {
+                renderTimeline(recordsData.data.records);
+            }
+        })
+        .catch(function(error) {
+            console.error('加载同步记录失败:', error);
+            showAlert('加载数据失败', 'danger');
+        });
 
-        if (recordsData.status === 'success') {
-            renderTimeline(recordsData.data.records);
-        }
-
-        if (heatmapData.status === 'success') {
-            cachedHeatmapData = heatmapData.data;
-            renderHeatmap(cachedHeatmapData, true);
-        }
-    } catch (error) {
-        console.error('加载仪表板数据失败:', error);
-        showAlert('加载数据失败', 'danger');
-    }
+    fetch(appUrl('/api/stats/heatmap'), fetchOpts)
+        .then(function(res) { return res.json(); })
+        .then(function(heatmapData) {
+            if (heatmapData.status === 'success') {
+                cachedHeatmapData = heatmapData.data;
+                renderHeatmap(cachedHeatmapData, true);
+            }
+        })
+        .catch(function(error) {
+            console.error('加载热力图失败:', error);
+            showAlert('加载数据失败', 'danger');
+        });
 }
 
 // ========== 时间线 ==========
@@ -606,9 +617,14 @@ function renderTimeline(records) {
 
     container.innerHTML = html;
 
-    // 异步加载海报
+    // 异步加载海报（优先使用 records 响应中的 poster_url）
     records.forEach(function(record) {
-        if (record.subject_id) {
+        if (!record.subject_id) return;
+        if (record.poster_url) {
+            posterCache[record.subject_id] = record.poster_url;
+            try { localStorage.setItem(posterStorageKey(record.subject_id), record.poster_url); } catch (e) {}
+            applyPoster(record.subject_id, record.poster_url);
+        } else {
             loadPoster(record.subject_id);
         }
     });

--- a/tests/api/test_bgm_poster.py
+++ b/tests/api/test_bgm_poster.py
@@ -1,6 +1,6 @@
 """Bangumi 仪表板封面 API 测试。"""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -25,36 +25,29 @@ def app_bgm_poster():
 
 @pytest.mark.asyncio
 async def test_get_subject_poster_success(app_bgm_poster):
-    mock_bgm = MagicMock()
-    mock_bgm.get_subject.return_value = {
-        "id": 123,
-        "images": {"large": "https://lain.bgm.tv/pic/cover/l/a/b/c.jpg"},
-    }
-
-    def fake_get(section, key, fallback=""):
-        if section == "dev" and key == "bgm_image_proxy":
-            return "https://img-proxy.example.com"
-        return fallback
-
-    with patch("app.api.bgm_poster._get_public_bangumi_api", return_value=mock_bgm):
-        with patch("app.api.bgm_poster.config_manager.get", side_effect=fake_get):
-            transport = ASGITransport(app=app_bgm_poster)
-            async with AsyncClient(transport=transport, base_url="http://test") as ac:
-                r = await ac.get("/api/bgm/subjects/123/poster")
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+        return_value={123: "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg"},
+    ) as mock_get:
+        transport = ASGITransport(app=app_bgm_poster)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/bgm/subjects/123/poster")
 
     assert r.status_code == 200
     data = r.json()
     assert data["status"] == "success"
-    assert data["url"] == "https://img-proxy.example.com/pic/cover/l/a/b/c.jpg"
-    mock_bgm.get_subject.assert_called_once_with(123)
+    assert data["url"] == "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg"
+    mock_get.assert_awaited_once_with([123])
 
 
 @pytest.mark.asyncio
 async def test_get_subject_poster_no_image(app_bgm_poster):
-    mock_bgm = MagicMock()
-    mock_bgm.get_subject.return_value = {"id": 123, "images": {}}
-
-    with patch("app.api.bgm_poster._get_public_bangumi_api", return_value=mock_bgm):
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
         transport = ASGITransport(app=app_bgm_poster)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             r = await ac.get("/api/bgm/subjects/123/poster")
@@ -63,16 +56,17 @@ async def test_get_subject_poster_no_image(app_bgm_poster):
 
 
 @pytest.mark.asyncio
-async def test_get_subject_poster_not_found(app_bgm_poster):
-    mock_bgm = MagicMock()
-    mock_bgm.get_subject.return_value = {}
-
-    with patch("app.api.bgm_poster._get_public_bangumi_api", return_value=mock_bgm):
+async def test_get_subject_poster_service_error(app_bgm_poster):
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
         transport = ASGITransport(app=app_bgm_poster)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             r = await ac.get("/api/bgm/subjects/123/poster")
 
-    assert r.status_code == 404
+    assert r.status_code == 502
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -226,6 +226,55 @@ async def test_get_sync_records(
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
+        assert "poster_url" not in data["data"]["records"][0]
+
+
+@pytest.mark.asyncio
+async def test_get_sync_records_include_poster(
+    app_with_auth, mock_sync_service, mock_database_manager
+):
+    """测试 records 批量附带 poster_url"""
+    mock_database_manager.get_sync_records.return_value = {
+        "records": [
+            {
+                "id": 1,
+                "title": "Test Show",
+                "season": 1,
+                "episode": 5,
+                "status": "success",
+                "subject_id": 123,
+            },
+            {
+                "id": 2,
+                "title": "No Subject",
+                "season": 1,
+                "episode": 1,
+                "status": "success",
+                "subject_id": None,
+            },
+        ],
+        "total": 2,
+    }
+
+    with patch(
+        "app.utils.bgm_poster_service.get_poster_urls",
+        new_callable=AsyncMock,
+        return_value={123: "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg"},
+    ) as mock_posters:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/records?include_poster=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    records = data["data"]["records"]
+    assert (
+        records[0]["poster_url"]
+        == "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg"
+    )
+    assert records[1]["poster_url"] is None
+    mock_posters.assert_awaited_once_with([123])
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_bgm_image_url.py
+++ b/tests/utils/test_bgm_image_url.py
@@ -17,6 +17,33 @@ def test_extract_poster_url_prefers_large():
     assert extract_poster_url(subject) == "https://lain.bgm.tv/pic/cover/l/a/b/c.jpg"
 
 
+def test_extract_poster_url_prefers_small_for_timeline():
+    subject = {
+        "images": {
+            "large": "https://lain.bgm.tv/pic/cover/l/a/b/c.jpg",
+            "small": "https://lain.bgm.tv/pic/cover/s/a/b/c.jpg",
+            "grid": "https://lain.bgm.tv/pic/cover/g/a/b/c.jpg",
+        }
+    }
+    assert (
+        extract_poster_url(subject, prefer_sizes=("small", "grid", "medium", "large"))
+        == "https://lain.bgm.tv/pic/cover/s/a/b/c.jpg"
+    )
+
+
+def test_extract_poster_url_falls_back_to_grid_when_no_small():
+    subject = {
+        "images": {
+            "large": "https://lain.bgm.tv/pic/cover/l/a/b/c.jpg",
+            "grid": "https://lain.bgm.tv/pic/cover/g/a/b/c.jpg",
+        }
+    }
+    assert (
+        extract_poster_url(subject, prefer_sizes=("small", "grid", "large"))
+        == "https://lain.bgm.tv/pic/cover/g/a/b/c.jpg"
+    )
+
+
 def test_extract_poster_url_falls_back_to_medium():
     subject = {"images": {"medium": "https://lain.bgm.tv/pic/cover/m/a/b/c.jpg"}}
     assert extract_poster_url(subject) == "https://lain.bgm.tv/pic/cover/m/a/b/c.jpg"

--- a/tests/utils/test_bgm_poster_service.py
+++ b/tests/utils/test_bgm_poster_service.py
@@ -1,0 +1,141 @@
+"""Bangumi 封面批量解析服务单元测试。"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.utils.bgm_poster_service import (
+    clear_poster_service_caches,
+    get_poster_urls,
+    get_poster_urls_sync,
+    get_shared_bangumi_api,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_poster_service():
+    clear_poster_service_caches()
+    yield
+    clear_poster_service_caches()
+
+
+def test_get_shared_bangumi_api_reuses_instance():
+    with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+        a = get_shared_bangumi_api()
+        b = get_shared_bangumi_api()
+    assert a is b
+
+
+def test_get_poster_urls_sync_dedupes_and_prefers_small():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.side_effect = [
+        {
+            "id": 1,
+            "images": {
+                "small": "https://lain.bgm.tv/pic/cover/s/a/b/1.jpg",
+                "large": "https://lain.bgm.tv/pic/cover/l/a/b/1.jpg",
+            },
+        },
+        {
+            "id": 2,
+            "images": {"large": "https://lain.bgm.tv/pic/cover/l/c/d/2.jpg"},
+        },
+    ]
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+            result = get_poster_urls_sync([1, 2, 1])
+
+    assert result == {
+        1: "https://lain.bgm.tv/pic/cover/s/a/b/1.jpg",
+        2: "https://lain.bgm.tv/pic/cover/l/c/d/2.jpg",
+    }
+    assert mock_bgm.get_subject.call_count == 2
+
+
+def test_get_poster_urls_sync_applies_image_proxy():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.return_value = {
+        "id": 10,
+        "images": {"small": "https://lain.bgm.tv/pic/cover/s/x/y/10.jpg"},
+    }
+
+    def fake_get(section, key, fallback=""):
+        if section == "dev" and key == "bgm_image_proxy":
+            return "https://img-proxy.example.com"
+        return fallback
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch(
+            "app.utils.bgm_poster_service.config_manager.get", side_effect=fake_get
+        ):
+            result = get_poster_urls_sync([10])
+
+    assert result[10] == "https://img-proxy.example.com/pic/cover/s/x/y/10.jpg"
+
+
+def test_get_poster_urls_sync_skips_failed_subject():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.side_effect = [
+        RuntimeError("network"),
+        {"id": 2, "images": {"small": "https://lain.bgm.tv/pic/cover/s/c/d/2.jpg"}},
+    ]
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+            result = get_poster_urls_sync([1, 2])
+
+    assert result == {2: "https://lain.bgm.tv/pic/cover/s/c/d/2.jpg"}
+
+
+def test_get_poster_urls_sync_uses_process_cache():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.return_value = {
+        "id": 5,
+        "images": {"small": "https://lain.bgm.tv/pic/cover/s/a/b/5.jpg"},
+    }
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+            first = get_poster_urls_sync([5])
+            second = get_poster_urls_sync([5])
+
+    assert first == second
+    mock_bgm.get_subject.assert_called_once()
+
+
+def test_get_poster_urls_sync_accepts_string_subject_ids():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.return_value = {
+        "id": 42,
+        "images": {"small": "https://lain.bgm.tv/pic/cover/s/a/b/42.jpg"},
+    }
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+            result = get_poster_urls_sync(["42", 42, "0", "bad"])
+
+    assert result == {42: "https://lain.bgm.tv/pic/cover/s/a/b/42.jpg"}
+    mock_bgm.get_subject.assert_called_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_get_poster_urls_async():
+    with patch(
+        "app.utils.bgm_poster_service.get_poster_urls_sync",
+        return_value={1: "https://example.com/1.jpg"},
+    ) as mock_sync:
+        result = await get_poster_urls([1])
+
+    assert result == {1: "https://example.com/1.jpg"}
+    mock_sync.assert_called_once_with([1], None)


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化/重构 (perf/refactor)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
优化仪表板「最近同步」时间线的封面加载，减少首页等待与多余请求。

**后端**
- 新增 `app/utils/bgm_poster_service.py`：共享 `BangumiApi` 实例、进程级 poster URL 缓存（24h，随 `bgm_image_proxy` 命名空间失效）、`get_poster_urls()` 批量解析
- `/api/records` 支持 `include_poster=true`，在响应中批量附带 `poster_url`（含图片反代改写）
- `bgm_poster.py` 复用同一服务；`get_subject` 经 `asyncio.to_thread` 执行，避免阻塞事件循环
- `extract_poster_url()` 支持尺寸优先级；时间线默认 `small → grid → medium`，替代原先 `large` 大图
- 修复 `subject_id` 在库中为 TEXT 时与整数比较导致的类型错误

**前端**
- 仪表板 records 请求改为 `include_poster=true`，优先使用响应中的 `poster_url`，保留 `loadPoster` / localStorage 作为 fallback
- 拆分 `Promise.all`，stats / 时间线 / 热力图独立加载，避免最慢接口拖住整页

**效果（冷缓存）**
- 浏览器对本机的 poster 请求：6 次 → 0 次（合并进 records）
- 封面图规格：`large` → `small`，体积更小
- 图片反代（`bgm_image_proxy`）行为不变

---

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
