### PR TITLE
chore: HTTP 成功请求日志改为 DEBUG

### DIFF
--- a/app/utils/http_base.py
+++ b/app/utils/http_base.py
@@ -4,8 +4,8 @@
 支持链式配置自定义成功/失败消息，不改变原有 httpx API 行为。
 
 日志策略：
-  INFO  — 自定义简短消息 + 技术摘要（METHOD url → status elapsed）
-  DEBUG — 请求详情（headers, params, body）+ 响应详情（headers, body）
+  INFO  — 失败摘要（METHOD url → error）
+  DEBUG — 成功摘要（METHOD url → status elapsed）+ 请求/响应详情
 
 使用示例::
 
@@ -154,10 +154,9 @@ class HttpClientBase:
         logger.debug("\n".join(parts))
 
     def _log_success(self, response: httpx.Response, method: str, url: str) -> None:
-        """INFO: 合并摘要（prefix + 技术信息）; DEBUG: 响应详情"""
+        """DEBUG: 成功摘要（prefix + 技术信息）+ 响应详情"""
         elapsed = response.elapsed.total_seconds()
-        # INFO: 合并为单条日志
-        logger.info(
+        logger.debug(
             f"{self._prefix}[{self._label}] {method.upper()} {url} "
             f"→ {response.status_code} ({elapsed:.2f}s)"
         )

--- a/tests/utils/test_http_base.py
+++ b/tests/utils/test_http_base.py
@@ -202,18 +202,18 @@ class TestSyncHttpClient:
             client = SyncHttpClient(label="T", max_retries=0)
             assert client.request("GET", "http://example.com") is resp
 
-    def test_request_logs_info_success(self):
+    def test_request_logs_debug_success(self):
         resp = _mock_response(status_code=200, text="hello")
         with patch("app.utils.http_base.create_sync_client") as mc:
             mc.return_value = _mock_sync_httpx(response=resp)
             with patch("app.utils.http_base.logger") as ml:
                 client = SyncHttpClient(label="T", max_retries=0).prefix("🔔")
                 client.request("GET", "http://example.com")
-                assert ml.info.call_count == 1
-                info_msg = str(ml.info.call_args[0][0])
-                assert "🔔" in info_msg
-                assert "[T]" in info_msg and "GET" in info_msg and "200" in info_msg
-                ml.debug.assert_called()
+                assert ml.info.call_count == 0
+                debug_msgs = [str(c[0][0]) for c in ml.debug.call_args_list]
+                summary = next(m for m in debug_msgs if "→ 200" in m)
+                assert "🔔" in summary
+                assert "[T]" in summary and "GET" in summary
 
     def test_request_failure_logs(self):
         err = httpx.ConnectError("conn refused")
@@ -462,13 +462,13 @@ class TestLogging:
             msg = ml.debug.call_args[0][0]
             assert "Body(Form)" in msg
 
-    def test_log_success_info_and_debug(self):
+    def test_log_success_debug_only(self):
         resp = _mock_response(status_code=200, text="hello", headers={"X": "1"})
         client = SyncHttpClient(label="T").prefix("🚀").success_tpl("成功")
         with patch("app.utils.http_base.logger") as ml:
             client._log_success(resp, "GET", "http://example.com")
-            assert ml.info.call_count == 1
-            ml.debug.assert_called_once()
+            assert ml.info.call_count == 0
+            assert ml.debug.call_count == 2
 
     def test_log_failure_info(self):
         client = (


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🧰 维护相关 (chore)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
将 `SyncHttpClient` / `AsyncHttpClient` 成功请求的摘要日志（如 `📚 [Bangumi] GET https://api.bgm.tv/... → 200 (0.40s)`）从 **INFO** 降为 **DEBUG**，减少正常同步时的日志刷屏。

- 修改 [`app/utils/http_base.py`](app/utils/http_base.py) 中 `_log_success()` 的日志级别
- 失败请求摘要仍保持 **INFO**，错误默认可见
- 开启 `dev.debug = True` 后仍可查看完整 HTTP 请求/响应详情

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
