### PR TITLE
feature: 支持fongmi定时同步

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -197,6 +197,13 @@ async def update_config(
         except Exception as ex:
             logger.debug("飞牛调度器随配置更新: %s", ex)
 
+        try:
+            from ..services.fongmi.scheduler import fongmi_scheduler
+
+            await fongmi_scheduler.apply_config_after_save()
+        except Exception as ex:
+            logger.debug("fongmi 调度器随配置更新: %s", ex)
+
         # 如果密码被更新，需要重新初始化安全管理器以确保运行时状态一致
         if password_updated:
             security_manager._init_auth_config()

--- a/app/api/fongmi.py
+++ b/app/api/fongmi.py
@@ -46,9 +46,7 @@ async def fongmi_manual_sync(
 ) -> dict[str, Any]:
     cfg = config_manager.get_fongmi_config()
     if not cfg.get("enabled"):
-        raise HTTPException(
-            status_code=400, detail="fongmi 同步未启用，请在配置中开启"
-        )
+        raise HTTPException(status_code=400, detail="fongmi 同步未启用，请在配置中开启")
 
     try:
         result: FongmiSyncResult = await fongmi_sync_service.run_sync(
@@ -79,9 +77,7 @@ async def fongmi_debug_scan(
     服务端 20 秒超时，避免网段扫描无响应时长时间挂起。
     """
     try:
-        data = await asyncio.wait_for(
-            fongmi_sync_service.debug_scan(), timeout=20.0
-        )
+        data = await asyncio.wait_for(fongmi_sync_service.debug_scan(), timeout=20.0)
         return {
             "status": "success",
             "message": f"发现 {data['discovered_devices']} 台设备",

--- a/app/api/fongmi.py
+++ b/app/api/fongmi.py
@@ -1,0 +1,133 @@
+"""fongmi 局域网轮询同步 API"""
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from ..core.config import config_manager
+from ..core.logging import logger
+from ..services.fongmi.sync_service import FongmiSyncResult, fongmi_sync_service
+from .deps import get_current_user_flexible
+
+router = APIRouter(prefix="/api/fongmi", tags=["fongmi"])
+
+
+class DebugSyncRequest(BaseModel):
+    """调试单设备同步请求"""
+
+    device_ip: str
+    device_port: int = 9978
+    device_name: str = ""
+
+
+@router.get("/status")
+async def fongmi_status(
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    cfg = config_manager.get_fongmi_config()
+    return {
+        "status": "success",
+        "data": {
+            "enabled": bool(cfg.get("enabled")),
+            "devices": cfg.get("devices"),
+            "subnet": cfg.get("subnet"),
+            "auto_scan": cfg.get("auto_scan"),
+            "sync_interval": cfg.get("sync_interval"),
+            "min_percent": cfg.get("min_percent"),
+        },
+    }
+
+
+@router.post("/sync/manual")
+async def fongmi_manual_sync(
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    cfg = config_manager.get_fongmi_config()
+    if not cfg.get("enabled"):
+        raise HTTPException(
+            status_code=400, detail="fongmi 同步未启用，请在配置中开启"
+        )
+
+    try:
+        result: FongmiSyncResult = await fongmi_sync_service.run_sync(
+            ignore_enabled=False
+        )
+        return {
+            "status": "success" if result.success else "error",
+            "message": result.message,
+            "data": {
+                "synced_count": result.synced_count,
+                "skipped_count": result.skipped_count,
+                "error_count": result.error_count,
+                "discovered_devices": result.discovered_devices,
+            },
+        }
+    except Exception as e:
+        logger.error(f"fongmi 手动同步失败: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/debug/scan")
+async def fongmi_debug_scan(
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    """调试用：搜寻所有配置的设备并拉取当前 /media 状态（不过滤完成进度）。
+
+    用于在调试工具中验证设备发现、/media 拉取、集数解析是否正常。
+    服务端 20 秒超时，避免网段扫描无响应时长时间挂起。
+    """
+    try:
+        data = await asyncio.wait_for(
+            fongmi_sync_service.debug_scan(), timeout=20.0
+        )
+        return {
+            "status": "success",
+            "message": f"发现 {data['discovered_devices']} 台设备",
+            "data": data,
+        }
+    except asyncio.TimeoutError:
+        logger.warning("fongmi 调试扫描超时（20s）")
+        raise HTTPException(
+            status_code=504,
+            detail="扫描超时（20秒），请检查网段配置是否过大或设备是否在线",
+        ) from None
+    except Exception as e:
+        logger.error(f"fongmi 调试扫描失败: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/debug/sync")
+async def fongmi_debug_sync_one(
+    req: DebugSyncRequest,
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    """调试用：对指定设备当前播放内容执行一次 Bangumi 同步，返回前后对比。
+
+    会实际调用 Bangumi API 标记看过（幂等），用于调试匹配是否正确。
+    服务端 30 秒超时（Bangumi API 可能较慢）。
+    """
+    try:
+        data = await asyncio.wait_for(
+            fongmi_sync_service.debug_sync_one(
+                device_ip=req.device_ip,
+                device_port=req.device_port,
+                device_name=req.device_name,
+            ),
+            timeout=30.0,
+        )
+        return {
+            "status": "success",
+            "message": data.get("after", {}).get("message", ""),
+            "data": data,
+        }
+    except asyncio.TimeoutError:
+        logger.warning(f"fongmi 调试同步超时（30s）：{req.device_ip}")
+        raise HTTPException(
+            status_code=504,
+            detail="同步超时（30秒），Bangumi API 响应过慢或网络异常",
+        ) from None
+    except Exception as e:
+        logger.error(f"fongmi 调试同步失败: {e}")
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -111,6 +111,12 @@ class ConfigManager:
             ("dev", "debug"): "DEBUG_MODE",
             ("web", "base_path"): "APPLICATION_ROOT",
             ("feiniu", "db_path"): "FEINIU_DB_PATH",
+            ("fongmi", "enabled"): "FONGMI_ENABLED",
+            ("fongmi", "devices"): "FONGMI_DEVICES",
+            ("fongmi", "subnet"): "FONGMI_SUBNET",
+            ("fongmi", "auto_scan"): "FONGMI_AUTO_SCAN",
+            ("fongmi", "sync_interval"): "FONGMI_SYNC_INTERVAL",
+            ("fongmi", "min_percent"): "FONGMI_MIN_PERCENT",
         }
 
         for (section, option), env_var in env_overrides.items():
@@ -438,6 +444,48 @@ class ConfigManager:
         out["db_path"] = str(out.get("db_path") or "").strip()
         out["user_filter"] = str(out.get("user_filter") or "all").strip() or "all"
         out["time_range"] = str(out.get("time_range") or "all").strip() or "all"
+        out["sync_interval"] = str(
+            out.get("sync_interval") or defaults["sync_interval"]
+        ).strip()
+
+        return out
+
+    def get_fongmi_config(self) -> dict[str, Any]:
+        """fongmi 局域网轮询同步配置（默认关闭）
+
+        与 feiniu 驱动不同，fongmi 不依赖本地数据库，而是通过局域网 HTTP
+        轮询设备的 /media 端点获取播放状态。
+        """
+        defaults: dict[str, Any] = {
+            "enabled": False,
+            "devices": "",
+            "subnet": "",
+            "auto_scan": True,
+            "sync_interval": "*/3 * * * *",
+            "min_percent": 80,
+        }
+        raw = self.get_section("fongmi", {})
+        out: dict[str, Any] = {**defaults, **raw}
+
+        ev = out.get("enabled", False)
+        if isinstance(ev, str):
+            out["enabled"] = ev.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            out["enabled"] = bool(ev)
+
+        av = out.get("auto_scan", True)
+        if isinstance(av, str):
+            out["auto_scan"] = av.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            out["auto_scan"] = bool(av)
+
+        try:
+            out["min_percent"] = int(out.get("min_percent", 80))
+        except (TypeError, ValueError):
+            out["min_percent"] = 80
+
+        out["devices"] = str(out.get("devices") or "").strip()
+        out["subnet"] = str(out.get("subnet") or "").strip()
         out["sync_interval"] = str(
             out.get("sync_interval") or defaults["sync_interval"]
         ).strip()

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from .api.auth import router as auth_router
 from .api.bgm_poster import router as bgm_poster_router
 from .api.config import router as config_router
 from .api.feiniu import router as feiniu_router
+from .api.fongmi import router as fongmi_router
 from .api.health import router as health_router
 from .api.inbox import router as inbox_router
 from .api.logs import router as logs_router
@@ -32,6 +33,7 @@ from .core.public_url import get_public_base_path
 from .core.startup_info import startup_info
 from .services.feiniu.scheduler import feiniu_scheduler
 from .services.feiniu.sync_service import ensure_feiniu_startup_watermark
+from .services.fongmi.scheduler import fongmi_scheduler
 from .services.mapping_service import mapping_service
 from .services.sync_service import sync_service
 from .services.trakt.scheduler import trakt_scheduler
@@ -73,6 +75,7 @@ app.include_router(notification_router)
 app.include_router(inbox_router)
 app.include_router(trakt_router)
 app.include_router(feiniu_router)
+app.include_router(fongmi_router)
 app.include_router(upgrade_router)
 
 
@@ -133,6 +136,16 @@ async def startup_event():
                     logger.error("飞牛调度器启动失败")
             except Exception as e:
                 logger.error(f"飞牛调度器启动异常: {e}")
+            try:
+                fm_ok = await fongmi_scheduler.start()
+                if fm_ok:
+                    logger.info(
+                        "fongmi 定时同步：延迟启动阶段结束（未启用时不会注册定时任务）"
+                    )
+                else:
+                    logger.error("fongmi 调度器启动失败")
+            except Exception as e:
+                logger.error(f"fongmi 调度器启动异常: {e}")
 
         task = asyncio.create_task(delayed_scheduler_start())
         _background_tasks.add(task)
@@ -166,6 +179,12 @@ async def shutdown_event():
         logger.info("飞牛调度器已停止")
     except Exception as e:
         logger.error(f"停止飞牛调度器失败: {e}")
+
+    try:
+        await fongmi_scheduler.stop()
+        logger.info("fongmi 调度器已停止")
+    except Exception as e:
+        logger.error(f"停止 fongmi 调度器失败: {e}")
 
     # 关闭同步服务线程池
     try:

--- a/app/services/fongmi/__init__.py
+++ b/app/services/fongmi/__init__.py
@@ -1,0 +1,5 @@
+"""fongmi 局域网轮询同步"""
+
+from .sync_service import fongmi_sync_service
+
+__all__ = ["fongmi_sync_service"]

--- a/app/services/fongmi/client.py
+++ b/app/services/fongmi/client.py
@@ -23,8 +23,8 @@ from .models import FongmiDevice, FongmiWatchRecord
 PORT_START = 9978
 PORT_END = 9998
 _DEFAULT_PORT = 9978
-_HTTP_TIMEOUT = 3.0        # /media 请求超时
-_PROBE_TIMEOUT = 0.3       # /device 探测超时（局域网内足够）
+_HTTP_TIMEOUT = 3.0  # /media 请求超时
+_PROBE_TIMEOUT = 0.3  # /device 探测超时（局域网内足够）
 _DISCOVER_SEMAPHORE = 100  # 网段扫描并发上限
 
 # 直播流标记（Long.MIN_VALUE）
@@ -47,8 +47,18 @@ _BRACKET_EP_RE = re.compile(r"[\[【(]\s*0*(\d{1,3})\s*[\]】)]")
 # 季号标记（仅当 N>1 时才视为多季）
 _SEASON_CN_RE = re.compile(r"第\s*([一二三四五六七八九十2-9])\s*[季期]")
 _SEASON_EN_RE = re.compile(r"[Ss]eason\s*0*([2-9]\d?)", re.IGNORECASE)
-_CN_NUM_MAP = {"一": 1, "二": 2, "三": 3, "四": 4, "五": 5,
-               "六": 6, "七": 7, "八": 8, "九": 9, "十": 10}
+_CN_NUM_MAP = {
+    "一": 1,
+    "二": 2,
+    "三": 3,
+    "四": 4,
+    "五": 5,
+    "六": 6,
+    "七": 7,
+    "八": 8,
+    "九": 9,
+    "十": 10,
+}
 
 # 文件名清理用正则
 _BRACKET_RE = re.compile(r"\[[^\]]*\]|\([^)]*\)|\{[^}]*\}|【[^】]*】|《[^》]*》")
@@ -187,6 +197,7 @@ async def _probe_ports(
     client: httpx.AsyncClient, ip: str, ports: list[int]
 ) -> tuple[int, dict] | None:
     """并行探测指定 IP 的多个端口，返回第一个命中的 (port, info)"""
+
     async def _one(p: int) -> tuple[int, dict | None]:
         return p, await _probe_device(client, ip, p)
 

--- a/app/services/fongmi/client.py
+++ b/app/services/fongmi/client.py
@@ -1,0 +1,403 @@
+"""fongmi 局域网设备发现与 /media 轮询
+
+参考 fongmi 官方 docs/LOCAL.md：
+- 端口范围 9978-9998（NanoHTTPD），默认 9978
+- GET /device → {uuid, name, ip, type, version, ...}
+- GET /media  → {state, speed, title, artist, artwork, url, duration, position}
+
+注：/media 端点为 fongmi 扩展，原版 TVBoxOSC 谱系不支持，故本驱动仅适用于
+fongmi 及其 fork（TV-K、OK影视、WebHomeTV 等）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import httpx
+
+from ...core.logging import logger
+from .models import FongmiDevice, FongmiWatchRecord
+
+# 端口与超时
+PORT_START = 9978
+PORT_END = 9998
+_DEFAULT_PORT = 9978
+_HTTP_TIMEOUT = 3.0        # /media 请求超时
+_PROBE_TIMEOUT = 0.3       # /device 探测超时（局域网内足够）
+_DISCOVER_SEMAPHORE = 100  # 网段扫描并发上限
+
+# 直播流标记（Long.MIN_VALUE）
+_LONG_MIN = -9223372036854775808
+
+# ===== 集数/季号解析 =====
+#
+# 季号策略（方案 B）：
+#   仅当出现 *明确的* 季号标记（S02E03 中 S>1、"第二季"、"Season 2"）才返回 season>1；
+#   S01/S00/无标记 一律视为 season=1，交给 SyncService 沿 Bangumi 续集链查找。
+#   避免源站统一标记为 S01 时误匹配到某一具体季。
+#
+# 集号优先级：SxxExx > EP/Exx > 第N集 > #N > [N] > 文件名兜底
+_SEASON_EP_RE = re.compile(r"[Ss](\d{1,2})\s*\.?[Ee](\d{1,3})", re.IGNORECASE)
+_EP_RE = re.compile(r"\b[Ee][Pp]?[\s.\-_]?\s*0*(\d{1,3})\b", re.IGNORECASE)
+_CN_EP_RE = re.compile(r"第\s*0*(\d{1,3})\s*[集话話章回]")
+_HASH_EP_RE = re.compile(r"#\s*0*(\d{1,3})\b")
+_BRACKET_EP_RE = re.compile(r"[\[【(]\s*0*(\d{1,3})\s*[\]】)]")
+
+# 季号标记（仅当 N>1 时才视为多季）
+_SEASON_CN_RE = re.compile(r"第\s*([一二三四五六七八九十2-9])\s*[季期]")
+_SEASON_EN_RE = re.compile(r"[Ss]eason\s*0*([2-9]\d?)", re.IGNORECASE)
+_CN_NUM_MAP = {"一": 1, "二": 2, "三": 3, "四": 4, "五": 5,
+               "六": 6, "七": 7, "八": 8, "九": 9, "十": 10}
+
+# 文件名清理用正则
+_BRACKET_RE = re.compile(r"\[[^\]]*\]|\([^)]*\)|\{[^}]*\}|【[^】]*】|《[^》]*》")
+_SIZE_RE = re.compile(r"\d+(?:\.\d+)?\s*(?:KB|MB|GB|TB)", re.IGNORECASE)
+_RESOLUTION_RE = re.compile(
+    r"\b(?:4K|2160P|1080P|720P|480P|360P|UHD|FHD|HD|HDR)\b", re.IGNORECASE
+)
+_RANGE_RE = re.compile(r"\b\d{1,4}\s*-\s*\d{1,4}\b")
+_FIRST_NUM_RE = re.compile(r"\d{1,3}")
+
+
+def _extract_episode_from_filename(text: str) -> int:
+    """文件名兜底：清理后取第一个 1-3 位数字。
+
+    移除扩展名、方括号内容、文件大小、分辨率、合集范围、季号标记后取首个数字。
+    """
+    if not text:
+        return 0
+    filename = text.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    filename = re.sub(r"\.\w+$", "", filename)
+    filename = _BRACKET_RE.sub(" ", filename)
+    filename = _SIZE_RE.sub(" ", filename)
+    filename = _RESOLUTION_RE.sub(" ", filename)
+    filename = _RANGE_RE.sub(" ", filename)
+    filename = _SEASON_CN_RE.sub(" ", filename)
+    filename = _SEASON_EN_RE.sub(" ", filename)
+    m = _FIRST_NUM_RE.search(filename)
+    if m:
+        n = int(m.group())
+        if 1 <= n <= 999:
+            return n
+    return 0
+
+
+def _detect_explicit_season(text: str) -> int:
+    """检测明确的季号标记，仅在 N>1 时返回 N，否则返回 1。"""
+    if not text:
+        return 1
+    m = _SEASON_CN_RE.search(text)
+    if m:
+        token = m.group(1)
+        n = _CN_NUM_MAP.get(token) or (int(token) if token.isdigit() else 0)
+        if n > 1:
+            return n
+    m = _SEASON_EN_RE.search(text)
+    if m:
+        n = int(m.group(1))
+        if n > 1:
+            return n
+    return 1
+
+
+def parse_episode_info(url: str, artist: str) -> tuple[int, int]:
+    """从 /media 的 url 与 artist 解析 (season, episode)。
+
+    方案 B：S01/S00/无标记 → season=1；仅 S>1 或「第二季」「Season 2」→ season>1。
+    集号优先级：url > artist；缺失回退为 1。
+    """
+    sources = [s for s in (url or "", artist or "") if s]
+
+    # 1. SxxExx（同时解析 season）
+    for text in sources:
+        m = _SEASON_EP_RE.search(text)
+        if m:
+            s = int(m.group(1))
+            ep = max(1, int(m.group(2)))
+            return (s if s > 1 else 1, ep)
+
+    # 2-6. 仅解析集号
+    episode = 0
+    for pattern in (_EP_RE, _CN_EP_RE, _HASH_EP_RE, _BRACKET_EP_RE):
+        if episode:
+            break
+        for text in sources:
+            m = pattern.search(text)
+            if m:
+                episode = max(1, int(m.group(1)))
+                break
+
+    # 6. 文件名兜底
+    if not episode:
+        for text in sources:
+            ep = _extract_episode_from_filename(text)
+            if ep > 0:
+                episode = ep
+                break
+
+    if not episode:
+        episode = 1
+
+    # 季号判定
+    season = 1
+    for text in sources:
+        s = _detect_explicit_season(text)
+        if s > 1:
+            season = s
+            break
+
+    return season, episode
+
+
+# ===== 设备发现与探测 =====
+
+
+def _is_fongmi_device_info(info: dict) -> bool:
+    """判断 /device 返回是否像 fongmi 设备"""
+    return any(k in info for k in ("uuid", "name", "ip"))
+
+
+def _build_device(ip: str, port: int, info: dict) -> FongmiDevice:
+    """从 /device 响应构造 FongmiDevice"""
+    return FongmiDevice(
+        ip=ip,
+        port=port,
+        uuid=str(info.get("uuid", "")),
+        name=str(info.get("name", ip)),
+        device_type=int(info.get("type", 0) or 0),
+        version=str(info.get("version", "")),
+    )
+
+
+async def _probe_device(client: httpx.AsyncClient, ip: str, port: int) -> dict | None:
+    """探测单个 ip:port 的 /device 端点"""
+    try:
+        resp = await client.get(f"http://{ip}:{port}/device", timeout=_PROBE_TIMEOUT)
+        if resp.status_code == 200:
+            info = resp.json()
+            if isinstance(info, dict) and _is_fongmi_device_info(info):
+                return info
+    except Exception:
+        pass
+    return None
+
+
+async def _probe_ports(
+    client: httpx.AsyncClient, ip: str, ports: list[int]
+) -> tuple[int, dict] | None:
+    """并行探测指定 IP 的多个端口，返回第一个命中的 (port, info)"""
+    async def _one(p: int) -> tuple[int, dict | None]:
+        return p, await _probe_device(client, ip, p)
+
+    tasks = [asyncio.create_task(_one(p)) for p in ports]
+    for result in await asyncio.gather(*tasks, return_exceptions=True):
+        if isinstance(result, tuple) and result[1]:
+            return result
+    return None
+
+
+async def discover_devices(
+    subnet: str, base_client: httpx.AsyncClient | None = None
+) -> list[FongmiDevice]:
+    """扫描网段（如 192.168.1）的默认端口 9978，发现 fongmi 设备。
+
+    只探测 9978（254 次），不扫全端口范围。非标端口设备请在 devices 配置中指定 ip:port。
+    """
+    if not subnet:
+        return []
+
+    own_client = base_client is None
+    client = base_client or httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=300, max_keepalive_connections=50)
+    )
+    found: list[FongmiDevice] = []
+
+    async def _check(ip: str) -> FongmiDevice | None:
+        info = await _probe_device(client, ip, _DEFAULT_PORT)
+        return _build_device(ip, _DEFAULT_PORT, info) if info else None
+
+    try:
+        sem = asyncio.Semaphore(_DISCOVER_SEMAPHORE)
+
+        async def _bounded(ip: str) -> FongmiDevice | None:
+            async with sem:
+                return await _check(ip)
+
+        tasks = [asyncio.create_task(_bounded(f"{subnet}.{i}")) for i in range(1, 255)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in results:
+            if isinstance(r, FongmiDevice):
+                found.append(r)
+    finally:
+        if own_client:
+            await client.aclose()
+
+    logger.info(f"fongmi 设备发现：网段 {subnet}.0/24 共找到 {len(found)} 台设备")
+    return found
+
+
+async def parse_device_entry(
+    entry: str, base_client: httpx.AsyncClient | None = None
+) -> FongmiDevice | None:
+    """解析手动配置的单个设备入口（ip 或 ip:port），查询 /device 补全信息。
+
+    指定端口则只探测该端口；未指定则默认端口 9978 优先，未命中再并行扫其余端口。
+    """
+    entry = (entry or "").strip()
+    if not entry:
+        return None
+
+    host = entry
+    port = 0
+    if ":" in entry:
+        parts = entry.rsplit(":", 1)
+        if parts[1].isdigit():
+            host, port_str = parts
+            port = int(port_str)
+
+    own_client = base_client is None
+    client = base_client or httpx.AsyncClient()
+    try:
+        # 指定端口或默认端口 9978：单次探测
+        target_port = port or _DEFAULT_PORT
+        info = await _probe_device(client, host, target_port)
+        if info:
+            return _build_device(host, target_port, info)
+        if port:
+            return None
+
+        # 默认端口未命中，并行探测其余端口
+        other_ports = [p for p in range(PORT_START, PORT_END + 1) if p != _DEFAULT_PORT]
+        hit = await _probe_ports(client, host, other_ports)
+        if hit:
+            return _build_device(host, hit[0], hit[1])
+    finally:
+        if own_client:
+            await client.aclose()
+    return None
+
+
+# ===== /media 拉取与解析 =====
+
+
+async def fetch_media(device: FongmiDevice, client: httpx.AsyncClient) -> dict | None:
+    """获取单台设备的 /media 播放状态"""
+    try:
+        resp = await client.get(
+            f"http://{device.ip}:{device.port}/media", timeout=_HTTP_TIMEOUT
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        pass
+    return None
+
+
+def media_is_complete(media: dict, min_percent: int) -> bool:
+    """判断 /media 是否达到「看完」条件
+
+    - duration 为正且 position/duration >= min_percent/100
+    - 直播流（duration <= 0 或 Long.MIN_VALUE）不视为完成
+    """
+    if not media or not media.get("title"):
+        return False
+    duration = media.get("duration", 0) or 0
+    if duration <= 0 or duration == _LONG_MIN:
+        return False
+    position = media.get("position", 0) or 0
+    if position <= 0:
+        return False
+    return (position / duration) >= (min_percent / 100.0)
+
+
+def media_to_record(device: FongmiDevice, media: dict) -> FongmiWatchRecord | None:
+    """将 /media 转为 FongmiWatchRecord（仅提取字段，不判断是否完成）"""
+    title = (media.get("title") or "").strip()
+    if not title:
+        return None
+    url = str(media.get("url") or "")
+    artist = media.get("artist")
+    artist_s = str(artist) if artist else None
+    season, episode = parse_episode_info(url, artist_s or "")
+    return FongmiWatchRecord(
+        device_ip=device.ip,
+        device_name=device.name,
+        title=title,
+        episode=episode,
+        season=season,
+        episode_url=url,
+        artist=artist_s,
+        release_date="",
+    )
+
+
+def media_to_debug_dict(device: FongmiDevice, media: dict | None) -> dict:
+    """将 /media 转为调试展示用的 dict（含解析后的集号与进度百分比）"""
+    base = {
+        "device_ip": device.ip,
+        "device_port": device.port,
+        "device_name": device.name,
+    }
+    if not media:
+        return {**base, "media": None}
+
+    url = str(media.get("url") or "")
+    artist = media.get("artist")
+    artist_s = str(artist) if artist else ""
+    season, episode = parse_episode_info(url, artist_s)
+    duration = media.get("duration", 0) or 0
+    position = media.get("position", 0) or 0
+    percent = 0.0
+    if duration > 0 and duration != _LONG_MIN and position > 0:
+        percent = round(position / duration * 100, 1)
+    return {
+        **base,
+        "media": {
+            "state": media.get("state"),
+            "title": (media.get("title") or "").strip(),
+            "url": url,
+            "artist": artist_s,
+            "duration": duration,
+            "position": position,
+            "percent": percent,
+            "parsed_season": season,
+            "parsed_episode": episode,
+        },
+    }
+
+
+async def fetch_completed_records(
+    devices: list[FongmiDevice], min_percent: int
+) -> list[FongmiWatchRecord]:
+    """并行拉取所有设备的 /media，返回达到「看完」条件的观看记录"""
+    if not devices:
+        return []
+    records: list[FongmiWatchRecord] = []
+    async with httpx.AsyncClient() as client:
+        tasks = [fetch_media(d, client) for d in devices]
+        media_list = await asyncio.gather(*tasks, return_exceptions=True)
+        for device, media in zip(devices, media_list):
+            if isinstance(media, Exception) or not media:
+                continue
+            if not media_is_complete(media, min_percent):
+                continue
+            rec = media_to_record(device, media)
+            if rec:
+                records.append(rec)
+    return records
+
+
+async def fetch_all_media_status(devices: list[FongmiDevice]) -> list[dict]:
+    """并行拉取所有设备的 /media 当前状态（不过滤完成），返回调试展示用 dict 列表"""
+    if not devices:
+        return []
+    async with httpx.AsyncClient() as client:
+        tasks = [fetch_media(d, client) for d in devices]
+        media_list = await asyncio.gather(*tasks, return_exceptions=True)
+    return [
+        media_to_debug_dict(d, m if isinstance(m, dict) else None)
+        for d, m in zip(devices, media_list)
+    ]

--- a/app/services/fongmi/models.py
+++ b/app/services/fongmi/models.py
@@ -1,0 +1,36 @@
+"""fongmi 设备与观看记录模型"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FongmiDevice:
+    """单台 fongmi 设备（来自 /device 端点）"""
+
+    ip: str
+    port: int
+    uuid: str
+    name: str
+    device_type: int  # 0=手机, 1=电视
+    version: str = ""
+
+
+@dataclass(frozen=True)
+class FongmiWatchRecord:
+    """单条可同步的观看记录（已满足「看完」条件）
+
+    fongmi 的 /media 端点无直接集数字段，集号需从 url/artist 解析，
+    解析失败时回退为 1。release_date 在 /media 中也无可信来源，统一传空串，
+    让 SyncService 侧按标题/季/集匹配。
+    """
+
+    device_ip: str
+    device_name: str
+    title: str
+    episode: int
+    season: int
+    episode_url: str
+    artist: str | None = None
+    release_date: str = ""

--- a/app/services/fongmi/scheduler.py
+++ b/app/services/fongmi/scheduler.py
@@ -1,0 +1,150 @@
+"""fongmi 局域网轮询定时同步（单任务，Cron 来自 config.ini [fongmi]）"""
+
+from __future__ import annotations
+
+import asyncio
+
+from apscheduler.executors.asyncio import AsyncIOExecutor
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from ...core.config import config_manager
+from ...core.logging import logger
+from .sync_service import fongmi_sync_service
+
+
+class FongmiScheduler:
+    JOB_ID = "fongmi_media_sync"
+
+    def __init__(self) -> None:
+        self.scheduler: AsyncIOScheduler | None = None
+        self._scheduler_config = config_manager.get_scheduler_config()
+
+    def _fongmi_enabled(self) -> bool:
+        cfg = config_manager.get_fongmi_config()
+        return bool(cfg.get("enabled"))
+
+    async def start(self) -> bool:
+        try:
+            if self.scheduler and self.scheduler.running:
+                if self._fongmi_enabled():
+                    self._schedule_or_refresh_job()
+                else:
+                    try:
+                        self.scheduler.remove_job(self.JOB_ID)
+                    except Exception:
+                        pass
+                return True
+
+            if not self._fongmi_enabled():
+                logger.info(
+                    "fongmi 同步未启用，本次不注册定时任务（APScheduler 未创建）"
+                )
+                return True
+
+            jobstores = {"default": MemoryJobStore()}
+            executors = {"default": AsyncIOExecutor()}
+            job_defaults = {
+                "coalesce": True,
+                "max_instances": 1,
+                "misfire_grace_time": 60,
+            }
+            self.scheduler = AsyncIOScheduler(
+                jobstores=jobstores,
+                executors=executors,
+                job_defaults=job_defaults,
+                timezone="Asia/Shanghai",
+            )
+            self.scheduler.start()
+            self._schedule_or_refresh_job()
+            logger.info("fongmi 调度器启动成功")
+            return True
+        except Exception as e:
+            logger.error(f"启动 fongmi 调度器失败: {e}")
+            return False
+
+    async def stop(self) -> bool:
+        try:
+            if self.scheduler and self.scheduler.running:
+                self.scheduler.shutdown()
+                self.scheduler = None
+                logger.info("fongmi 调度器已停止")
+            return True
+        except Exception as e:
+            logger.error(f"停止 fongmi 调度器失败: {e}")
+            return False
+
+    def _default_cron_trigger(self) -> CronTrigger:
+        """与 config.ini / get_fongmi_config 默认一致：每 5 分钟"""
+        return CronTrigger(
+            minute="*/5",
+            hour="*",
+            day="*",
+            month="*",
+            day_of_week="*",
+        )
+
+    def _parse_cron(self, cron_expression: str) -> CronTrigger:
+        parts = cron_expression.split()
+        if len(parts) != 5:
+            logger.warning(f"fongmi Cron 无效，使用默认每 5 分钟: {cron_expression}")
+            return self._default_cron_trigger()
+        return CronTrigger(
+            minute=parts[0],
+            hour=parts[1],
+            day=parts[2],
+            month=parts[3],
+            day_of_week=parts[4],
+        )
+
+    def _schedule_or_refresh_job(self) -> None:
+        if not self.scheduler or not self.scheduler.running:
+            return
+        cfg = config_manager.get_fongmi_config()
+        cron_expr = cfg.get("sync_interval") or "*/5 * * * *"
+        trigger = self._parse_cron(str(cron_expr))
+
+        try:
+            self.scheduler.remove_job(self.JOB_ID)
+        except Exception:
+            pass
+
+        self.scheduler.add_job(
+            func=self._run_sync_job,
+            trigger=trigger,
+            id=self.JOB_ID,
+            name="fongmi media sync",
+            replace_existing=True,
+        )
+        logger.info(f"fongmi 定时任务已注册: {cron_expr}")
+
+    async def _run_sync_job(self) -> None:
+        if not self._fongmi_enabled():
+            logger.debug("fongmi 未启用，跳过定时同步")
+            return
+        timeout = self._scheduler_config.get("job_timeout", 300)
+        try:
+            await asyncio.wait_for(fongmi_sync_service.run_sync(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.error(f"fongmi 定时同步超时 ({timeout} 秒)")
+        except Exception as e:
+            logger.error(f"fongmi 定时同步失败: {e}")
+
+    def reload_job_if_running(self) -> None:
+        """配置保存后若调度器在运行，则按新 Cron 重建任务（无需整进程重启）"""
+        if self.scheduler and self.scheduler.running and self._fongmi_enabled():
+            self._schedule_or_refresh_job()
+
+    async def apply_config_after_save(self) -> None:
+        """保存 config.ini 后同步调度状态（与 Web 配置联动）"""
+        if self._fongmi_enabled():
+            if not self.scheduler or not self.scheduler.running:
+                await self.start()
+            else:
+                self._schedule_or_refresh_job()
+        else:
+            await self.stop()
+
+
+fongmi_scheduler = FongmiScheduler()

--- a/app/services/fongmi/sync_service.py
+++ b/app/services/fongmi/sync_service.py
@@ -129,7 +129,10 @@ class FongmiSyncService:
         return FongmiSyncResult(
             ok,
             f"fongmi 同步: 已提交 {synced}, 跳过 {skipped}, 失败 {errors}",
-            synced, skipped, errors, len(devices),
+            synced,
+            skipped,
+            errors,
+            len(devices),
         )
 
     async def debug_scan(self) -> dict:
@@ -154,8 +157,11 @@ class FongmiSyncService:
         返回 {before: FongMi 解析结果, after: Bangumi 匹配+标记结果}。
         """
         device = FongmiDevice(
-            ip=device_ip, port=device_port, uuid="",
-            name=device_name or device_ip, device_type=0,
+            ip=device_ip,
+            port=device_port,
+            uuid="",
+            name=device_name or device_ip,
+            device_type=0,
         )
 
         async with httpx.AsyncClient() as client:
@@ -170,7 +176,10 @@ class FongmiSyncService:
         rec = media_to_record(device, media)
         if not rec:
             return {
-                "before": {"device_ip": device_ip, "title": (media.get("title") or "").strip()},
+                "before": {
+                    "device_ip": device_ip,
+                    "title": (media.get("title") or "").strip(),
+                },
                 "after": {"status": "error", "message": "无法解析播放记录（标题为空）"},
             }
 
@@ -193,7 +202,10 @@ class FongmiSyncService:
             )
         except Exception as e:
             logger.error(f"fongmi 调试同步执行失败: {e}")
-            return {"before": before, "after": {"status": "error", "message": f"同步异常: {e}"}}
+            return {
+                "before": before,
+                "after": {"status": "error", "message": f"同步异常: {e}"},
+            }
 
         after = {
             "status": result.status,

--- a/app/services/fongmi/sync_service.py
+++ b/app/services/fongmi/sync_service.py
@@ -1,0 +1,209 @@
+"""fongmi 观看记录 → CustomItem → SyncService
+
+通过局域网轮询 /media 端点获取实时播放状态。去重采用进程内 set
+（设备 IP + episode_url），不新增数据库表，避免侵入 database 模块。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import httpx
+
+from ...core.config import config_manager
+from ...core.logging import logger
+from ...models.sync import CustomItem
+from ..sync_service import sync_service
+from .client import (
+    discover_devices,
+    fetch_all_media_status,
+    fetch_completed_records,
+    fetch_media,
+    media_to_record,
+    parse_device_entry,
+)
+from .models import FongmiDevice, FongmiWatchRecord
+
+# 同步记录 / 通知中的来源标识（与 Plex、Trakt、feiniu 等并列）
+FONGMI_SYNC_SOURCE = "fongmi"
+
+
+@dataclass
+class FongmiSyncResult:
+    success: bool
+    message: str
+    synced_count: int
+    skipped_count: int
+    error_count: int
+    discovered_devices: int = 0
+
+
+class FongmiSyncService:
+    """fongmi 同步服务
+
+    进程内去重集合：{(device_ip, episode_url)}，每个设备每集只同步一次。
+    进程重启后集合清空，但已标记过的 Bangumi 条目重复标记无副作用（幂等）。
+    """
+
+    _synced_keys: set[tuple[str, str]] = set()
+
+    def _record_to_custom_item(self, rec: FongmiWatchRecord) -> CustomItem:
+        return CustomItem(
+            media_type="episode",
+            title=rec.title,
+            ori_title=None,
+            season=rec.season,
+            episode=rec.episode,
+            release_date=rec.release_date,
+            user_name=rec.device_name,
+            source=FONGMI_SYNC_SOURCE,
+        )
+
+    async def _resolve_devices(self, cfg: dict) -> list[FongmiDevice]:
+        """根据配置解析要轮询的设备列表（手动配置优先，可选网段扫描）"""
+        devices: list[FongmiDevice] = []
+        raw_devices = (cfg.get("devices") or "").strip()
+        if raw_devices:
+            entries = [s.strip() for s in raw_devices.split(",") if s.strip()]
+            results = await asyncio.gather(
+                *[parse_device_entry(e) for e in entries],
+                return_exceptions=True,
+            )
+            for entry, res in zip(entries, results):
+                if isinstance(res, Exception):
+                    logger.warning(f"fongmi 设备连接异常: {entry} - {res}")
+                elif res:
+                    devices.append(res)
+                    logger.info(f"fongmi 设备已连接: {res.name} ({res.ip}:{res.port})")
+                else:
+                    logger.warning(f"fongmi 设备连接失败: {entry}")
+
+        if cfg.get("auto_scan") and (cfg.get("subnet") or "").strip():
+            found = await discover_devices(str(cfg["subnet"]).strip())
+            existing_ips = {d.ip for d in devices}
+            for d in found:
+                if d.ip not in existing_ips:
+                    devices.append(d)
+
+        return devices
+
+    async def run_sync(self, *, ignore_enabled: bool = False) -> FongmiSyncResult:
+        cfg = config_manager.get_fongmi_config()
+        if not ignore_enabled and not cfg.get("enabled"):
+            return FongmiSyncResult(True, "fongmi 同步未启用", 0, 0, 0)
+
+        devices = await self._resolve_devices(cfg)
+        if not devices:
+            return FongmiSyncResult(False, "未发现任何 fongmi 设备", 0, 0, 0, 0)
+
+        min_percent = int(cfg.get("min_percent") or 95)
+        records = await fetch_completed_records(devices, min_percent)
+
+        synced = skipped = errors = 0
+        for rec in records:
+            key = (rec.device_ip, rec.episode_url)
+            if key in self._synced_keys:
+                skipped += 1
+                continue
+
+            item = self._record_to_custom_item(rec)
+            try:
+                result = await asyncio.to_thread(
+                    sync_service.sync_custom_item, item, FONGMI_SYNC_SOURCE
+                )
+            except Exception as e:
+                logger.error(f"fongmi 单条同步执行失败: {e}")
+                errors += 1
+                continue
+
+            if result.status == "success":
+                self._synced_keys.add(key)
+                synced += 1
+            elif result.status == "ignored":
+                skipped += 1
+            else:
+                errors += 1
+
+        ok = errors == 0
+        return FongmiSyncResult(
+            ok,
+            f"fongmi 同步: 已提交 {synced}, 跳过 {skipped}, 失败 {errors}",
+            synced, skipped, errors, len(devices),
+        )
+
+    async def debug_scan(self) -> dict:
+        """调试用：搜寻设备并拉取当前 /media 状态（不过滤完成）"""
+        cfg = config_manager.get_fongmi_config()
+        logger.info(
+            f"fongmi 调试扫描开始：enabled={cfg.get('enabled')}, "
+            f"devices={cfg.get('devices')!r}, auto_scan={cfg.get('auto_scan')}, "
+            f"subnet={cfg.get('subnet')!r}"
+        )
+        devices = await self._resolve_devices(cfg)
+        logger.info(f"fongmi 调试扫描：发现 {len(devices)} 台设备")
+        media_list = await fetch_all_media_status(devices)
+        logger.info(f"fongmi 调试扫描：拉取到 {len(media_list)} 条媒体状态")
+        return {"discovered_devices": len(devices), "devices": media_list}
+
+    async def debug_sync_one(
+        self, device_ip: str, device_port: int, device_name: str
+    ) -> dict:
+        """调试用：对指定设备当前播放内容执行一次 Bangumi 同步，返回前后对比。
+
+        返回 {before: FongMi 解析结果, after: Bangumi 匹配+标记结果}。
+        """
+        device = FongmiDevice(
+            ip=device_ip, port=device_port, uuid="",
+            name=device_name or device_ip, device_type=0,
+        )
+
+        async with httpx.AsyncClient() as client:
+            media = await fetch_media(device, client)
+
+        if not media:
+            return {
+                "before": {"device_ip": device_ip, "media": None},
+                "after": {"status": "error", "message": "无法拉取该设备的 /media 状态"},
+            }
+
+        rec = media_to_record(device, media)
+        if not rec:
+            return {
+                "before": {"device_ip": device_ip, "title": (media.get("title") or "").strip()},
+                "after": {"status": "error", "message": "无法解析播放记录（标题为空）"},
+            }
+
+        before = {
+            "device_ip": device_ip,
+            "device_name": device.name,
+            "title": rec.title,
+            "season": rec.season,
+            "episode": rec.episode,
+            "url": rec.episode_url,
+            "artist": rec.artist,
+            "duration": media.get("duration", 0),
+            "position": media.get("position", 0),
+        }
+
+        item = self._record_to_custom_item(rec)
+        try:
+            result = await asyncio.to_thread(
+                sync_service.sync_custom_item, item, FONGMI_SYNC_SOURCE
+            )
+        except Exception as e:
+            logger.error(f"fongmi 调试同步执行失败: {e}")
+            return {"before": before, "after": {"status": "error", "message": f"同步异常: {e}"}}
+
+        after = {
+            "status": result.status,
+            "message": result.message,
+            "data": result.data or {},
+        }
+        if result.status == "success":
+            self._synced_keys.add((rec.device_ip, rec.episode_url))
+
+        return {"before": before, "after": after}
+
+
+fongmi_sync_service = FongmiSyncService()

--- a/config.ini
+++ b/config.ini
@@ -279,3 +279,13 @@ time_range = all
 # 每 15 分钟扫描一次（五段式 Cron）
 sync_interval = */15 * * * *
 limit = 100
+
+# fongmi 插件设置，默认关闭；开启后只读 fongmi 数据库目录下的 fongmi.db，按进度同步到 Bangumi。
+# 详见 README「fongmi」章节。
+[fongmi]
+enabled = false
+devices = 
+subnet = 192.168.1
+auto_scan = True
+min_percent = 80
+sync_interval = */3 * * * *

--- a/config.ini
+++ b/config.ini
@@ -280,12 +280,17 @@ time_range = all
 sync_interval = */15 * * * *
 limit = 100
 
-# fongmi 插件设置，默认关闭；开启后只读 fongmi 数据库目录下的 fongmi.db，按进度同步到 Bangumi。
+# fongmi 插件设置，默认关闭；开启后使用定时轮询的方式在局域网内扫描设备并拉取播放信息，按进度同步到 Bangumi。
 # 详见 README「fongmi」章节。
 [fongmi]
 enabled = false
+# 设备列表，留空则扫描局域网内所有设备。填写 IP 地址，多个用英文逗号分隔。
 devices = 
+# 局域网子网段，默认 192.168.1.x。填写子网段可加快扫描速度。
 subnet = 192.168.1
+# 是否自动扫描
 auto_scan = True
+# 播放进度百分比阈值（默认80%），低于此值的播放进度不会同步到 Bangumi。
 min_percent = 80
+# 默认每 3 分钟扫描一次（五段式 Cron）。
 sync_interval = */3 * * * *

--- a/docs/usage/fongmi.md
+++ b/docs/usage/fongmi.md
@@ -1,0 +1,100 @@
+---
+title: 📺 fongmi 局域网同步
+order: 17
+---
+
+# 📺 fongmi 局域网同步
+
+通过定时轮询局域网内 [fongmi](https://github.com/fongmi) 设备的内置 HTTP API，检测「看完」的剧集并自动提交到 Bangumi。无需修改 APP 或安装插件。
+
+## 1. 适用范围
+
+本驱动依赖 fongmi 扩展的 `/media` 与 `/device` 端点，**仅适用于 fongmi 及其 fork**：
+
+- [fongmi](https://github.com/fongmi)（蜂蜜影视，本体）
+- [TV-K](https://github.com/kknifer7/TV-K)（影视-K版）
+- [OK影视](https://github.com/okcaptain/TV)
+- [WebHomeTV](https://github.com/motao123/webtv)
+- 其他基于 fongmi 的二开版本
+
+::: tip 判断方法
+在设备上打开 fongmi APP，用浏览器访问 `http://设备IP:9978/media`，若返回 JSON 则支持。
+:::
+
+::: warning 不兼容原版 TVBoxOSC
+原版 TVBoxOSC 谱系（q215613905/TVBoxOS、takagen99/Box 等）没有 `/media` 端点，无法使用本驱动。
+:::
+
+## 2. 工作原理
+
+```
+Bangumi-syncer  ──轮询──>  fongmi APP（电视/手机）
+     │                         │
+     │  GET /device             │  设备信息（uuid/name/ip/type）
+     │  GET /media              │  播放状态（title/url/position/duration）
+     │                          │
+     └── 检测播放完成(≥95%) ──>  标记 Bangumi 单集为看过
+```
+
+- **设备发现**：扫描局域网 9978-9998 端口，通过 `/device` 端点识别 fongmi 设备
+- **集数解析**：从 `/media` 的 `url` 与 `artist` 字段解析集号（支持 `S01E001`、`EP01`、`第N集` 等格式）
+- **完成判定**：`position / duration ≥ min_percent`（默认 95%），直播流不判定
+- **去重**：每个设备每集只同步一次（进程内去重，重启后重置，Bangumi 标记操作幂等）
+
+## 3. 配置
+
+### 在 WebUI「配置管理」中设置
+
+- 在配置区找到 **fongmi**。
+- 勾选 **启用**。
+- **设备 IP**：手动指定设备 IP（逗号分隔，可带端口），例如 `192.168.1.100` 或 `192.168.1.100:9979`。
+- **自动扫描**：开启后会扫描下方网段。
+- **网段**：例如 `192.168.1`（会扫描 `192.168.1.1-254` 的 9978-9998 端口）。
+- **视为看完的最低进度**：默认 80%。
+- **定时 Cron**：默认每 5 分钟 `*/5 * * * *`。
+- 保存配置后，定时任务会随配置热更新，无需重启。
+
+### Docker 部署注意事项
+
+fongmi 设备发现依赖局域网扫描，Docker 部署时需使用 `host` 网络模式：
+
+```yaml
+services:
+  bangumi-syncer:
+    network_mode: host
+    environment:
+      - FONGMI_ENABLED=true
+      - FONGMI_DEVICES=192.168.1.100
+      # 或自动扫描
+      - FONGMI_AUTO_SCAN=true
+      - FONGMI_SUBNET=192.168.1
+```
+
+::: warning
+bridge 网络模式下容器只能扫描到 `172.x.x.x` 网段，无法发现局域网设备。
+:::
+
+### 环境变量
+
+| 环境变量               | 说明                           |
+| ---------------------- | ------------------------------ |
+| `FONGMI_ENABLED`       | 启用同步（`true`/`false`）     |
+| `FONGMI_DEVICES`       | 设备 IP 列表（逗号分隔）       |
+| `FONGMI_SUBNET`        | 自动扫描网段                   |
+| `FONGMI_AUTO_SCAN`     | 启用自动扫描（`true`/`false`） |
+| `FONGMI_SYNC_INTERVAL` | 定时 Cron 表达式               |
+| `FONGMI_MIN_PERCENT`   | 完成阈值百分比                 |
+
+## 4. API
+
+| 端点                      | 方法 | 说明                                 |
+| ------------------------- | ---- | ------------------------------------ |
+| `/api/fongmi/status`      | GET  | 查看配置状态                         |
+| `/api/fongmi/sync/manual` | POST | 手动触发一次同步                     |
+| `/api/fongmi/debug/scan`  | POST | 调试：搜寻设备并拉取 /media 状态     |
+| `/api/fongmi/debug/sync`  | POST | 调试：指定设备执行同步，返回前后对比 |
+
+## 5. 手动同步测试
+
+- 调用 `POST /api/fongmi/sync/manual` 或在 WebUI 调试工具中触发。
+- 查看返回的 `synced_count` 与同步记录。

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2221,6 +2221,12 @@ main.app-main > *:nth-child(12) {
     border: 1px solid rgba(20, 184, 166, 0.2);
 }
 
+.tl-source--fongmi {
+    background-color: rgba(59, 130, 246, 0.12);
+    color: #2563eb;
+    border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
 .tl-source--test {
     background-color: rgba(108, 117, 125, 0.12);
     color: var(--app-text-muted);
@@ -2251,6 +2257,11 @@ main.app-main > *:nth-child(12) {
 [data-theme="dark"] .tl-source--feiniu {
     background-color: rgba(20, 184, 166, 0.15);
     color: #14b8a6;
+}
+
+[data-theme="dark"] .tl-source--fongmi {
+    background-color: rgba(59, 130, 246, 0.15);
+    color: #60a5fa;
 }
 
 .tl-time {

--- a/templates/config.html
+++ b/templates/config.html
@@ -902,6 +902,114 @@
                 </div>
             </div>
         </div>
+        <!-- fongmi -->
+        <div class="row">
+            <div class="col-12">
+                <div id="config-section-fongmi" class="card shadow-sm mb-4 config-card">
+                    <div class="card-header py-3">
+                        <div class="d-flex align-items-center">
+                            <i class="bi bi-tv me-2 text-secondary"></i>
+                            <h6 class="m-0 fw-semibold">fongmi 局域网同步</h6>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-12">
+                                <div class="form-check form-switch mb-3">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="fongmi-enabled"
+                                           name="fongmi.enabled">
+                                    <label class="form-check-label fw-semibold" for="fongmi-enabled">
+                                        <i class="bi bi-tv me-1 text-secondary"></i>启用 fongmi 同步
+                                        <i class="bi bi-question-circle ms-1 text-muted"
+                                           data-bs-toggle="tooltip"
+                                           title="默认关闭。开启后会定时轮询局域网内 fongmi 设备的 /media 端点，检测「看完」的剧集并提交到 Bangumi。仅支持 fongmi 及其 fork（TV-K、OK影视、WebHomeTV 等），原版 TVBoxOSC 不支持。"></i>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="col-12">
+                                <label for="fongmi-devices" class="form-label fw-semibold">
+                                    <i class="bi bi-list-stars me-1 text-primary"></i>设备列表
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="手动指定 fongmi 设备 IP，多个用英文逗号分隔，可带端口。例如：192.168.1.100 或 192.168.1.100:9979。留空则依赖自动扫描。"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="fongmi-devices"
+                                       name="fongmi.devices"
+                                       placeholder="如：192.168.1.100, 192.168.1.101:9979">
+                            </div>
+                            <div class="col-12">
+                                <div class="form-check form-switch mb-3">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           id="fongmi-auto-scan"
+                                           name="fongmi.auto_scan" checked>
+                                    <label class="form-check-label fw-semibold" for="fongmi-auto-scan">
+                                        <i class="bi bi-wifi me-1 text-info"></i>自动扫描网段
+                                        <i class="bi bi-question-circle ms-1 text-muted"
+                                           data-bs-toggle="tooltip"
+                                           title="开启后会扫描下方网段的 9978 端口自动发现 fongmi 设备。单台设备时建议关闭，直接填设备 IP。"></i>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="fongmi-subnet" class="form-label fw-semibold">
+                                    <i class="bi bi-diagram-3 me-1 text-success"></i>网段
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="自动扫描的网段，如 192.168.1（不含最后一段）"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="fongmi-subnet"
+                                       name="fongmi.subnet"
+                                       placeholder="如：192.168.1">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="fongmi-min-percent" class="form-label fw-semibold">
+                                    <i class="bi bi-percent me-1 text-warning"></i>完成阈值（%）
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="播放进度达到此百分比视为「看完」，默认 80"></i>
+                                </label>
+                                <input type="number"
+                                       class="form-control form-control-lg"
+                                       id="fongmi-min-percent"
+                                       name="fongmi.min_percent"
+                                       min="1"
+                                       max="100"
+                                       value="80">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="fongmi-sync-interval" class="form-label fw-semibold">
+                                    <i class="bi bi-clock me-1 text-primary"></i>同步频率（Cron）
+                                    <i class="bi bi-question-circle ms-1 text-muted"
+                                       data-bs-toggle="tooltip"
+                                       title="轮询 fongmi 设备的 cron 表达式，默认每 3 分钟"></i>
+                                </label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="fongmi-sync-interval"
+                                       name="fongmi.sync_interval"
+                                       value="*/3 * * * *">
+                            </div>
+                            <div class="col-12">
+                                <div class="alert alert-info mb-0">
+                                    <i class="bi bi-info-circle me-2"></i>
+                                    <strong>提示：</strong>需先在 fongmi APP
+                                    中开启局域网控制（设置 → 关于 → 本地地址），可访问
+                                    <code>http://设备IP:9978/media</code> 确认返回 JSON。Docker
+                                    部署需使用 <code>network_mode: host</code>，否则无法扫描到局域网设备。
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
     <!-- 操作按钮 -->
     <div id="config-section-actions" class="row">
@@ -1188,6 +1296,7 @@ function refreshConfigPageToc() {
         { id: 'config-section-bangumi-data', label: 'Data', mode: 'always' },
         { id: 'config-section-notify', label: '通知', mode: 'always' },
         { id: 'config-section-feiniu', label: '飞牛', mode: 'always' },
+        { id: 'config-section-fongmi', label: 'fongmi', mode: 'always' },
         { id: 'config-section-actions', label: '保存区', mode: 'always', primary: true },
     ];
     items.forEach(function (item) {
@@ -1360,6 +1469,18 @@ function populateForm(config) {
         document.getElementById('feiniu-limit').value = (fn.limit != null && fn.limit !== '') ? fn.limit : 100;
     }
     
+    // 填充 fongmi 配置
+    const fm = config.fongmi || {};
+    const fmEnabled = document.getElementById('fongmi-enabled');
+    if (fmEnabled) {
+        fmEnabled.checked = fm.enabled === true || fm.enabled === 'true' || String(fm.enabled).toLowerCase() === 'true';
+        document.getElementById('fongmi-devices').value = fm.devices || '';
+        document.getElementById('fongmi-auto-scan').checked = fm.auto_scan === true || fm.auto_scan === 'true' || String(fm.auto_scan).toLowerCase() === 'true';
+        document.getElementById('fongmi-subnet').value = fm.subnet || '';
+        document.getElementById('fongmi-min-percent').value = (fm.min_percent != null && fm.min_percent !== '') ? fm.min_percent : 80;
+        document.getElementById('fongmi-sync-interval').value = fm.sync_interval || '*/3 * * * *';
+    }
+
     // 填充认证配置
     if (config.auth) {
         document.getElementById('auth-enabled').checked = config.auth.enabled !== false;
@@ -1539,6 +1660,14 @@ async function saveConfig() {
                 time_range: document.getElementById('feiniu-time-range').value || 'all',
                 sync_interval: document.getElementById('feiniu-sync-interval').value.trim() || '*/15 * * * *',
                 limit: parseInt(document.getElementById('feiniu-limit').value, 10) || 100
+            },
+            fongmi: {
+                enabled: document.getElementById('fongmi-enabled').checked,
+                devices: document.getElementById('fongmi-devices').value.trim(),
+                auto_scan: document.getElementById('fongmi-auto-scan').checked,
+                subnet: document.getElementById('fongmi-subnet').value.trim(),
+                min_percent: parseInt(document.getElementById('fongmi-min-percent').value, 10) || 80,
+                sync_interval: document.getElementById('fongmi-sync-interval').value.trim() || '*/3 * * * *'
             },
             auth: {
                 enabled: document.getElementById('auth-enabled').checked,

--- a/templates/config.html
+++ b/templates/config.html
@@ -946,7 +946,8 @@
                                     <input class="form-check-input"
                                            type="checkbox"
                                            id="fongmi-auto-scan"
-                                           name="fongmi.auto_scan" checked>
+                                           name="fongmi.auto_scan"
+                                           checked>
                                     <label class="form-check-label fw-semibold" for="fongmi-auto-scan">
                                         <i class="bi bi-wifi me-1 text-info"></i>自动扫描网段
                                         <i class="bi bi-question-circle ms-1 text-muted"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -413,6 +413,7 @@ function getSourceColor(source) {
         case 'jellyfin': return 'primary';
         case 'custom': return 'secondary';
         case 'feiniu': return 'info';
+        case 'fongmi': return 'primary';
         case 'test': return 'secondary';
         default: return 'secondary';
     }
@@ -558,6 +559,7 @@ function renderTimeline(records) {
         'jellyfin': 'tl-source--jellyfin',
         'custom': 'tl-source--custom',
         'feiniu': 'tl-source--feiniu',
+        'fongmi': 'tl-source--fongmi',
         'test': 'tl-source--test'
     };
 

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -156,6 +156,39 @@
             </div>
         </div>
     </div>
+    <!-- fongmi 同步测试 -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header py-3">
+                    <div class="d-flex align-items-center">
+                        <i class="bi bi-tv me-2 text-secondary"></i>
+                        <h6 class="m-0 fw-semibold">fongmi 同步测试</h6>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-8">
+                            <label class="form-label fw-semibold">说明</label>
+                            <div class="form-text">
+                                点击下方按钮将搜寻所有配置的 fongmi 设备并拉取当前 <code>/media</code> 状态，
+                                <strong>不管观看进度如何</strong>，用于验证设备发现、API 拉取、集数解析是否正常。
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <button type="button"
+                                    class="btn btn-primary w-100"
+                                    id="fongmi-debug-scan-btn"
+                                    onclick="triggerFongmiDebugScan()">
+                                <i class="bi bi-search me-1"></i>搜寻设备并拉取状态
+                            </button>
+                        </div>
+                    </div>
+                    <div id="fongmi-scan-result" class="mt-3" style="display: none;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <!-- 网络诊断工具 -->
     <div class="row">
         <div class="col-12">
@@ -559,6 +592,223 @@ async function triggerFeiniuManualSync() {
     } finally {
         btn.disabled = false;
         btn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i>立即触发飞牛同步';
+    }
+}
+
+// fongmi：搜寻设备并拉取当前 /media 状态（调试用，不过滤完成）
+async function triggerFongmiDebugScan() {
+    const btn = document.getElementById('fongmi-debug-scan-btn');
+    const out = document.getElementById('fongmi-scan-result');
+    const url = appUrl('/api/fongmi/debug/scan');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>搜寻中...';
+    out.style.display = 'block';
+    out.innerHTML = '<div class="alert alert-info mb-0"><i class="bi bi-hourglass-split me-2"></i>正在搜寻设备并拉取状态，请稍候…</div>';
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Accept': 'application/json' }
+        });
+        let data = {};
+        try {
+            data = await response.json();
+        } catch (_) {
+            data = {};
+        }
+        if (!response.ok) {
+            const detail = data.detail != null
+                ? (typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail))
+                : (data.message || '请求失败');
+            out.innerHTML = `
+                <div class="alert alert-danger mb-0">
+                    <i class="bi bi-x-circle me-2"></i><strong>无法执行</strong>（HTTP ${response.status}）<br>
+                    <span class="small">${detail}</span>
+                </div>`;
+            return;
+        }
+        const d = data.data || {};
+        const devices = d.devices || [];
+        const foundCount = d.discovered_devices ?? 0;
+        if (foundCount === 0) {
+            out.innerHTML = `
+                <div class="alert alert-warning mb-0">
+                    <i class="bi bi-exclamation-triangle me-2"></i><strong>未发现设备</strong><br>
+                    <span class="small">请检查配置中的设备 IP 或自动扫描网段是否正确，以及 fongmi APP 是否正在运行。</span>
+                </div>`;
+            return;
+        }
+        let rows = '';
+        devices.forEach(function (dev, idx) {
+            const m = dev.media;
+            if (!m) {
+                rows += `
+                    <tr>
+                        <td>${dev.device_name || dev.device_ip}</td>
+                        <td>${dev.device_ip}:${dev.device_port}</td>
+                        <td colspan="7" class="text-muted text-center">无播放信息</td>
+                    </tr>`;
+                return;
+            }
+            const progress = m.percent != null ? m.percent.toFixed(1) + '%' : '-';
+            const title = m.title || '<span class="text-muted">无</span>';
+            const safeIp = dev.device_ip.replace(/'/g, "\\'");
+            const safeName = (dev.device_name || dev.device_ip || '').replace(/'/g, "\\'");
+            rows += `
+                <tr id="fongmi-row-${idx}">
+                    <td>${dev.device_name || dev.device_ip}</td>
+                    <td><small>${dev.device_ip}:${dev.device_port}</small></td>
+                    <td>${title}</td>
+                    <td class="text-center">S${m.parsed_season}E${m.parsed_episode}</td>
+                    <td><small class="text-break">${m.url || ''}</small></td>
+                    <td><small class="text-break">${m.artist || ''}</small></td>
+                    <td class="text-center">${progress}</td>
+                    <td class="text-center">${m.state ?? '-'}</td>
+                    <td class="text-center">
+                        <button class="btn btn-sm btn-outline-primary" onclick="fongmiDebugSync(${idx}, '${safeIp}', ${dev.device_port}, '${safeName}')">
+                            <i class="bi bi-cloud-arrow-up me-1"></i>同步
+                        </button>
+                    </td>
+                </tr>
+                <tr id="fongmi-result-${idx}" style="display:none;">
+                    <td colspan="9" class="bg-light p-2"></td>
+                </tr>`;
+        });
+        out.innerHTML = `
+            <div class="alert alert-success mb-2">
+                <i class="bi bi-check-circle me-2"></i>
+                <strong>发现 ${foundCount} 台设备</strong>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>设备名</th>
+                            <th>地址</th>
+                            <th>标题</th>
+                            <th class="text-center">解析集号</th>
+                            <th>URL</th>
+                            <th>Artist</th>
+                            <th class="text-center">进度</th>
+                            <th class="text-center">state</th>
+                            <th class="text-center">操作</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>`;
+    } catch (error) {
+        console.error('fongmi 调试扫描请求失败:', error);
+        out.innerHTML = `
+            <div class="alert alert-danger mb-0">
+                <i class="bi bi-x-circle me-2"></i><strong>网络错误</strong><br>
+                <span class="small">${error.message || String(error)}</span>
+            </div>`;
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-search me-1"></i>搜寻设备并拉取状态';
+    }
+}
+
+// fongmi：对指定设备执行单次 Bangumi 同步并展示前后对比
+async function fongmiDebugSync(idx, deviceIp, devicePort, deviceName) {
+    const btn = document.querySelector(`#fongmi-row-${idx} button`);
+    const resultRow = document.getElementById(`fongmi-result-${idx}`);
+    if (!btn || !resultRow) return;
+
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>同步中';
+    resultRow.style.display = 'table-row';
+    resultRow.querySelector('td').innerHTML =
+        '<div class="alert alert-info mb-0"><i class="bi bi-hourglass-split me-2"></i>正在拉取 /media 并同步到 Bangumi，请稍候…</div>';
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 35000);
+    try {
+        const response = await fetch(appUrl('/api/fongmi/debug/sync'), {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                device_ip: deviceIp,
+                device_port: devicePort,
+                device_name: deviceName
+            }),
+            signal: controller.signal
+        });
+        let data = {};
+        try { data = await response.json(); } catch (_) { data = {}; }
+        if (!response.ok) {
+            const detail = data.detail != null
+                ? (typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail))
+                : (data.message || '请求失败');
+            resultRow.querySelector('td').innerHTML =
+                `<div class="alert alert-danger mb-0"><i class="bi bi-x-circle me-2"></i><strong>同步失败</strong>（HTTP ${response.status}）<br><span class="small">${detail}</span></div>`;
+            return;
+        }
+        const d = data.data || {};
+        const before = d.before || {};
+        const after = d.after || {};
+        const afterData = after.data || {};
+        const status = after.status || 'unknown';
+        const statusColor = status === 'success' ? 'success'
+            : status === 'ignored' ? 'secondary'
+            : 'danger';
+        const statusIcon = status === 'success' ? 'check-circle'
+            : status === 'ignored' ? 'dash-circle'
+            : 'x-circle';
+
+        // before
+        const beforeHtml = `
+            <div class="small">
+                <div><span class="text-muted">设备：</span>${before.device_name || ''} (${before.device_ip || ''})</div>
+                <div><span class="text-muted">标题：</span>${before.title || '-'}</div>
+                <div><span class="text-muted">解析：</span>S${before.season ?? '?'}E${before.episode ?? '?'}</div>
+                <div><span class="text-muted">URL：</span><span class="text-break">${before.url || '-'}</span></div>
+                <div><span class="text-muted">Artist：</span><span class="text-break">${before.artist || '-'}</span></div>
+            </div>`;
+
+        // after
+        let afterHtml = '';
+        if (status === 'success' && afterData.subject_id) {
+            const bgmTitle = afterData.bgm_title || before.title || '';
+            const subjectUrl = `https://bgm.tv/subject/${afterData.subject_id}`;
+            const epUrl = afterData.episode_id ? `https://bgm.tv/ep/${afterData.episode_id}` : '';
+            afterHtml = `
+                <div class="small">
+                    <div><span class="text-muted">Bangumi 标题：</span>${bgmTitle}</div>
+                    <div><span class="text-muted">条目：</span><a href="${subjectUrl}" target="_blank">${subjectUrl}</a></div>
+                    ${epUrl ? `<div><span class="text-muted">章节：</span><a href="${epUrl}" target="_blank">${epUrl}</a></div>` : ''}
+                    <div><span class="text-muted">结果：</span>${after.message || ''}</div>
+                </div>`;
+        } else {
+            afterHtml = `
+                <div class="small">
+                    <div><span class="text-muted">结果：</span><span class="text-${statusColor}">${after.message || '-'}</span></div>
+                </div>`;
+        }
+
+        resultRow.querySelector('td').innerHTML = `
+            <div class="d-flex gap-3 flex-wrap">
+                <div class="flex-grow-1">
+                    <div class="fw-bold mb-1 text-muted"><i class="bi bi-arrow-bar-right me-1"></i>FongMi 解析（同步前）</div>
+                    ${beforeHtml}
+                </div>
+                <div class="flex-grow-1">
+                    <div class="fw-bold mb-1 text-muted"><i class="bi bi-arrow-bar-left me-1"></i>Bangumi 匹配（同步后）
+                        <span class="badge bg-${statusColor} ms-1"><i class="bi bi-${statusIcon} me-1"></i>${status}</span>
+                    </div>
+                    ${afterHtml}
+                </div>
+            </div>`;
+    } catch (error) {
+        const isTimeout = error.name === 'AbortError';
+        resultRow.querySelector('td').innerHTML =
+            `<div class="alert alert-danger mb-0"><i class="bi bi-x-circle me-2"></i><strong>${isTimeout ? '请求超时' : '网络错误'}</strong><br><span class="small">${isTimeout ? '同步超过 35 秒未完成。' : (error.message || String(error))}</span></div>`;
+    } finally {
+        clearTimeout(timeoutId);
+        btn.disabled = false;
+        btn.innerHTML = '<i class="bi bi-cloud-arrow-up me-1"></i>同步';
     }
 }
 

--- a/templates/records.html
+++ b/templates/records.html
@@ -44,6 +44,7 @@
                         <option value="emby">Emby</option>
                         <option value="jellyfin">Jellyfin</option>
                         <option value="feiniu">飞牛</option>
+                        <option value="fongmi">fongmi</option>
                         <option value="test">测试</option>
                         <option value="retry">重试记录</option>
                     </select>
@@ -240,6 +241,7 @@ function getSourceColor(source) {
         case 'jellyfin': return 'primary';
         case 'custom': return 'secondary';
         case 'feiniu': return 'info';
+        case 'fongmi': return 'primary';
         case 'test': return 'secondary';
         default: return 'secondary';
     }
@@ -248,7 +250,7 @@ function getSourceColor(source) {
 function getSourceTlClass(source) {
     const s = source.toLowerCase();
     if (s.startsWith('retry-')) return 'retry';
-    if (['plex', 'emby', 'jellyfin', 'custom', 'feiniu', 'test'].indexOf(s) !== -1) return s;
+    if (['plex', 'emby', 'jellyfin', 'custom', 'feiniu', 'fongmi', 'test'].indexOf(s) !== -1) return s;
     return 'custom';
 }
 

--- a/tests/services/test_fongmi_client.py
+++ b/tests/services/test_fongmi_client.py
@@ -1,0 +1,178 @@
+"""fongmi client 集数解析与完成判定"""
+
+import pytest
+
+from app.services.fongmi.client import (
+    media_is_complete,
+    media_to_record,
+    parse_episode_info,
+)
+from app.services.fongmi.models import FongmiDevice
+
+_LONG_MIN = -9223372036854775808
+
+
+def _device() -> FongmiDevice:
+    return FongmiDevice(
+        ip="192.168.1.100",
+        port=9978,
+        uuid="abcd1234",
+        name="客厅电视",
+        device_type=1,
+    )
+
+
+# ===== parse_episode_info =====
+
+
+@pytest.mark.parametrize(
+    "url,artist,expect_season,expect_ep",
+    [
+        # 1. SxxExx 系列
+        # 方案 B：S01 视为默认（无季号），返回 season=1
+        ("http://x/S01E001.mp4", "", 1, 1),
+        ("http://x/S01E003.mp4", "", 1, 3),
+        ("http://x/s1e1.mp4", "", 1, 1),
+        ("http://x/S01.E05.mkv", "", 1, 5),
+        # S>1 才视为多季
+        ("http://x/S02E12.mp4", "", 2, 12),
+        ("http://x/show S02E03 [1080p].mkv", "", 2, 3),
+        ("http://x/S03E05.mkv", "", 3, 5),
+        # 2. EP/Exx 系列（含分隔符变体）
+        ("http://x/EP05.mp4", "", 1, 5),
+        ("http://x/ep12.mp4", "", 1, 12),
+        ("http://x/E03.mp4", "", 1, 3),
+        ("http://x/E.05.mp4", "", 1, 5),
+        ("http://x/E-12.mp4", "", 1, 12),
+        ("http://x/EP_03.mp4", "", 1, 3),
+        # 3. 中文集号（集/话/話/章/期/回）
+        ("http://x/第3集.mp4", "", 1, 3),
+        ("http://x/第10话.mp4", "", 1, 10),
+        ("http://x/第5話.mp4", "", 1, 5),
+        ("http://x/第5章.mp4", "", 1, 5),
+        ("http://x/第8回.mp4", "", 1, 8),
+        # 「第2期」视为季号标记（season=2），季号被移除后无集号数字，回退为 1
+        ("http://x/第2期.mp4", "", 2, 1),
+        # 4. #番号格式
+        ("http://x/Show #01.mp4", "", 1, 1),
+        ("http://x/番剧 #12.mkv", "", 1, 12),
+        # 5. 方括号/书名号内纯数字
+        ("http://x/[01].mp4", "", 1, 1),
+        ("http://x/番剧【12】.mkv", "", 1, 12),
+        ("http://x/Show(05).mp4", "", 1, 5),
+        # 6. 用户真实样本：凡人修仙传（夸父盘统一标为 S01，应视为 season=1）
+        (
+            "http://127.0.0.1:6678/proxy/play/夸父盘/凡人修仙传/F.S01E003.mp4",
+            "[1013.46MB] 001-4K F.S01E003.mp4",
+            1,
+            3,
+        ),
+        # 斗破苍穹年番 207 集（url 含端口 6678 不应干扰）
+        (
+            "http://127.0.0.1:6678/proxy/play/夸父盘/斗破苍穹年番/207 4K.mp4",
+            "[909.50MB] 201-300 207 4K.mp4",
+            1,
+            207,
+        ),
+        ("http://x/夸父盘/斗破苍穹年番/207 4K.mp4", "", 1, 207),
+        ("", "[909.50MB] 201-300 207 4K.mp4", 1, 207),
+        # 7. 纯数字文件名
+        ("http://x/01.mp4", "", 1, 1),
+        ("http://x/12.mp4", "", 1, 12),
+        # 8. 带分辨率标记
+        ("http://x/05 1080p.mp4", "", 1, 5),
+        ("http://x/12.720p.mkv", "", 1, 12),
+        # 9. 方括号内为文件大小，应跳过
+        ("", "[1.63GB] 001-4K.mp4", 1, 1),
+        ("", "[734MB] 01-100 04 4K.mp4", 1, 4),
+        # 10. 带端口号的 url 不应误解析端口为集号
+        ("http://127.0.0.1:9978/proxy/斗破苍穹年番/207.mp4", "", 1, 207),
+        # 11. 明确季号标记（方案 B：仅这些情况返回 season>1）
+        ("http://x/番剧 第二季/EP05.mp4", "", 2, 5),
+        ("http://x/番剧 第二期/第3集.mp4", "", 2, 3),
+        ("http://x/番剧 第3季/05.mp4", "", 3, 5),
+        ("http://x/Show Season 2/EP05.mp4", "", 2, 5),
+        ("http://x/Show Season 02/E03.mp4", "", 2, 3),
+        # 12. 无信息回退
+        ("", "", 1, 1),
+    ],
+)
+def test_parse_episode_info(url, artist, expect_season, expect_ep):
+    season, ep = parse_episode_info(url, artist)
+    assert season == expect_season
+    assert ep == expect_ep
+
+
+def test_parse_episode_info_url_priority_over_artist():
+    """url 中的 S01E001 应优先于 artist 中的数字"""
+    season, ep = parse_episode_info("http://x/S02E05.mp4", "[1GB] 999-4K.mp4")
+    assert season == 2
+    assert ep == 5
+
+
+# ===== media_is_complete =====
+
+
+def test_media_is_complete_above_threshold():
+    media = {"title": "测试番", "duration": 100000, "position": 96000}
+    assert media_is_complete(media, 95) is True
+
+
+def test_media_is_complete_below_threshold():
+    media = {"title": "测试番", "duration": 100000, "position": 50000}
+    assert media_is_complete(media, 95) is False
+
+
+def test_media_is_complete_no_title():
+    media = {"duration": 100000, "position": 96000}
+    assert media_is_complete(media, 95) is False
+
+
+def test_media_is_complete_live_stream_long_min():
+    """直播流 duration 为 Long.MIN_VALUE，不视为完成"""
+    media = {
+        "title": "直播",
+        "duration": _LONG_MIN,
+        "position": 1000,
+    }
+    assert media_is_complete(media, 95) is False
+
+
+def test_media_is_complete_negative_duration():
+    media = {"title": "x", "duration": -1, "position": 100}
+    assert media_is_complete(media, 95) is False
+
+
+def test_media_is_complete_zero_position():
+    media = {"title": "x", "duration": 100000, "position": 0}
+    assert media_is_complete(media, 95) is False
+
+
+# ===== media_to_record =====
+
+
+def test_media_to_record_basic():
+    media = {
+        "title": "凡人修仙传",
+        "url": "http://x/夸父盘/凡人修仙传/F.S01E001.mp4",
+        "artist": "[1.63GB] 001-4K F.S01E001.mp4",
+        "duration": 1400000,
+        "position": 1380000,
+    }
+    rec = media_to_record(_device(), media)
+    assert rec is not None
+    assert rec.title == "凡人修仙传"
+    assert rec.season == 1
+    assert rec.episode == 1
+    assert rec.device_ip == "192.168.1.100"
+    assert rec.device_name == "客厅电视"
+
+
+def test_media_to_record_no_title_returns_none():
+    media = {"url": "http://x", "duration": 100, "position": 99}
+    assert media_to_record(_device(), media) is None
+
+
+def test_media_to_record_empty_title_returns_none():
+    media = {"title": "  ", "url": "http://x", "duration": 100, "position": 99}
+    assert media_to_record(_device(), media) is None

--- a/tests/services/test_fongmi_scheduler.py
+++ b/tests/services/test_fongmi_scheduler.py
@@ -1,0 +1,108 @@
+"""fongmi scheduler 配置与生命周期"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.fongmi.scheduler import FongmiScheduler
+
+
+def _enabled_cfg(**kwargs) -> dict:
+    base = {
+        "enabled": True,
+        "devices": "",
+        "subnet": "",
+        "auto_scan": False,
+        "sync_interval": "*/5 * * * *",
+        "min_percent": 95,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _disabled_cfg() -> dict:
+    return _enabled_cfg(enabled=False)
+
+
+def test_parse_cron_valid():
+    s = FongmiScheduler()
+    trigger = s._parse_cron("*/5 * * * *")
+    assert trigger is not None
+
+
+def test_parse_cron_invalid_falls_back():
+    s = FongmiScheduler()
+    trigger = s._parse_cron("bad cron")
+    # 应回退到默认 trigger（不抛异常）
+    assert trigger is not None
+
+
+def test_fongmi_enabled_true():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        assert s._fongmi_enabled() is True
+
+
+def test_fongmi_enabled_false():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _disabled_cfg()
+        assert s._fongmi_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_start_when_disabled_no_scheduler_created():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _disabled_cfg()
+        cm.get_scheduler_config.return_value = {"job_timeout": 300}
+        ok = await s.start()
+    assert ok is True
+    assert s.scheduler is None  # 未启用时不创建调度器
+
+
+@pytest.mark.asyncio
+async def test_start_when_enabled_creates_scheduler():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        cm.get_scheduler_config.return_value = {"job_timeout": 300}
+        ok = await s.start()
+    assert ok is True
+    assert s.scheduler is not None
+    assert s.scheduler.running is True
+    # 清理
+    await s.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_when_running():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        cm.get_scheduler_config.return_value = {"job_timeout": 300}
+        await s.start()
+        ok = await s.stop()
+    assert ok is True
+    assert s.scheduler is None
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_running():
+    s = FongmiScheduler()
+    ok = await s.stop()
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_apply_config_after_save_disables():
+    s = FongmiScheduler()
+    with patch("app.services.fongmi.scheduler.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        cm.get_scheduler_config.return_value = {"job_timeout": 300}
+        await s.start()
+        # 切换为关闭
+        cm.get_fongmi_config.return_value = _disabled_cfg()
+        await s.apply_config_after_save()
+    assert s.scheduler is None

--- a/tests/services/test_fongmi_sync_service.py
+++ b/tests/services/test_fongmi_sync_service.py
@@ -1,0 +1,234 @@
+"""fongmi sync_service 同步流程与去重"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.sync import SyncResponse
+from app.services.fongmi.models import FongmiWatchRecord
+from app.services.fongmi.sync_service import (
+    FONGMI_SYNC_SOURCE,
+    fongmi_sync_service,
+)
+
+
+def _enabled_cfg(**kwargs) -> dict:
+    base = {
+        "enabled": True,
+        "devices": "",
+        "subnet": "",
+        "auto_scan": False,
+        "sync_interval": "*/5 * * * *",
+        "min_percent": 95,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _sample_record(**kwargs) -> FongmiWatchRecord:
+    base = dict(
+        device_ip="192.168.1.100",
+        device_name="客厅电视",
+        title="测试番剧",
+        episode=1,
+        season=1,
+        episode_url="http://x/S01E001.mp4",
+        artist=None,
+        release_date="",
+    )
+    base.update(kwargs)
+    return FongmiWatchRecord(**base)
+
+
+def test_record_to_custom_item_episode():
+    rec = _sample_record()
+    item = fongmi_sync_service._record_to_custom_item(rec)
+    assert item.media_type == "episode"
+    assert item.title == "测试番剧"
+    assert item.season == 1
+    assert item.episode == 1
+    assert item.user_name == "客厅电视"
+    assert item.source == FONGMI_SYNC_SOURCE
+
+
+def test_sync_source_constant():
+    assert FONGMI_SYNC_SOURCE == "fongmi"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_not_enabled():
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = {"enabled": False}
+        r = await fongmi_sync_service.run_sync()
+    assert r.success is True
+    assert "未启用" in r.message
+    assert r.synced_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_no_devices():
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        with patch.object(fongmi_sync_service, "_resolve_devices", return_value=[]):
+            r = await fongmi_sync_service.run_sync()
+    assert r.success is False
+    assert "未发现" in r.message
+
+
+@pytest.mark.asyncio
+async def test_run_sync_success(tmp_path):
+    rec = _sample_record()
+    fongmi_sync_service._synced_keys.clear()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="success", message="已标记为看过")
+
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        with patch.object(
+            fongmi_sync_service, "_resolve_devices", return_value=[object()]
+        ):
+            with patch(
+                "app.services.fongmi.sync_service.fetch_completed_records",
+                return_value=[rec],
+            ):
+                with patch(
+                    "app.services.fongmi.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.fongmi.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await fongmi_sync_service.run_sync()
+    assert r.success is True
+    assert r.synced_count == 1
+    assert r.error_count == 0
+    # 去重集合应包含该记录
+    assert ("192.168.1.100", "http://x/S01E001.mp4") in fongmi_sync_service._synced_keys
+
+
+@pytest.mark.asyncio
+async def test_run_sync_skip_already_synced():
+    """同一设备同一集第二次同步应跳过"""
+    rec = _sample_record()
+    fongmi_sync_service._synced_keys.clear()
+    fongmi_sync_service._synced_keys.add(("192.168.1.100", "http://x/S01E001.mp4"))
+
+    async def fail_to_thread(*_a, **_kw):
+        raise AssertionError("不应调用 Bangumi 同步")
+
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        with patch.object(
+            fongmi_sync_service, "_resolve_devices", return_value=[object()]
+        ):
+            with patch(
+                "app.services.fongmi.sync_service.fetch_completed_records",
+                return_value=[rec],
+            ):
+                with patch(
+                    "app.services.fongmi.sync_service.asyncio.to_thread",
+                    side_effect=fail_to_thread,
+                ):
+                    with patch(
+                        "app.services.fongmi.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await fongmi_sync_service.run_sync()
+    assert r.success is True
+    assert r.skipped_count == 1
+    assert r.synced_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_error_counts():
+    rec = _sample_record()
+    fongmi_sync_service._synced_keys.clear()
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("sync thread failed")
+
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        with patch.object(
+            fongmi_sync_service, "_resolve_devices", return_value=[object()]
+        ):
+            with patch(
+                "app.services.fongmi.sync_service.fetch_completed_records",
+                return_value=[rec],
+            ):
+                with patch(
+                    "app.services.fongmi.sync_service.asyncio.to_thread",
+                    side_effect=boom,
+                ):
+                    with patch(
+                        "app.services.fongmi.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch("app.services.fongmi.sync_service.logger") as log:
+                            r = await fongmi_sync_service.run_sync()
+    assert r.success is False
+    assert r.error_count == 1
+    log.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sync_ignored_counts_skipped():
+    rec = _sample_record()
+    fongmi_sync_service._synced_keys.clear()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="ignored", message="屏蔽关键词")
+
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg()
+        with patch.object(
+            fongmi_sync_service, "_resolve_devices", return_value=[object()]
+        ):
+            with patch(
+                "app.services.fongmi.sync_service.fetch_completed_records",
+                return_value=[rec],
+            ):
+                with patch(
+                    "app.services.fongmi.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.fongmi.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await fongmi_sync_service.run_sync()
+    assert r.success is True
+    assert r.skipped_count == 1
+    assert r.synced_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_ignore_enabled_when_switch_off():
+    """ignore_enabled 时即使开关为关也执行扫描"""
+    rec = _sample_record()
+    fongmi_sync_service._synced_keys.clear()
+
+    async def fake_to_thread(*_a, **_kw):
+        return SyncResponse(status="success", message="ok")
+
+    with patch("app.services.fongmi.sync_service.config_manager") as cm:
+        cm.get_fongmi_config.return_value = _enabled_cfg(enabled=False)
+        with patch.object(
+            fongmi_sync_service, "_resolve_devices", return_value=[object()]
+        ):
+            with patch(
+                "app.services.fongmi.sync_service.fetch_completed_records",
+                return_value=[rec],
+            ):
+                with patch(
+                    "app.services.fongmi.sync_service.asyncio.to_thread",
+                    side_effect=fake_to_thread,
+                ):
+                    with patch(
+                        "app.services.fongmi.sync_service.asyncio.sleep",
+                        new_callable=AsyncMock,
+                    ):
+                        r = await fongmi_sync_service.run_sync(ignore_enabled=True)
+    assert r.synced_count == 1


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
✨ 新功能 (feature)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
fongmi 局域网同步
通过定时轮询局域网内 fongmi 设备的内置 HTTP API，检测「看完」的剧集并自动提交到 Bangumi。
fongmi 是一个tvbox的变种，在电视上用它非常的好用，之前就有想要实现一个自动观影记录流程的想法，这几天在看fongmi仓库的时候偶然看到了它内置了一个[本地 HTTP API](https://github.com/FongMi/TV/blob/fongmi/docs/LOCAL.md)，想着能把tvbox全都给实现了，但是现实很残酷，只有fongmi及fongmi衍生版本可用。

- [fongmi](https://github.com/fongmi)（蜂蜜影视，本体）
- [TV-K](https://github.com/kknifer7/TV-K)（影视-K版）
- [OK影视](https://github.com/okcaptain/TV)
- [WebHomeTV](https://github.com/motao123/webtv)
- 其他基于 fongmi 的二开版本

除了原版不能用也挺好，我现在流程也走通了。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
vibe的代码，质量应该还行，望合并。