### PR TITLE
perf: 优化首页时间线海报异步加载

### DIFF
--- a/app/api/bgm_poster.py
+++ b/app/api/bgm_poster.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..core.logging import logger
-from ..utils.bgm_poster_service import get_poster_urls
+from ..utils.bgm_poster_service import get_poster_urls, normalize_subject_id
 from .deps import get_current_user_flexible
 
 router = APIRouter(prefix="/api/bgm", tags=["bgm"])
@@ -33,3 +33,30 @@ async def get_subject_poster(
         raise HTTPException(status_code=404, detail="该条目无封面图")
 
     return {"status": "success", "url": poster_url}
+
+
+@router.get("/subjects/posters")
+async def get_subjects_posters(
+    subject_ids: list[int] = Query(default=[]),
+    current_user: dict = Depends(get_current_user_flexible),
+) -> dict[str, Any]:
+    """批量返回条目封面图 URL（缺失条目不出现在 posters 中）。"""
+    ids: list[int] = []
+    seen: set[int] = set()
+    for raw_id in subject_ids:
+        subject_id = normalize_subject_id(raw_id)
+        if subject_id is not None and subject_id not in seen:
+            seen.add(subject_id)
+            ids.append(subject_id)
+
+    if not ids:
+        return {"status": "success", "posters": {}}
+
+    try:
+        poster_map = await get_poster_urls(ids)
+    except Exception as e:
+        logger.warning("批量获取封面失败: %s", e)
+        raise HTTPException(status_code=502, detail="获取条目信息失败") from e
+
+    posters = {str(subject_id): url for subject_id, url in poster_map.items()}
+    return {"status": "success", "posters": posters}

--- a/app/utils/bgm_poster_service.py
+++ b/app/utils/bgm_poster_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from ..core.config import config_manager
@@ -124,18 +125,42 @@ def get_poster_urls_sync(
     subject_ids: list[Any],
     prefer_sizes: tuple[str, ...] | None = None,
 ) -> dict[int, str]:
-    """同步批量解析封面 URL；失败条目跳过。"""
+    """同步批量解析封面 URL；失败条目跳过；未缓存条目并行请求。"""
     sizes = prefer_sizes if prefer_sizes is not None else timeline_poster_size_order()
     result: dict[int, str] = {}
     seen: set[int] = set()
+    to_fetch: list[int] = []
+    namespace = _poster_cache_namespace()
+
     for raw_id in subject_ids:
         subject_id = normalize_subject_id(raw_id)
         if subject_id is None or subject_id in seen:
             continue
         seen.add(subject_id)
-        url = _resolve_poster_url_sync(subject_id, prefer_sizes=sizes)
-        if url:
-            result[subject_id] = url
+        cached = _get_cached_poster_url(subject_id, namespace)
+        if cached:
+            result[subject_id] = cached
+        else:
+            to_fetch.append(subject_id)
+
+    if not to_fetch:
+        return result
+
+    max_workers = min(8, len(to_fetch))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_id = {
+            executor.submit(_resolve_poster_url_sync, sid, sizes): sid
+            for sid in to_fetch
+        }
+        for future in as_completed(future_to_id):
+            subject_id = future_to_id[future]
+            try:
+                url = future.result()
+                if url:
+                    result[subject_id] = url
+            except Exception as e:
+                logger.warning("获取条目 %s 封面失败: %s", subject_id, e)
+
     return result
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3227,6 +3227,10 @@ main.app-main > *:nth-child(12) {
     font-size: 1.1rem;
 }
 
+.timeline-poster-hint a {
+    font-weight: 600;
+}
+
 /* 信息区域 */
 .tl-body {
     flex: 1;

--- a/static/js/inbox.js
+++ b/static/js/inbox.js
@@ -435,4 +435,8 @@
     } else {
         init();
     }
+
+    window.BangumiInbox = {
+        openAnnouncementById: openAnnouncementById
+    };
 })();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -287,6 +287,9 @@ let recordDetailModal;
 
 // 海报缓存（命名空间随 Bangumi API / 图片反代配置变化而失效）
 const posterCache = {};
+let posterTrackTotal = 0;
+const posterPending = new Set();
+const posterFailed = new Set();
 
 function posterStorageKey(subjectId) {
     const ns = typeof window.__POSTER_CACHE_NS__ === 'string' ? window.__POSTER_CACHE_NS__ : '';
@@ -484,7 +487,7 @@ async function loadDashboardData() {
             showAlert('加载数据失败', 'danger');
         });
 
-    fetch(appUrl('/api/records?limit=6&skip_count=true&include_poster=true'), fetchOpts)
+    fetch(appUrl('/api/records?limit=6&skip_count=true'), fetchOpts)
         .then(function(res) { return res.json(); })
         .then(function(recordsData) {
             if (recordsData.status === 'success') {
@@ -607,56 +610,121 @@ function renderTimeline(records) {
 
     container.innerHTML = html;
 
-    // 异步加载海报（优先使用 records 响应中的 poster_url）
-    records.forEach(function(record) {
-        if (!record.subject_id) return;
-        if (record.poster_url) {
-            posterCache[record.subject_id] = record.poster_url;
-            try { localStorage.setItem(posterStorageKey(record.subject_id), record.poster_url); } catch (e) {}
-            applyPoster(record.subject_id, record.poster_url);
-        } else {
-            loadPoster(record.subject_id);
-        }
-    });
+    loadTimelinePosters(records);
 }
 
-async function fetchPosterFromApi(subjectId) {
-    const resp = await fetch(appUrl('/api/bgm/subjects/' + subjectId + '/poster'), {
-        credentials: 'include'
-    });
-    if (!resp.ok) throw new Error('HTTP ' + resp.status);
-    const data = await resp.json();
-    const imgUrl = data.url;
-    if (!imgUrl) throw new Error('no image');
-    return imgUrl;
+function removePosterHint() {
+    const hint = document.getElementById('timeline-poster-hint');
+    if (hint) hint.remove();
 }
 
-async function loadPoster(subjectId, retry) {
-    if (posterCache[subjectId]) {
-        applyPoster(subjectId, posterCache[subjectId]);
-        return;
+function showPosterHintBanner() {
+    const timeline = document.getElementById('sync-timeline');
+    if (!timeline || document.getElementById('timeline-poster-hint')) return;
+
+    const hint = document.createElement('div');
+    hint.id = 'timeline-poster-hint';
+    hint.className = 'timeline-poster-hint alert alert-warning py-2 px-3 mb-3 small';
+    hint.innerHTML = '番剧封面无法加载。请前往 <a href="' + appUrl('/config') + '">配置管理</a> 设置 <strong>HTTP 代理</strong>，或配置 <strong>Bangumi API / 图片反代</strong>。详见 <a href="#" id="timeline-poster-hint-announcement">收件箱公告</a>。';
+    timeline.parentNode.insertBefore(hint, timeline);
+
+    const announcementLink = document.getElementById('timeline-poster-hint-announcement');
+    if (announcementLink) {
+        announcementLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            if (window.BangumiInbox && window.BangumiInbox.openAnnouncementById) {
+                window.BangumiInbox.openAnnouncementById('20260616-bgm-image-proxy');
+            }
+        });
     }
+}
 
-    try {
-        const cached = localStorage.getItem(posterStorageKey(subjectId));
-        if (cached) {
-            posterCache[subjectId] = cached;
-            applyPoster(subjectId, cached);
+function maybeShowPosterHint() {
+    if (posterPending.size > 0 || posterTrackTotal === 0) return;
+    if (posterFailed.size < posterTrackTotal) return;
+    showPosterHintBanner();
+}
+
+function markPosterFailed(subjectId) {
+    document.querySelectorAll('.timeline-poster img[data-sid="' + subjectId + '"]').forEach(function(img) {
+        const poster = img.closest('.timeline-poster');
+        if (!poster) return;
+        poster.classList.remove('timeline-poster--loading');
+        poster.classList.add('timeline-poster--placeholder');
+        poster.innerHTML = '<i class="bi bi-film"></i>';
+    });
+}
+
+function finishPoster(subjectId, success) {
+    const key = String(subjectId);
+    posterPending.delete(key);
+    if (!success) {
+        posterFailed.add(key);
+        markPosterFailed(subjectId);
+    }
+    maybeShowPosterHint();
+}
+
+function loadTimelinePosters(records) {
+    const subjectIds = [];
+    const seen = {};
+    records.forEach(function(record) {
+        if (!record.subject_id || seen[record.subject_id]) return;
+        seen[record.subject_id] = true;
+        subjectIds.push(record.subject_id);
+    });
+    if (subjectIds.length === 0) return;
+
+    posterTrackTotal = subjectIds.length;
+    posterPending.clear();
+    posterFailed.clear();
+    subjectIds.forEach(function(sid) { posterPending.add(String(sid)); });
+    removePosterHint();
+
+    const needFetch = [];
+    subjectIds.forEach(function(sid) {
+        if (posterCache[sid]) {
+            applyPoster(sid, posterCache[sid]);
             return;
         }
-    } catch (e) {}
+        try {
+            const cached = localStorage.getItem(posterStorageKey(sid));
+            if (cached) {
+                posterCache[sid] = cached;
+                applyPoster(sid, cached);
+                return;
+            }
+        } catch (e) {}
+        needFetch.push(sid);
+    });
 
-    try {
-        const imgUrl = await fetchPosterFromApi(subjectId);
-        posterCache[subjectId] = imgUrl;
-        try { localStorage.setItem(posterStorageKey(subjectId), imgUrl); } catch (e) {}
-        applyPoster(subjectId, imgUrl);
-    } catch (e) {
-        // 首次失败后延迟重试一次（应对首次登录时序问题）
-        if (!retry) {
-            setTimeout(function() { loadPoster(subjectId, true); }, 2000);
-        }
-    }
+    if (needFetch.length === 0) return;
+
+    const params = new URLSearchParams();
+    needFetch.forEach(function(sid) { params.append('subject_ids', sid); });
+
+    fetch(appUrl('/api/bgm/subjects/posters?' + params.toString()), {
+        credentials: 'include'
+    })
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+            if (data.status !== 'success') throw new Error('bad response');
+            const posters = data.posters || {};
+            needFetch.forEach(function(sid) {
+                const url = posters[String(sid)];
+                if (url) {
+                    posterCache[sid] = url;
+                    try { localStorage.setItem(posterStorageKey(sid), url); } catch (e) {}
+                    applyPoster(sid, url);
+                } else {
+                    finishPoster(sid, false);
+                }
+            });
+        })
+        .catch(function(error) {
+            console.error('批量加载封面失败:', error);
+            needFetch.forEach(function(sid) { finishPoster(sid, false); });
+        });
 }
 
 // 修复：querySelectorAll 确保同一 subject_id 的所有记录都设置海报
@@ -664,12 +732,12 @@ function applyPoster(subjectId, url) {
     document.querySelectorAll('.timeline-poster img[data-sid="' + subjectId + '"]').forEach(function(img) {
         img.onload = function() {
             img.classList.add('loaded');
-            var poster = img.closest('.timeline-poster');
+            const poster = img.closest('.timeline-poster');
             if (poster) poster.classList.remove('timeline-poster--loading');
+            finishPoster(subjectId, true);
         };
         img.onerror = function() {
-            var poster = img.closest('.timeline-poster');
-            if (poster) poster.classList.remove('timeline-poster--loading');
+            finishPoster(subjectId, false);
         };
         img.src = url;
     });

--- a/tests/api/test_bgm_poster.py
+++ b/tests/api/test_bgm_poster.py
@@ -86,3 +86,70 @@ async def test_get_subject_poster_requires_auth():
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         r = await ac.get("/api/bgm/subjects/123/poster")
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_subjects_posters_batch_success(app_bgm_poster):
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+        return_value={
+            123: "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg",
+            456: "https://img-proxy.example.com/pic/cover/s/d/e/f.jpg",
+        },
+    ) as mock_get:
+        transport = ASGITransport(app=app_bgm_poster)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get(
+                "/api/bgm/subjects/posters",
+                params={"subject_ids": [123, 456, 123, 0, -1]},
+            )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "success"
+    assert data["posters"] == {
+        "123": "https://img-proxy.example.com/pic/cover/s/a/b/c.jpg",
+        "456": "https://img-proxy.example.com/pic/cover/s/d/e/f.jpg",
+    }
+    mock_get.assert_awaited_once_with([123, 456])
+
+
+@pytest.mark.asyncio
+async def test_get_subjects_posters_empty_list(app_bgm_poster):
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        transport = ASGITransport(app=app_bgm_poster)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/bgm/subjects/posters")
+
+    assert r.status_code == 200
+    assert r.json() == {"status": "success", "posters": {}}
+    mock_get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_subjects_posters_service_error(app_bgm_poster):
+    with patch(
+        "app.api.bgm_poster.get_poster_urls",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        transport = ASGITransport(app=app_bgm_poster)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            r = await ac.get("/api/bgm/subjects/posters", params={"subject_ids": [1]})
+
+    assert r.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_get_subjects_posters_requires_auth():
+    app = FastAPI()
+    app.include_router(bgm_poster_router)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/api/bgm/subjects/posters", params={"subject_ids": [1]})
+    assert r.status_code == 401

--- a/tests/utils/test_bgm_poster_service.py
+++ b/tests/utils/test_bgm_poster_service.py
@@ -139,3 +139,24 @@ async def test_get_poster_urls_async():
 
     assert result == {1: "https://example.com/1.jpg"}
     mock_sync.assert_called_once_with([1], None)
+
+
+def test_get_poster_urls_sync_parallel_partial_failure():
+    mock_bgm = MagicMock()
+    mock_bgm.get_subject.side_effect = [
+        RuntimeError("network"),
+        {"id": 2, "images": {"small": "https://lain.bgm.tv/pic/cover/s/c/d/2.jpg"}},
+        {"id": 3, "images": {"small": "https://lain.bgm.tv/pic/cover/s/c/d/3.jpg"}},
+    ]
+
+    with patch(
+        "app.utils.bgm_poster_service.get_shared_bangumi_api", return_value=mock_bgm
+    ):
+        with patch("app.utils.bgm_poster_service.config_manager.get", return_value=""):
+            result = get_poster_urls_sync([1, 2, 3])
+
+    assert result == {
+        2: "https://lain.bgm.tv/pic/cover/s/c/d/2.jpg",
+        3: "https://lain.bgm.tv/pic/cover/s/c/d/3.jpg",
+    }
+    assert mock_bgm.get_subject.call_count == 3


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🚀 优化/重构 (perf/refactor)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
将仪表板「最近同步」时间线与 Bangumi 封面获取解耦，解决 Bangumi 被墙或未配置代理时时间线长时间转圈的问题。

**后端**
- 新增 `GET /api/bgm/subjects/posters?subject_ids=1&subject_ids=2`，批量返回封面 URL
- `get_poster_urls_sync()` 对未缓存条目使用 `ThreadPoolExecutor` 并行请求（最多 8 并发）
- 保留 `include_poster` 参数及单条 `GET /api/bgm/subjects/{id}/poster`，向后兼容

**前端**
- 时间线改为只请求 `/api/records`（去掉 `include_poster=true`），本地数据渲染后异步批量拉封面
- 封面加载失败时显示占位图标；全部失败时在时间线卡片顶部提示配置 HTTP 代理或 Bangumi API / 图片反代
- `inbox.js` 暴露 `window.BangumiInbox.openAnnouncementById`，横幅可跳转收件箱公告

**体验与性能**
- 时间线首屏不再等待 Bangumi API，通常毫秒级展示
- 封面由串行阻塞改为批量 + 并行加载，正常网络下整体更快；被墙时约 15s 内失败并给出配置指引，而非长时间白屏转圈

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
