### PR TITLE
feat: 新增日志智能分组功能

### DIFF
--- a/app/api/logs.py
+++ b/app/api/logs.py
@@ -4,15 +4,51 @@
 
 import asyncio
 import os
+from collections import deque
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ..core.config import config_manager
 from ..core.logging import logger, resolved_dev_log_file_path
+from ..utils.log_grouping import group_log_lines
 from .deps import get_current_user_flexible
 
 router = APIRouter(prefix="/api", tags=["logs"])
+
+
+def _read_lines_tail(log_file_path: str, limit: str) -> list[str]:
+    """读取日志行；有 limit 时仅保留尾部行（deque）。"""
+    with open(log_file_path, encoding="utf-8", errors="ignore") as f:
+        if limit == "all":
+            return f.readlines()
+        try:
+            limit_num = int(limit)
+        except ValueError:
+            return f.readlines()
+        if limit_num <= 0:
+            return []
+        return list(deque(f, maxlen=limit_num))
+
+
+def _filter_lines(
+    lines: list[str],
+    level: Optional[str],
+    search: Optional[str],
+) -> list[str]:
+    """按级别与关键词筛选日志行。"""
+    if level:
+        level_upper = level.upper()
+        lines = [
+            line
+            for line in lines
+            if level_upper in line.upper()
+            or (level_upper == "WARNING" and "WARN" in line.upper())
+        ]
+    if search:
+        search_lower = search.lower()
+        lines = [line for line in lines if search_lower in line.lower()]
+    return lines
 
 
 def _read_log_file(
@@ -20,51 +56,50 @@ def _read_log_file(
     level: Optional[str],
     search: Optional[str],
     limit: str,
+    grouped: bool = False,
 ) -> dict:
     """同步读取日志文件并应用筛选（阻塞 I/O，需在线程中执行）"""
+    empty_stats = {"size": 0, "lines": 0, "modified": None, "errors": 0}
     if not os.path.exists(log_file_path):
-        return {
-            "content": "",
-            "stats": {"size": 0, "lines": 0, "modified": None, "errors": 0},
+        result: dict[str, Any] = {
+            "stats": empty_stats,
         }
+        if grouped:
+            result["groups"] = []
+            result["orphans"] = []
+            result["debug_mode"] = config_manager.get("dev", "debug", fallback=False)
+        else:
+            result["content"] = ""
+        return result
 
-    # 获取文件统计信息
     file_stats = os.stat(log_file_path)
     file_size = file_stats.st_size
     file_modified = file_stats.st_mtime
 
-    # 读取日志内容
-    with open(log_file_path, encoding="utf-8", errors="ignore") as f:
-        lines = f.readlines()
+    all_lines = _read_lines_tail(log_file_path, limit)
+    error_count = sum(1 for line in all_lines if "ERROR" in line.upper())
 
-    # 统计错误数量
-    error_count = sum(1 for line in lines if "ERROR" in line.upper())
+    filtered = _filter_lines(all_lines, level, search)
 
-    # 应用筛选
-    if level:
-        lines = [line for line in lines if level.upper() in line.upper()]
+    stats = {
+        "size": file_size,
+        "lines": len(filtered),
+        "modified": file_modified * 1000,
+        "errors": error_count,
+    }
 
-    if search:
-        lines = [line for line in lines if search.lower() in line.lower()]
-
-    # 限制行数
-    if limit != "all":
-        try:
-            limit_num = int(limit)
-            lines = lines[-limit_num:] if len(lines) > limit_num else lines
-        except ValueError:
-            pass
-
-    content = "".join(lines)
+    if grouped:
+        grouping = group_log_lines(filtered)
+        return {
+            "groups": grouping["groups"],
+            "orphans": grouping["orphans"],
+            "debug_mode": config_manager.get("dev", "debug", fallback=False),
+            "stats": stats,
+        }
 
     return {
-        "content": content,
-        "stats": {
-            "size": file_size,
-            "lines": len(lines) if not level and not search else len(lines),
-            "modified": file_modified * 1000,  # 转换为毫秒
-            "errors": error_count,
-        },
+        "content": "".join(filtered),
+        "stats": stats,
     }
 
 
@@ -81,25 +116,28 @@ async def get_logs(
     level: Optional[str] = None,
     search: Optional[str] = None,
     limit: str = Query("100"),
+    grouped: bool = Query(False),
     current_user: dict = Depends(get_current_user_flexible),
 ) -> dict[str, Any]:
     """获取日志内容"""
     try:
         log_path = resolved_dev_log_file_path(config_manager)
         if log_path is None:
-            return {
-                "status": "success",
-                "data": {
-                    "content": "",
-                    "stats": {"size": 0, "lines": 0, "modified": None, "errors": 0},
-                },
+            empty = {
+                "stats": {"size": 0, "lines": 0, "modified": None, "errors": 0},
             }
+            if grouped:
+                empty["groups"] = []
+                empty["orphans"] = []
+                empty["debug_mode"] = config_manager.get("dev", "debug", fallback=False)
+            else:
+                empty["content"] = ""
+            return {"status": "success", "data": empty}
 
         log_file_path = os.fspath(log_path)
 
-        # 文件 I/O 放入线程避免阻塞事件循环
         result = await asyncio.to_thread(
-            _read_log_file, log_file_path, level, search, limit
+            _read_log_file, log_file_path, level, search, limit, grouped
         )
 
         return {"status": "success", "data": result}
@@ -120,7 +158,6 @@ async def clear_logs(
 
         log_file_path = os.fspath(log_path)
 
-        # 文件 I/O 放入线程避免阻塞事件循环
         await asyncio.to_thread(_clear_log_file, log_file_path)
 
         return {"status": "success", "message": "日志清空成功"}

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sse_starlette.sse import EventSourceResponse
 
-from ..core.logging import logger
+from ..core.logging import logger, new_retry_sync_run_id, sync_log_context
 from ..core.security import security_manager
 from ..models.sync import CustomItem
 from ..services.custom import custom_sync_service
@@ -311,7 +311,8 @@ async def retry_sync_record(
         )
 
         # 执行同步
-        result = sync_service.sync_custom_item(retry_item, source=retry_source)
+        with sync_log_context(new_retry_sync_run_id(record_id)):
+            result = sync_service.sync_custom_item(retry_item, source=retry_source)
 
         # 如果重试成功，更新原记录的状态
         if result.status == "success":
@@ -412,11 +413,13 @@ async def retry_sync_record_stream(
             }
 
             # 在线程中执行同步任务（sync_custom_item 是同步方法，会阻塞事件循环）
-            task = asyncio.create_task(
-                asyncio.to_thread(
-                    sync_service.sync_custom_item, retry_item, source=retry_source
-                )
-            )
+            def _run_retry() -> Any:
+                with sync_log_context(new_retry_sync_run_id(record_id)):
+                    return sync_service.sync_custom_item(
+                        retry_item, source=retry_source
+                    )
+
+            task = asyncio.create_task(asyncio.to_thread(_run_retry))
 
             # 等待任务完成，同时实时推送日志
             while not task.done():

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -2,11 +2,15 @@
 日志管理模块
 """
 
+import contextvars
 import datetime
 import os
 import sys
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .config import ConfigManager
@@ -15,6 +19,38 @@ if TYPE_CHECKING:
 DEFAULT_DEV_LOG_FILE = "./log.txt"
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# 同步日志关联 ID（线程内通过 ContextVar 传播）
+sync_run_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "sync_run_id", default=None
+)
+
+RUN_ID_FIELD_WIDTH = 28  # 供 UI 等宽展示参考；写入文件时不填充空格
+
+
+def get_sync_run_id() -> Optional[str]:
+    """当前同步 run_id；无上下文时为 None。"""
+    return sync_run_id.get()
+
+
+@contextmanager
+def sync_log_context(run_id: str) -> Iterator[str]:
+    """在作用域内为日志行附加 [run:...] 标记。"""
+    token = sync_run_id.set(run_id)
+    try:
+        yield run_id
+    finally:
+        sync_run_id.reset(token)
+
+
+def new_inline_sync_run_id(counter: int) -> str:
+    """直调 sync_custom_item 时生成 run_id。"""
+    return f"sync_inline_{counter}_{int(time.time())}"
+
+
+def new_retry_sync_run_id(record_id: int) -> str:
+    """手动重试同步记录时生成 run_id。"""
+    return f"retry_{record_id}_{int(time.time())}"
 
 
 def resolve_dev_log_file_path(raw: str) -> Path:
@@ -209,14 +245,23 @@ class Logger:
             for i in args
         ]
 
+    def _format_level_field(self, level: Optional[str]) -> str:
+        """级别标签，如 [INFO]、[DEBUG]。"""
+        if not level:
+            return ""
+        return f"[{level}]"
+
     def _format_log_line(self, *args, level: Optional[str]) -> str:
         """格式化日志行（不输出）"""
-        level_prefix = f"[{level}]" if level else ""
-        timestamp = (
-            f"[{datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S.%f')[:-3]}] "
-        )
+        timestamp = f"[{datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S.%f')[:-3]}]"
         message = " ".join(str(i) for i in args)
-        return timestamp + level_prefix + " " + message
+        head = timestamp
+        if level:
+            head += " " + self._format_level_field(level)
+        run_id = get_sync_run_id()
+        if run_id:
+            head += f" [run:{run_id}]"
+        return f"{head} {message}"
 
     def log(
         self,

--- a/app/services/sync_service/__init__.py
+++ b/app/services/sync_service/__init__.py
@@ -12,7 +12,12 @@ from typing import Any, Optional
 
 from ...core.config import config_manager
 from ...core.database import database_manager
-from ...core.logging import logger
+from ...core.logging import (
+    get_sync_run_id,
+    logger,
+    new_inline_sync_run_id,
+    sync_log_context,
+)
 from ...models.sync import CustomItem, SyncResponse
 from ...utils.bangumi_api import BangumiApi
 from ...utils.bangumi_data import BangumiData, bangumi_data
@@ -434,21 +439,59 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                     f"TV番剧自动归档为「看过」失败（单集已处理）: subject_id={bgm_se_id} {e}"
                 )
 
+    def _allocate_inline_run_id(self) -> str:
+        """直调 sync_custom_item 时分配 run_id。"""
+        with self._tasks_lock:
+            self._task_counter += 1
+            counter = self._task_counter
+        return new_inline_sync_run_id(counter)
+
     def sync_custom_item(
         self, item: CustomItem, source: str = "custom"
     ) -> SyncResponse:
         """同步自定义项目"""
+        existing_run_id = get_sync_run_id()
+        if existing_run_id:
+            return self._sync_custom_item_impl(item, source)
+        inline_id = self._allocate_inline_run_id()
+        with sync_log_context(inline_id):
+            return self._sync_custom_item_impl(item, source)
+
+    def _sync_custom_item_impl(
+        self, item: CustomItem, source: str = "custom"
+    ) -> SyncResponse:
+        actual_source = item.source if item.source else source
+        status_holder: list[str] = ["error"]
         try:
-            # 如果item中包含source字段，优先使用item的source
-            actual_source = item.source if item.source else source
+            logger.info(
+                f"同步开始: {item.title} S{item.season:02d}E{item.episode:02d} ({actual_source})"
+            )
+            return self._sync_custom_item_body(
+                item, source, actual_source, status_holder
+            )
+        finally:
+            logger.info(f"同步结束: status={status_holder[0]}")
+
+    def _sync_custom_item_body(
+        self,
+        item: CustomItem,
+        source: str,
+        actual_source: str,
+        status_holder: list[str],
+    ) -> SyncResponse:
+        try:
             sync_action = (item.sync_action or "").strip().lower()
             if sync_action == "mark_watching":
                 if item.media_type == "movie":
-                    return self.sync_movie_watching(item, source)
-                return SyncResponse(
+                    result = self.sync_movie_watching(item, source)
+                    status_holder[0] = result.status
+                    return result
+                result = SyncResponse(
                     status="ignored",
                     message="仅支持剧场版标记在看",
                 )
+                status_holder[0] = result.status
+                return result
 
             logger.info(f"接收到同步请求：{item}")
 
@@ -457,6 +500,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
             # 参数校验
             validation_error = self._normalize_custom_item_params(item)
             if validation_error is not None:
+                status_holder[0] = validation_error.status
                 return validation_error
 
             # 查找番剧ID及其是否为特定季度ID的标记
@@ -464,12 +508,14 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                 self._find_matching_subject(item, actual_source)
             )
             if subject_error_response is not None:
+                status_holder[0] = subject_error_response.status
                 return subject_error_response
 
             # 获取对应用户的bangumi API实例
             bgm = self._get_bangumi_api_for_user(item.user_name)
             if not bgm:
                 logger.error(f"无法为用户 {item.user_name} 创建bangumi API实例")
+                status_holder[0] = "error"
                 return SyncResponse(status="error", message="bangumi配置错误")
 
             # 查询 bangumi 章节：电影走短路径，剧集走季番解析
@@ -480,6 +526,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
             except ValueError as ve:
                 # 捕获认证错误（通知已在 BangumiApi 中发送）
                 if "认证失败" in str(ve) or "access_token" in str(ve):
+                    status_holder[0] = "error"
                     return SyncResponse(status="error", message=str(ve))
                 else:
                     raise ve
@@ -495,6 +542,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                     subject_id=subject_id,
                     error_message="不存在或集数过多",
                 )
+                status_holder[0] = "error"
                 return SyncResponse(status="error", message="未找到对应的剧集")
 
             # 通过实例缓存获取 Bangumi 平台标题（无额外 API 调用）
@@ -525,6 +573,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
             except ValueError as ve:
                 # 捕获认证错误（通知已在 BangumiApi 中发送）
                 if "认证失败" in str(ve) or "access_token" in str(ve):
+                    status_holder[0] = "error"
                     return SyncResponse(status="error", message=str(ve))
                 else:
                     raise ve
@@ -551,7 +600,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                 bgm_title=bgm_title,
             )
 
-            return SyncResponse(
+            result = SyncResponse(
                 status="success",
                 message=result_message,
                 data={
@@ -563,6 +612,8 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                     "episode_id": bgm_ep_id,
                 },
             )
+            status_holder[0] = result.status
+            return result
         except Exception as e:
             logger.error(f"自定义同步处理出错: {e}")
 
@@ -588,6 +639,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin):
                 additional_info=f"完整错误信息: {traceback.format_exc()}",
             )
 
+            status_holder[0] = "error"
             return SyncResponse(status="error", message=f"处理失败: {str(e)}")
 
     def _check_user_permission(self, user_name: str) -> bool:

--- a/app/services/sync_service/task_manager.py
+++ b/app/services/sync_service/task_manager.py
@@ -5,9 +5,10 @@
 
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from typing import Any, Optional
 
-from ...core.logging import logger
+from ...core.logging import logger, sync_log_context
 from ...models.sync import CustomItem, SyncResponse
 
 
@@ -53,11 +54,18 @@ class TaskManagerMixin:
             task_id = f"sync_{self._task_counter}_{int(time.time())}"
             self._register_task(task_id, item.model_dump(), source)
 
-        # 提交到线程池异步执行
-        self._executor.submit(self._sync_custom_item_sync, item, source, task_id)
+        # 提交到线程池异步执行（contextvars 需 copy_context 传播）
+        ctx = copy_context()
+
+        def _run() -> SyncResponse:
+            with sync_log_context(task_id):
+                return self._sync_custom_item_sync(item, source, task_id)
+
+        self._executor.submit(ctx.run, _run)
 
         # 不等待结果，立即返回任务ID
-        logger.info(f"同步任务 {task_id} 已提交到异步队列")
+        with sync_log_context(task_id):
+            logger.info(f"同步任务 {task_id} 已提交到异步队列")
         return task_id
 
     def _sync_custom_item_sync(
@@ -122,10 +130,17 @@ class TaskManagerMixin:
             task_id = f"{source}_{self._task_counter}_{int(time.time())}"
             self._register_task(task_id, data, source)
 
-        self._executor.submit(
-            self._run_media_server_task, data, task_id, source, sync_method_name
-        )
-        logger.info(f"{source.capitalize()}同步任务 {task_id} 已提交到异步队列")
+        ctx = copy_context()
+
+        def _run() -> SyncResponse:
+            with sync_log_context(task_id):
+                return self._run_media_server_task(
+                    data, task_id, source, sync_method_name
+                )
+
+        self._executor.submit(ctx.run, _run)
+        with sync_log_context(task_id):
+            logger.info(f"{source.capitalize()}同步任务 {task_id} 已提交到异步队列")
         return task_id
 
     def _run_media_server_task(
@@ -138,7 +153,8 @@ class TaskManagerMixin:
         """媒体服务器同步任务的线程池执行体"""
         try:
             self._update_task_status(task_id, "running")
-            result = getattr(self, sync_method_name)(data)
+            with sync_log_context(task_id):
+                result = getattr(self, sync_method_name)(data)
             self._update_task_status(task_id, "completed", result=result.model_dump())
             return result
         except Exception as e:

--- a/app/utils/log_grouping.py
+++ b/app/utils/log_grouping.py
@@ -1,0 +1,304 @@
+"""
+同步日志分组解析：按 [run:xxx] 聚合，历史日志启发式回退。
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+RUN_ID_RE = re.compile(r"\[run:([^\]]+)\]")
+TIMESTAMP_RE = re.compile(r"^\[(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\]")
+LEVEL_RE = re.compile(r"\[(DEBUG|INFO ?|WARN(?:ING)? ?|ERROR)\]")
+
+SYNC_START_RE = re.compile(
+    r"接收到同步请求|同步开始:|同步任务 .+ 已提交到异步队列|"
+    r"(?:Plex|Emby|Jellyfin)同步任务 .+ 已提交到异步队列|"
+    r"重试同步记录 \d+:"
+)
+SYNC_END_RE = re.compile(
+    r"同步结束:|bgm:.*(已标记|跳过|归档|已在看)|"
+    r"异步(?:Plex|Emby|Jellyfin)?同步任务 .+ 失败|自定义同步处理出错"
+)
+LOGIN_ORPHAN_RE = re.compile(
+    r"登录成功|登录失败|被锁定|登出|清理过期会话|密码更新完成|多账号配置处理完成"
+)
+
+_TITLE_QUOTED_RE = re.compile(r"title='([^']*)'")
+_SE_EP_RE = re.compile(r"\bS(\d+)E(\d+)\b")
+_SYNC_START_TITLE_RE = re.compile(r"同步开始: (.+) S(\d+)E(\d+)")
+_RETRY_TITLE_RE = re.compile(r"重试同步记录 \d+: (.+?) S(\d+)E(\d+)")
+_SOURCE_QUOTED_RE = re.compile(r"source='([^']+)'")
+_SOURCE_PAREN_RE = re.compile(r"\(([^)]+)\)\s*$")
+
+
+def _extract_timestamp(line: str) -> str | None:
+    m = TIMESTAMP_RE.match(line)
+    return m.group(1) if m else None
+
+
+def _extract_level(line: str) -> str | None:
+    m = LEVEL_RE.search(line)
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    if raw == "WARN":
+        return "WARNING"
+    return raw
+
+
+def _is_login_orphan(line: str) -> bool:
+    return bool(LOGIN_ORPHAN_RE.search(line))
+
+
+def _parse_timestamp_dt(ts: str) -> datetime | None:
+    try:
+        return datetime.strptime(ts, "%Y/%m/%d %H:%M:%S.%f")
+    except ValueError:
+        return None
+
+
+def _duration_ms(timestamps: list[str]) -> int | None:
+    if not timestamps:
+        return None
+    start = _parse_timestamp_dt(timestamps[0])
+    end = _parse_timestamp_dt(timestamps[-1])
+    if not start or not end:
+        return None
+    return max(0, int((end - start).total_seconds() * 1000))
+
+
+def _parse_title_info(lines: list[str]) -> dict[str, Any]:
+    title = ""
+    season = 0
+    episode = 0
+    source = ""
+    for line in lines:
+        m = _SYNC_START_TITLE_RE.search(line)
+        if m:
+            title = m.group(1).strip()
+            season = int(m.group(2))
+            episode = int(m.group(3))
+        m2 = _RETRY_TITLE_RE.search(line)
+        if m2:
+            title = m2.group(1).strip()
+            season = int(m2.group(2))
+            episode = int(m2.group(3))
+        for tm in _TITLE_QUOTED_RE.finditer(line):
+            candidate = tm.group(1).strip()
+            if candidate and (not title or len(candidate) > len(title)):
+                title = candidate
+        sm = _SE_EP_RE.search(line)
+        if sm and not season:
+            season = int(sm.group(1))
+            episode = int(sm.group(2))
+        sq = _SOURCE_QUOTED_RE.search(line)
+        if sq:
+            source = sq.group(1)
+        if "同步开始:" in line or "重试同步记录" in line:
+            sp = _SOURCE_PAREN_RE.search(line)
+            if sp:
+                source = sp.group(1).strip()
+    return {"title": title, "season": season, "episode": episode, "source": source}
+
+
+def _looks_like_sync_group(lines: list[str], info: dict[str, Any]) -> bool:
+    """可识别为一次同步的组；否则归入其他系统日志。"""
+    if info.get("title"):
+        return True
+    if any(SYNC_START_RE.search(line) for line in lines):
+        return True
+    if any(
+        keyword in line
+        for line in lines
+        for keyword in ("接收到同步请求", "同步结束:", "bgm:", "重试同步记录")
+    ):
+        return True
+    return False
+
+
+def _infer_status(lines: list[str]) -> str:
+    for line in reversed(lines):
+        if "同步结束:" in line:
+            if "status=success" in line:
+                return "success"
+            if "status=ignored" in line:
+                return "ignored"
+            if "status=error" in line:
+                return "error"
+        if "ERROR" in line or "失败" in line or "自定义同步处理出错" in line:
+            return "error"
+        if "bgm:" in line and ("已标记" in line or "已在看" in line or "归档" in line):
+            return "success"
+        if "跳过" in line and "bgm:" in line:
+            return "ignored"
+    return "unknown"
+
+
+def _count_levels(lines: list[str]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for line in lines:
+        level = _extract_level(line)
+        if level:
+            counts[level] += 1
+    return dict(counts)
+
+
+def _build_group(
+    run_id: str,
+    lines: list[str],
+    *,
+    ambiguous: bool = False,
+    truncated: bool = False,
+) -> dict[str, Any]:
+    info = _parse_title_info(lines)
+    timestamps = [t for line in lines if (t := _extract_timestamp(line))]
+    duration = _duration_ms(timestamps)
+    return {
+        "run_id": run_id,
+        "title": info["title"],
+        "season": info["season"],
+        "episode": info["episode"],
+        "source": info["source"],
+        "status": _infer_status(lines),
+        "start_time": timestamps[0] if timestamps else "",
+        "end_time": timestamps[-1] if timestamps else "",
+        "duration_ms": duration,
+        "line_count": len(lines),
+        "level_counts": _count_levels(lines),
+        "ambiguous": ambiguous,
+        "truncated": truncated,
+        "lines": lines,
+    }
+
+
+def _heuristic_group_orphans(
+    orphan_lines: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """无 run_id 行的启发式分组；登录相关行始终保留为 orphan。"""
+    remaining: list[str] = []
+    login_orphans: list[str] = []
+    for line in orphan_lines:
+        if _is_login_orphan(line):
+            login_orphans.append(line)
+        else:
+            remaining.append(line)
+
+    groups: list[dict[str, Any]] = []
+    current_lines: list[str] = []
+    open_groups = 0
+    ambiguous = False
+
+    for line in remaining:
+        is_start = bool(SYNC_START_RE.search(line))
+        is_end = bool(SYNC_END_RE.search(line))
+
+        if is_start:
+            if current_lines:
+                groups.append(
+                    _build_group(
+                        f"heuristic_{len(groups)}",
+                        current_lines,
+                        ambiguous=open_groups > 0,
+                    )
+                )
+                if open_groups > 0:
+                    ambiguous = True
+            current_lines = [line]
+            open_groups += 1
+            if is_end:
+                groups.append(
+                    _build_group(
+                        f"heuristic_{len(groups)}",
+                        current_lines,
+                        ambiguous=open_groups > 1,
+                    )
+                )
+                current_lines = []
+                open_groups = max(0, open_groups - 1)
+        elif current_lines:
+            current_lines.append(line)
+            if is_end:
+                groups.append(
+                    _build_group(
+                        f"heuristic_{len(groups)}",
+                        current_lines,
+                        ambiguous=open_groups > 1,
+                    )
+                )
+                current_lines = []
+                open_groups = max(0, open_groups - 1)
+        else:
+            login_orphans.append(line)
+
+    if current_lines:
+        groups.append(
+            _build_group(
+                f"heuristic_{len(groups)}",
+                current_lines,
+                ambiguous=True,
+            )
+        )
+
+    if ambiguous:
+        for g in groups:
+            if g["run_id"].startswith("heuristic_"):
+                g["ambiguous"] = True
+
+    return groups, login_orphans
+
+
+def group_log_lines(
+    lines: list[str],
+    *,
+    truncated_run_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """
+    将日志行按 run_id 分组。
+
+    返回 {"groups": [...], "orphans": [...]}。
+    """
+    truncated_run_ids = truncated_run_ids or set()
+    by_run: dict[str, list[str]] = defaultdict(list)
+    no_run_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.rstrip("\n")
+        if not stripped:
+            continue
+        m = RUN_ID_RE.search(stripped)
+        if m:
+            by_run[m.group(1).strip()].append(stripped)
+        else:
+            no_run_lines.append(stripped)
+
+    groups: list[dict[str, Any]] = []
+    for run_id, run_lines in by_run.items():
+        groups.append(
+            _build_group(
+                run_id,
+                run_lines,
+                truncated=run_id in truncated_run_ids,
+            )
+        )
+
+    heuristic_groups, orphans = _heuristic_group_orphans(no_run_lines)
+    groups.extend(heuristic_groups)
+
+    recognized: list[dict[str, Any]] = []
+    for group in groups:
+        info = {
+            "title": group.get("title"),
+            "season": group.get("season"),
+            "episode": group.get("episode"),
+        }
+        if _looks_like_sync_group(group.get("lines", []), info):
+            recognized.append(group)
+        else:
+            orphans.extend(group.get("lines", []))
+
+    recognized.sort(key=lambda g: g.get("start_time") or "")
+
+    return {"groups": recognized, "orphans": orphans}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2356,19 +2356,30 @@ pre {
     transform: scale(0.95);
 }
 
-/* 日志查看器样式 */
+/* 日志查看器样式（与 app-subcard / stats-card 设计令牌一致） */
 .log-viewer {
-    height: 500px;
+    height: 560px;
     overflow-y: auto;
-    background-color: #1e1e1e;
-    border-radius: 0 0 12px 12px;
+    background: var(--app-bg-card-header);
+    border-radius: 0 0 var(--app-radius-card-sm) var(--app-radius-card-sm);
+}
+
+.log-viewer.log-viewer--grouped {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.log-viewer.log-viewer--grouped .log-groups {
+    flex: 1;
+    min-height: 0;
 }
 
 .log-text {
-    color: #d4d4d4;
+    color: var(--app-text);
     font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
     font-size: 0.875rem;
-    line-height: 1.4;
+    line-height: 1.5;
     margin: 0;
     padding: 1rem;
     background-color: transparent;
@@ -2378,20 +2389,401 @@ pre {
 }
 
 .log-viewer::-webkit-scrollbar {
-    width: 12px;
+    width: 8px;
 }
 
 .log-viewer::-webkit-scrollbar-track {
-    background-color: #2d2d2d;
+    background-color: transparent;
 }
 
 .log-viewer::-webkit-scrollbar-thumb {
-    background-color: #555;
-    border-radius: 6px;
+    background-color: var(--app-border-strong);
+    border-radius: 4px;
 }
 
 .log-viewer::-webkit-scrollbar-thumb:hover {
-    background-color: #777;
+    background-color: var(--app-text-muted);
+}
+
+/* 同步日志分组 */
+.log-groups {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+}
+
+.log-groups-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.log-groups-scroll > .log-group-card,
+.log-groups-scroll > .log-groups-more-hint {
+    flex-shrink: 0;
+}
+
+.log-groups-scroll::-webkit-scrollbar {
+    width: 8px;
+}
+
+.log-groups-scroll::-webkit-scrollbar-thumb {
+    background-color: var(--app-border-strong);
+    border-radius: 4px;
+}
+
+.log-orphans-footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--app-divider);
+    background: var(--app-bg-card-header);
+}
+
+.log-group-card {
+    --group-accent: var(--app-orange);
+    --group-accent-soft: var(--app-orange-soft);
+    position: relative;
+    border: 1px solid var(--app-glass-border);
+    border-radius: var(--app-radius-card-sm);
+    background: var(--app-bg-card);
+    box-shadow: var(--app-shadow-card);
+    overflow: hidden;
+    transition:
+        border-color 0.22s var(--app-ease-smooth),
+        box-shadow 0.24s var(--app-ease-smooth);
+}
+
+.log-group-card::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: var(--group-accent);
+}
+
+.log-group-card:hover {
+    border-color: color-mix(in srgb, var(--group-accent) 24%, var(--app-glass-border));
+    box-shadow: var(--app-shadow-card-hover);
+}
+
+.log-group-card[data-status='success'] {
+    --group-accent: var(--app-green);
+    --group-accent-soft: var(--app-green-soft);
+}
+
+.log-group-card[data-status='error'] {
+    --group-accent: var(--app-red);
+    --group-accent-soft: var(--app-red-soft);
+}
+
+.log-group-card[data-status='ignored'] {
+    --group-accent: var(--app-gray);
+    --group-accent-soft: var(--app-gray-soft);
+}
+
+.log-group-card[data-status='unknown'] {
+    --group-accent: var(--app-orange);
+    --group-accent-soft: var(--app-orange-soft);
+}
+
+.log-group-header {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem 0.75rem 1.15rem;
+    cursor: pointer;
+    user-select: none;
+    background: var(--app-bg-card-header);
+    border-bottom: 1px solid var(--app-divider);
+}
+
+.log-group-header-main {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.log-group-status-dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--group-accent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--group-accent) 22%, transparent);
+}
+
+.log-group-title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem 0.55rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.log-group-title-wrap {
+    min-width: 0;
+    flex: 1;
+}
+
+.log-group-title {
+    font-weight: 600;
+    font-size: 0.875rem;
+    line-height: 1.35;
+    color: var(--app-text);
+    word-break: break-word;
+}
+
+.log-group-badges {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0;
+}
+
+.log-group-badges .badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+.log-group-header-actions {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.45rem;
+    flex-shrink: 0;
+}
+
+.log-group-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--app-text-muted);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.log-group-meta .bi {
+    font-size: 0.75rem;
+    opacity: 0.85;
+}
+
+.log-group-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.3rem 0.55rem;
+    border: 1px solid var(--app-glass-border);
+    border-radius: 10px;
+    background: var(--app-bg-input);
+    color: var(--app-text-muted);
+    font-size: 0.75rem;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+        background 0.22s var(--app-ease-smooth),
+        border-color 0.22s var(--app-ease-smooth),
+        color 0.22s var(--app-ease-smooth);
+}
+
+.log-group-btn:hover {
+    background: var(--group-accent-soft);
+    border-color: color-mix(in srgb, var(--group-accent) 35%, var(--app-glass-border));
+    color: var(--app-text);
+}
+
+.log-group-copy--done {
+    border-color: rgba(var(--app-green-rgb), 0.35) !important;
+    background: var(--app-green-soft) !important;
+    color: var(--app-green) !important;
+}
+
+.log-group-btn .bi {
+    font-size: 0.85rem;
+}
+
+.log-group-toggle .bi {
+    transition: transform 0.2s ease;
+}
+
+.log-group-card.is-collapsed .log-group-toggle .bi {
+    transform: rotate(-90deg);
+}
+
+.log-group-debug-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0 1rem 0.5rem 1.15rem;
+    font-size: 0.75rem;
+    color: var(--app-text-muted);
+    background: var(--app-bg-card-header);
+}
+
+.log-group-debug-hint .bi {
+    font-size: 0.75rem;
+}
+
+.log-group-body {
+    max-height: 280px;
+    overflow-y: auto;
+    background: var(--app-bg-card);
+    padding: 0.25rem 0 0.5rem;
+}
+
+.log-group-body.collapsed {
+    display: none;
+}
+
+.log-group-body::-webkit-scrollbar {
+    width: 6px;
+}
+
+.log-group-body::-webkit-scrollbar-thumb {
+    background-color: var(--app-border-strong);
+    border-radius: 4px;
+}
+
+.log-line {
+    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    padding: 0.2rem 1rem 0.2rem 1.15rem;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    border-left: 2px solid transparent;
+}
+
+.log-line--alt {
+    background: var(--app-bg-hover);
+}
+
+.log-line:hover {
+    background: var(--group-accent-soft);
+    border-left-color: var(--group-accent);
+}
+
+.log-group-card .log-line--debug {
+    color: var(--app-text-muted);
+}
+
+.log-group-card .log-line--info {
+    color: var(--app-text-dim);
+}
+
+.log-group-card .log-line--warning {
+    color: var(--app-orange);
+}
+
+.log-group-card .log-line--error {
+    color: var(--app-red);
+}
+
+.log-orphans-section {
+    margin: 0;
+    padding: 0.55rem 1rem;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    color: var(--app-text-muted);
+}
+
+.log-orphans-section summary {
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    padding: 0.15rem 0;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.log-orphans-hint {
+    font-size: 0.6875rem;
+    font-weight: 400;
+    color: var(--app-text-muted);
+    opacity: 0.85;
+}
+
+.log-orphans-section summary::-webkit-details-marker {
+    display: none;
+}
+
+.log-orphans-section summary::before {
+    content: '▸';
+    display: inline-block;
+    margin-right: 0.35rem;
+    transition: transform 0.2s ease;
+}
+
+.log-orphans-section[open] summary::before {
+    transform: rotate(90deg);
+}
+
+.log-orphans-body {
+    margin-top: 0.35rem;
+    max-height: 160px;
+    overflow-y: auto;
+    border-top: 1px solid var(--app-divider);
+    padding: 0.35rem 0 0.5rem;
+}
+
+.log-viewer.log-viewer--grouped > .text-center.text-muted,
+.log-groups-scroll > .text-center.text-muted {
+    padding: 2rem 1rem;
+    color: var(--app-text-muted) !important;
+}
+
+.log-groups-more-hint {
+    text-align: center;
+    padding: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--app-text-muted);
+    border: 1px dashed var(--app-border);
+    border-radius: var(--app-radius-card-sm);
+    background: var(--app-bg-card);
+}
+
+@media (max-width: 767.98px) {
+    .log-group-header {
+        flex-wrap: wrap;
+        align-items: flex-start;
+    }
+
+    .log-group-header-main {
+        width: 100%;
+    }
+
+    .log-group-header-actions {
+        width: 100%;
+        justify-content: flex-end;
+        padding-top: 0.45rem;
+        margin-top: 0.15rem;
+        border-top: 1px solid var(--app-divider);
+    }
+
+    .log-group-copy-label {
+        display: none;
+    }
+
+    .log-group-meta {
+        font-size: 0.6875rem;
+    }
 }
 
 /* ========== 登录页面专用样式 ========== */

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -1,0 +1,652 @@
+/**
+ * 日志管理页：分组视图、筛选、自动刷新、一键复制
+ */
+(function () {
+    'use strict';
+
+    const DEFAULT_EXPAND_RECENT = 3;
+    const COPY_FEEDBACK_MS = 2000;
+
+    let autoRefreshInterval = null;
+    let clearLogsModal = null;
+    let lastModified = null;
+    let lastGrouped = null;
+    /** @type {Record<string, boolean>} run_id -> true 表示折叠 */
+    let groupCollapseState = {};
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const modalEl = document.getElementById('clearLogsModal');
+        if (modalEl) {
+            clearLogsModal = new bootstrap.Modal(modalEl);
+        }
+        loadLogs();
+        startAutoRefresh();
+
+        document.getElementById('auto-refresh').addEventListener('change', function () {
+            if (this.checked) {
+                startAutoRefresh();
+            } else {
+                stopAutoRefresh();
+            }
+        });
+
+        document.getElementById('grouped-view').addEventListener('change', function () {
+            lastModified = null;
+            lastGrouped = null;
+            groupCollapseState = {};
+            loadLogs();
+        });
+    });
+
+    function startAutoRefresh() {
+        stopAutoRefresh();
+        autoRefreshInterval = setInterval(loadLogs, 5000);
+    }
+
+    function stopAutoRefresh() {
+        if (autoRefreshInterval) {
+            clearInterval(autoRefreshInterval);
+            autoRefreshInterval = null;
+        }
+    }
+
+    function getFilterParams() {
+        const level = document.getElementById('log-level').value;
+        const search = document.getElementById('log-search').value;
+        const limit = document.getElementById('log-lines-limit').value;
+        const grouped = document.getElementById('grouped-view').checked;
+        const params = new URLSearchParams();
+        if (level) params.set('level', level);
+        if (search) params.set('search', search);
+        if (limit) params.set('limit', limit);
+        if (grouped) params.set('grouped', 'true');
+        return params;
+    }
+
+    window.loadLogs = async function loadLogs() {
+        try {
+            const params = getFilterParams();
+            const response = await fetch(appUrl(`/api/logs?${params}`), {
+                credentials: 'include',
+            });
+            const data = await response.json();
+
+            if (data.status !== 'success') {
+                showAlert('加载日志失败: ' + (data.message || ''), 'danger');
+                return;
+            }
+
+            const stats = data.data.stats;
+            const grouped = document.getElementById('grouped-view').checked;
+            if (
+                lastModified !== null
+                && stats.modified === lastModified
+                && lastGrouped === grouped
+            ) {
+                return;
+            }
+            lastModified = stats.modified;
+            lastGrouped = grouped;
+
+            displayLogStats(stats);
+            updateDebugHint(data.data.debug_mode);
+
+            if (grouped) {
+                displayGroupedLogs(data.data.groups || [], data.data.orphans || [], data.data.debug_mode);
+            } else {
+                displayLogContent(data.data.content || '');
+            }
+        } catch (error) {
+            console.error('加载日志失败:', error);
+            showAlert('加载日志失败', 'danger');
+        }
+    };
+
+    window.applyLogFilter = function applyLogFilter() {
+        lastModified = null;
+        lastGrouped = null;
+        groupCollapseState = {};
+        loadLogs();
+    };
+
+    function displayLogStats(stats) {
+        document.getElementById('log-size').textContent = formatFileSize(stats.size);
+        document.getElementById('log-lines').textContent = stats.lines.toLocaleString();
+        if (stats.modified) {
+            const modDate = new Date(stats.modified);
+            document.getElementById('log-modified').textContent =
+                (modDate.getMonth() + 1) + '/' + modDate.getDate() + ' ' +
+                modDate.toTimeString().slice(0, 5);
+        } else {
+            document.getElementById('log-modified').textContent = '-';
+        }
+        document.getElementById('log-errors').textContent = stats.errors.toLocaleString();
+    }
+
+    function updateDebugHint(debugMode) {
+        const hint = document.getElementById('debug-mode-hint');
+        if (!hint) return;
+        hint.classList.toggle('d-none', !debugMode);
+    }
+
+    function displayLogContent(content) {
+        const logContent = document.getElementById('log-content');
+        logContent.innerHTML = '';
+        logContent.classList.remove('log-viewer--grouped');
+
+        if (!content || content.length === 0) {
+            logContent.innerHTML = '<div class="text-center p-4 text-muted">暂无日志内容</div>';
+            return;
+        }
+
+        const pre = document.createElement('pre');
+        pre.className = 'log-text';
+        pre.textContent = content;
+        logContent.appendChild(pre);
+        logContent.scrollTop = logContent.scrollHeight;
+    }
+
+    function groupKey(group) {
+        return group.run_id || ('group_' + formatGroupTitle(group));
+    }
+
+    function linesSignature(lines) {
+        if (!lines || lines.length === 0) {
+            return '0';
+        }
+        return String(lines.length) + ':' + lines[lines.length - 1];
+    }
+
+    function shouldStartCollapsed(group, index, total) {
+        const key = groupKey(group);
+        if (Object.prototype.hasOwnProperty.call(groupCollapseState, key)) {
+            return groupCollapseState[key];
+        }
+        if (group.status === 'error') {
+            return false;
+        }
+        return index < total - DEFAULT_EXPAND_RECENT;
+    }
+
+    function getScrollContainer() {
+        const container = document.getElementById('log-content');
+        return container.querySelector('.log-groups-scroll') || container;
+    }
+
+    function isNearBottom(el, threshold) {
+        threshold = threshold || 48;
+        return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    }
+
+    function displayGroupedLogs(groups, orphans, debugMode) {
+        const container = document.getElementById('log-content');
+        container.classList.add('log-viewer--grouped');
+
+        if (groups.length === 0 && orphans.length === 0) {
+            container.innerHTML = '<div class="text-center p-4 text-muted">暂无日志内容</div>';
+            return;
+        }
+
+        const scrollEl = getScrollContainer();
+        const stickToBottom = scrollEl ? isNearBottom(scrollEl) : false;
+        const scrollTop = scrollEl ? scrollEl.scrollTop : 0;
+
+        let wrapper = container.querySelector('.log-groups');
+        if (!wrapper) {
+            wrapper = createLogGroupsShell();
+            container.innerHTML = '';
+            container.appendChild(wrapper);
+        }
+
+        syncGroupedLogs(wrapper, groups, orphans, debugMode);
+
+        const nextScrollEl = getScrollContainer();
+        if (nextScrollEl) {
+            if (stickToBottom) {
+                nextScrollEl.scrollTop = nextScrollEl.scrollHeight;
+            } else {
+                nextScrollEl.scrollTop = scrollTop;
+            }
+        }
+    }
+
+    function createLogGroupsShell() {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'log-groups';
+        wrapper.innerHTML =
+            '<div class="log-groups-scroll"></div>' +
+            '<div class="log-orphans-footer" hidden></div>';
+        return wrapper;
+    }
+
+    function syncGroupedLogs(wrapper, groups, orphans, debugMode) {
+        const listEl = wrapper.querySelector('.log-groups-scroll');
+        const visibleGroups = groups.slice(-50);
+        const existingCards = new Map();
+
+        listEl.querySelectorAll('.log-group-card').forEach(function (card) {
+            existingCards.set(card.dataset.runId, card);
+        });
+
+        const orderedCards = [];
+        visibleGroups.forEach(function (group, index) {
+            const key = groupKey(group);
+            let card = existingCards.get(key);
+            if (card) {
+                updateGroupCard(card, group, debugMode);
+                existingCards.delete(key);
+            } else {
+                card = buildGroupCard(group, debugMode, index, visibleGroups.length);
+            }
+            orderedCards.push(card);
+        });
+
+        existingCards.forEach(function (card) {
+            const key = card.dataset.runId;
+            if (key) {
+                delete groupCollapseState[key];
+            }
+            card.remove();
+        });
+
+        let moreHint = listEl.querySelector('.log-groups-more-hint');
+        if (groups.length > 50) {
+            if (!moreHint) {
+                moreHint = document.createElement('div');
+                moreHint.className = 'log-groups-more-hint';
+                listEl.appendChild(moreHint);
+            }
+            moreHint.textContent = '仅显示最新 50 组，共 ' + groups.length + ' 组';
+        } else if (moreHint) {
+            moreHint.remove();
+        }
+
+        orderedCards.forEach(function (card) {
+            listEl.appendChild(card);
+        });
+        if (moreHint) {
+            listEl.appendChild(moreHint);
+        }
+
+        syncOrphansFooter(wrapper, orphans);
+    }
+
+    function syncOrphansFooter(wrapper, orphans) {
+        const footer = wrapper.querySelector('.log-orphans-footer');
+        if (!footer) {
+            return;
+        }
+        if (!orphans.length) {
+            footer.hidden = true;
+            footer.innerHTML = '';
+            return;
+        }
+
+        footer.hidden = false;
+        const detailsEl = footer.querySelector('details');
+        const wasOpen = detailsEl ? detailsEl.open : false;
+        footer.innerHTML = '';
+        footer.appendChild(buildOrphansSection(orphans));
+        const details = footer.querySelector('details');
+        if (details && wasOpen) {
+            details.open = true;
+        }
+    }
+
+    function statusLabel(status) {
+        switch (status) {
+            case 'success': return '成功';
+            case 'error': return '失败';
+            case 'ignored': return '忽略';
+            default: return '未知';
+        }
+    }
+
+    function statusBadgeClass(status) {
+        switch (status) {
+            case 'success': return 'bg-success';
+            case 'error': return 'bg-danger';
+            case 'ignored': return 'bg-secondary';
+            default: return 'bg-warning';
+        }
+    }
+
+    function formatGroupTitle(group) {
+        const name = (group.title || '').trim();
+        const se = (group.season && group.episode)
+            ? 'S' + String(group.season).padStart(2, '0') + 'E' + String(group.episode).padStart(2, '0')
+            : '';
+        if (name && se) {
+            return name + ' ' + se;
+        }
+        if (name) {
+            return name;
+        }
+        if (se) {
+            return se;
+        }
+        return '未识别同步';
+    }
+
+    function formatDuration(durationMs) {
+        if (durationMs == null || durationMs === undefined) {
+            return '';
+        }
+        if (durationMs < 1000) {
+            return durationMs + 'ms';
+        }
+        const sec = durationMs / 1000;
+        if (sec < 60) {
+            return (Number.isInteger(sec) ? String(sec) : sec.toFixed(1)) + 's';
+        }
+        return Math.round(sec) + 's';
+    }
+
+    function detectLineLevel(line) {
+        if (line.includes('[ERROR]')) return 'ERROR';
+        if (line.includes('[WARNING]') || line.includes('[WARN ]') || line.includes('[WARN]')) {
+            return 'WARNING';
+        }
+        if (line.includes('[DEBUG]')) return 'DEBUG';
+        if (line.includes('[INFO]')) return 'INFO';
+        return 'INFO';
+    }
+
+    function stripRunTagFromLine(line) {
+        return line.replace(/ \[run:[^\]]+\]/, '');
+    }
+
+    function renderGroupBadges(group) {
+        let html = '';
+        if (group.source) {
+            html += '<span class="badge rounded-pill bg-info">' + escapeHtml(group.source) + '</span>';
+        }
+        html += '<span class="badge rounded-pill ' + statusBadgeClass(group.status) + '">' +
+            statusLabel(group.status) + '</span>';
+        if (group.ambiguous) {
+            html += '<span class="badge rounded-pill bg-warning" title="并发交叉或历史日志，分组可能不完整">可能不完整</span>';
+        }
+        return html;
+    }
+
+    function renderGroupActions(group) {
+        const durationText = formatDuration(group.duration_ms);
+        return (durationText
+            ? '<span class="log-group-meta"><i class="bi bi-hourglass-split"></i>' + escapeHtml(durationText) + '</span>'
+            : '') +
+            '<span class="log-group-meta"><i class="bi bi-list-ul"></i>' + group.line_count + ' 行</span>' +
+            '<button type="button" class="log-group-btn log-group-copy" title="复制本组日志">' +
+            '<i class="bi bi-clipboard"></i><span class="log-group-copy-label">复制</span></button>' +
+            '<button type="button" class="log-group-btn log-group-toggle" title="折叠/展开" aria-expanded="true">' +
+            '<i class="bi bi-chevron-down"></i></button>';
+    }
+
+    function fillGroupBody(body, lines) {
+        body.innerHTML = '';
+        (lines || []).forEach(function (line, index) {
+            const row = document.createElement('div');
+            const level = detectLineLevel(line);
+            row.className = 'log-line log-line--' + level.toLowerCase();
+            if (index % 2 === 1) {
+                row.classList.add('log-line--alt');
+            }
+            row.textContent = stripRunTagFromLine(line);
+            body.appendChild(row);
+        });
+    }
+
+    function syncDebugHint(card, group, debugMode) {
+        let hint = card.querySelector('.log-group-debug-hint');
+        const show = debugMode && group.level_counts && group.level_counts.DEBUG > 0;
+        if (!show) {
+            if (hint) {
+                hint.remove();
+            }
+            return;
+        }
+        if (!hint) {
+            hint = document.createElement('div');
+            hint.className = 'log-group-debug-hint';
+            const body = card.querySelector('.log-group-body');
+            card.insertBefore(hint, body);
+        }
+        hint.innerHTML = '<i class="bi bi-bug"></i> 含 ' + group.level_counts.DEBUG + ' 条 DEBUG';
+    }
+
+    function bindGroupCardEvents(card) {
+        if (card.dataset.eventsBound === '1') {
+            return;
+        }
+        card.dataset.eventsBound = '1';
+
+        card.addEventListener('click', function (e) {
+            const copyBtn = e.target.closest('.log-group-copy');
+            if (copyBtn) {
+                e.stopPropagation();
+                if (card._logGroup) {
+                    copyGroupLines(card._logGroup, copyBtn);
+                }
+                return;
+            }
+
+            const toggleBtn = e.target.closest('.log-group-toggle');
+            const header = e.target.closest('.log-group-header');
+            if (!toggleBtn && !header) {
+                return;
+            }
+
+            e.stopPropagation();
+            toggleGroupBody(
+                card,
+                card.querySelector('.log-group-body'),
+                card.querySelector('.log-group-toggle'),
+            );
+        });
+    }
+
+    function applyCardCollapsed(card, body, toggleBtn, collapsed) {
+        body.classList.toggle('collapsed', collapsed);
+        card.classList.toggle('is-collapsed', collapsed);
+        if (toggleBtn) {
+            toggleBtn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        }
+    }
+
+    function buildGroupCard(group, debugMode, index, total) {
+        const card = document.createElement('div');
+        card.className = 'log-group-card';
+        card.dataset.runId = groupKey(group);
+        card.dataset.status = group.status || 'unknown';
+        card.dataset.linesSig = linesSignature(group.lines);
+
+        const title = formatGroupTitle(group);
+
+        const header = document.createElement('div');
+        header.className = 'log-group-header';
+
+        const main = document.createElement('div');
+        main.className = 'log-group-header-main';
+        main.innerHTML =
+            '<span class="log-group-status-dot" aria-hidden="true"></span>' +
+            '<div class="log-group-title-row">' +
+            '<div class="log-group-title">' + escapeHtml(title) + '</div>' +
+            '<div class="log-group-badges">' + renderGroupBadges(group) + '</div>' +
+            '</div>';
+
+        const actions = document.createElement('div');
+        actions.className = 'log-group-header-actions';
+        actions.innerHTML = renderGroupActions(group);
+
+        header.appendChild(main);
+        header.appendChild(actions);
+
+        const body = document.createElement('div');
+        body.className = 'log-group-body';
+        fillGroupBody(body, group.lines);
+
+        card.appendChild(header);
+        syncDebugHint(card, group, debugMode);
+        card.appendChild(body);
+
+        bindGroupCardEvents(card);
+        card._logGroup = group;
+
+        const collapsed = shouldStartCollapsed(group, index, total);
+        applyCardCollapsed(card, body, header.querySelector('.log-group-toggle'), collapsed);
+        if (collapsed) {
+            groupCollapseState[groupKey(group)] = true;
+        }
+
+        return card;
+    }
+
+    function updateGroupCard(card, group, debugMode) {
+        const key = groupKey(group);
+        card.dataset.runId = key;
+        card.dataset.status = group.status || 'unknown';
+
+        const title = formatGroupTitle(group);
+        card.querySelector('.log-group-title').textContent = title;
+        card.querySelector('.log-group-badges').innerHTML = renderGroupBadges(group);
+        card.querySelector('.log-group-header-actions').innerHTML = renderGroupActions(group);
+
+        const sig = linesSignature(group.lines);
+        if (card.dataset.linesSig !== sig) {
+            card.dataset.linesSig = sig;
+            fillGroupBody(card.querySelector('.log-group-body'), group.lines);
+        }
+
+        syncDebugHint(card, group, debugMode);
+        bindGroupCardEvents(card);
+        card._logGroup = group;
+    }
+
+    function toggleGroupBody(card, body, toggleBtn) {
+        const collapsed = !body.classList.contains('collapsed');
+        applyCardCollapsed(card, body, toggleBtn, collapsed);
+        const key = card.dataset.runId;
+        if (key) {
+            groupCollapseState[key] = collapsed;
+        }
+    }
+
+    function buildOrphansSection(orphans) {
+        const section = document.createElement('details');
+        section.className = 'log-orphans-section';
+        const summary = document.createElement('summary');
+        summary.innerHTML =
+            '<i class="bi bi-gear-wide-connected me-1"></i>其他系统日志 (' + orphans.length + ')' +
+            '<span class="log-orphans-hint">登录、启动等，与同步无关</span>';
+        section.appendChild(summary);
+
+        const body = document.createElement('div');
+        body.className = 'log-orphans-body';
+        orphans.forEach(function (line) {
+            const row = document.createElement('div');
+            row.className = 'log-line log-line--info';
+            row.textContent = line;
+            body.appendChild(row);
+        });
+        section.appendChild(body);
+        return section;
+    }
+
+    function copyGroupLines(group, btn) {
+        const text = (group.lines || []).map(stripRunTagFromLine).join('\n');
+        navigator.clipboard.writeText(text).then(function () {
+            flashCopyButton(btn);
+        }).catch(function () {
+            showAlert('复制失败', 'danger');
+        });
+    }
+
+    function flashCopyButton(btn) {
+        if (!btn || btn.classList.contains('log-group-copy--done')) {
+            return;
+        }
+        const icon = btn.querySelector('.bi');
+        const label = btn.querySelector('.log-group-copy-label');
+        const origIconClass = icon ? icon.className : '';
+        if (icon) {
+            icon.className = 'bi bi-check2';
+        }
+        if (label) {
+            label.textContent = '已复制';
+        }
+        btn.classList.add('log-group-copy--done');
+        window.setTimeout(function () {
+            if (icon) {
+                icon.className = origIconClass;
+            }
+            if (label) {
+                label.textContent = '复制';
+            }
+            btn.classList.remove('log-group-copy--done');
+        }, COPY_FEEDBACK_MS);
+    }
+
+    function escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    window.clearLogs = function clearLogs() {
+        clearLogsModal.show();
+    };
+
+    window.confirmClearLogs = async function confirmClearLogs() {
+        const createBackup = document.getElementById('backup-before-clear').checked;
+
+        try {
+            const response = await fetch(appUrl('/api/logs/clear'), {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ backup: createBackup }),
+            });
+            const data = await response.json();
+
+            if (data.status === 'success') {
+                clearLogsModal.hide();
+                showAlert('日志已清空', 'success');
+                lastModified = null;
+                lastGrouped = null;
+                groupCollapseState = {};
+                loadLogs();
+            } else {
+                showAlert('清空日志失败: ' + data.message, 'danger');
+            }
+        } catch (error) {
+            console.error('清空日志失败:', error);
+            showAlert('清空日志失败', 'danger');
+        }
+    };
+
+    function formatFileSize(bytes) {
+        if (bytes === 0) return '0 B';
+        const k = 1024;
+        const sizes = ['B', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    function showAlert(message, type) {
+        const toastContainer = document.querySelector('.toast-container');
+        if (!toastContainer) return;
+        const toast = document.createElement('div');
+        toast.className = 'toast align-items-center text-white bg-' + type + ' border-0';
+        toast.setAttribute('role', 'alert');
+        toast.innerHTML =
+            '<div class="d-flex">' +
+            '<div class="toast-body">' + escapeHtml(message) + '</div>' +
+            '<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>' +
+            '</div>';
+        toastContainer.appendChild(toast);
+        const bsToast = new bootstrap.Toast(toast);
+        bsToast.show();
+        toast.addEventListener('hidden.bs.toast', function () {
+            toast.remove();
+        });
+    }
+})();

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -85,6 +85,9 @@
             </div>
         </div>
         <div class="card-body">
+            <div id="debug-mode-hint" class="alert alert-info py-2 small d-none mb-3">
+                <i class="bi bi-bug me-1"></i>调试模式已开启，日志含 DEBUG 详情
+            </div>
             <div class="row g-3">
                 <div class="col-md-3">
                     <label for="log-level" class="form-label">日志级别</label>
@@ -129,9 +132,15 @@
                 <i class="bi bi-terminal me-2 card-header-icon"></i>
                 <h6 class="m-0 fw-semibold card-header-title">日志内容</h6>
             </div>
-            <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" id="auto-refresh" checked>
-                <label class="form-check-label" for="auto-refresh">自动刷新</label>
+            <div class="d-flex align-items-center flex-wrap gap-3">
+                <div class="form-check form-switch mb-0">
+                    <input class="form-check-input" type="checkbox" id="grouped-view" checked>
+                    <label class="form-check-label" for="grouped-view">智能分组</label>
+                </div>
+                <div class="form-check form-switch mb-0">
+                    <input class="form-check-input" type="checkbox" id="auto-refresh" checked>
+                    <label class="form-check-label" for="auto-refresh">自动刷新</label>
+                </div>
             </div>
         </div>
         <div class="card-body p-0">
@@ -172,172 +181,4 @@
         </div>
     </div>
 {% endblock %}
-{% block scripts %}
-    <script>
-let autoRefreshInterval;
-let clearLogsModal;
-
-document.addEventListener('DOMContentLoaded', function() {
-    clearLogsModal = new bootstrap.Modal(document.getElementById('clearLogsModal'));
-    loadLogs();
-    startAutoRefresh();
-    
-    // 监听自动刷新开关
-    document.getElementById('auto-refresh').addEventListener('change', function() {
-        if (this.checked) {
-            startAutoRefresh();
-        } else {
-            stopAutoRefresh();
-        }
-    });
-});
-
-function startAutoRefresh() {
-    stopAutoRefresh();
-    autoRefreshInterval = setInterval(loadLogs, 5000); // 每5秒刷新一次
-}
-
-function stopAutoRefresh() {
-    if (autoRefreshInterval) {
-        clearInterval(autoRefreshInterval);
-        autoRefreshInterval = null;
-    }
-}
-
-async function loadLogs() {
-    try {
-        const response = await fetch(appUrl('/api/logs'), {
-            credentials: 'include'
-        });
-        const data = await response.json();
-        
-        if (data.status === 'success') {
-            displayLogStats(data.data.stats);
-            displayLogContent(data.data.content);
-        } else {
-            showAlert('加载日志失败: ' + data.message, 'danger');
-        }
-    } catch (error) {
-        console.error('加载日志失败:', error);
-        showAlert('加载日志失败', 'danger');
-    }
-}
-
-function displayLogStats(stats) {
-    document.getElementById('log-size').textContent = formatFileSize(stats.size);
-    document.getElementById('log-lines').textContent = stats.lines.toLocaleString();
-    var modDate = new Date(stats.modified);
-    document.getElementById('log-modified').textContent = (modDate.getMonth()+1) + '/' + modDate.getDate() + ' ' + modDate.toTimeString().slice(0,5);
-    document.getElementById('log-errors').textContent = stats.errors.toLocaleString();
-}
-
-function displayLogContent(content) {
-    const logContent = document.getElementById('log-content');
-    logContent.innerHTML = '';
-    
-    if (!content || content.length === 0) {
-        logContent.innerHTML = '<div class="text-center p-4 text-muted">暂无日志内容</div>';
-        return;
-    }
-    
-    const pre = document.createElement('pre');
-    pre.className = 'log-text';
-    pre.textContent = content;
-    logContent.appendChild(pre);
-    
-    // 滚动到底部
-    logContent.scrollTop = logContent.scrollHeight;
-}
-
-async function applyLogFilter() {
-    const level = document.getElementById('log-level').value;
-    const search = document.getElementById('log-search').value;
-    const limit = document.getElementById('log-lines-limit').value;
-    
-    try {
-        const params = new URLSearchParams({
-            level: level,
-            search: search,
-            limit: limit
-        });
-        
-        const response = await fetch(appUrl(`/api/logs?${params}`));
-        const data = await response.json();
-        
-        if (data.status === 'success') {
-            displayLogContent(data.data.content);
-        } else {
-            showAlert('筛选日志失败: ' + data.message, 'danger');
-        }
-    } catch (error) {
-        console.error('筛选日志失败:', error);
-        showAlert('筛选日志失败', 'danger');
-    }
-}
-
-function clearLogs() {
-    clearLogsModal.show();
-}
-
-async function confirmClearLogs() {
-    const createBackup = document.getElementById('backup-before-clear').checked;
-    
-    try {
-        const response = await fetch(appUrl('/api/logs/clear'), {
-            method: 'POST',
-            credentials: 'include',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                backup: createBackup
-            })
-        });
-        
-        const data = await response.json();
-        
-        if (data.status === 'success') {
-            clearLogsModal.hide();
-            showAlert('日志已清空', 'success');
-            loadLogs();
-        } else {
-            showAlert('清空日志失败: ' + data.message, 'danger');
-        }
-    } catch (error) {
-        console.error('清空日志失败:', error);
-        showAlert('清空日志失败', 'danger');
-    }
-}
-
-function formatFileSize(bytes) {
-    if (bytes === 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-}
-
-function showAlert(message, type) {
-    // 创建Toast通知
-    const toastContainer = document.querySelector('.toast-container');
-    const toast = document.createElement('div');
-    toast.className = `toast align-items-center text-white bg-${type} border-0`;
-    toast.setAttribute('role', 'alert');
-    toast.innerHTML = `
-        <div class="d-flex">
-            <div class="toast-body">${message}</div>
-            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
-        </div>
-    `;
-    toastContainer.appendChild(toast);
-    
-    const bsToast = new bootstrap.Toast(toast);
-    bsToast.show();
-    
-    // 自动移除
-    toast.addEventListener('hidden.bs.toast', function() {
-        toast.remove();
-    });
-}
-    </script>
-{% endblock %}
+{% block scripts %}<script defer src="{{ '/static/js/logs.js' | static_v }}"></script>{% endblock %}

--- a/tests/api/test_logs_comprehensive.py
+++ b/tests/api/test_logs_comprehensive.py
@@ -316,3 +316,69 @@ async def test_clear_logs_exception(app_with_auth):
                 response = await client.post("/api/logs/clear")
 
                 assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_get_logs_grouped_response(app_with_auth):
+    """测试 grouped=true 返回结构化分组数据"""
+    log_content = (
+        "[2026/07/16 09:00:01.123] [INFO] [run:sync_1_100] 同步开始: 测试番剧 S01E01 (test)\n"
+        "[2026/07/16 09:00:02.456] [INFO] [run:sync_1_100] bgm: 测试番剧 已标记为看过\n"
+        "[2026/07/16 09:00:03.789] [INFO] [run:sync_1_100] 同步结束: status=success\n"
+        "[2026/07/16 09:00:04.000] [INFO] 用户 admin 登录成功\n"
+    )
+
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
+        with patch("app.api.logs.os.path.exists", return_value=True):
+            with patch("app.api.logs.os.stat") as mock_stat:
+                mock_stat.return_value = MagicMock(
+                    st_size=len(log_content), st_mtime=1234567890.0
+                )
+                with patch("builtins.open", mock_open(read_data=log_content)):
+                    with patch("app.api.logs.config_manager") as mock_cm:
+                        mock_cm.get.return_value = True
+                        async with AsyncClient(
+                            transport=ASGITransport(app=app_with_auth),
+                            base_url="http://test",
+                        ) as client:
+                            response = await client.get("/api/logs?grouped=true")
+
+                            assert response.status_code == 200
+                            data = response.json()
+                            assert data["status"] == "success"
+                            assert "content" not in data["data"]
+                            assert "groups" in data["data"]
+                            assert "orphans" in data["data"]
+                            assert "debug_mode" in data["data"]
+                            assert len(data["data"]["groups"]) == 1
+                            assert data["data"]["groups"][0]["run_id"] == "sync_1_100"
+                            assert data["data"]["groups"][0]["status"] == "success"
+                            assert len(data["data"]["orphans"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_logs_grouped_disabled(app_with_auth):
+    """测试 grouped=false 仍返回扁平 content"""
+    log_content = "Line 1\nLine 2\n"
+
+    with patch(
+        "app.api.logs.resolved_dev_log_file_path",
+        return_value=Path("/fake/app.log"),
+    ):
+        with patch("app.api.logs.os.path.exists", return_value=True):
+            with patch("app.api.logs.os.stat") as mock_stat:
+                mock_stat.return_value = MagicMock(st_size=100, st_mtime=1234567890.0)
+                with patch("builtins.open", mock_open(read_data=log_content)):
+                    async with AsyncClient(
+                        transport=ASGITransport(app=app_with_auth),
+                        base_url="http://test",
+                    ) as client:
+                        response = await client.get("/api/logs?grouped=false")
+
+                        assert response.status_code == 200
+                        data = response.json()
+                        assert "content" in data["data"]
+                        assert "groups" not in data["data"]

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -8,8 +8,12 @@ from unittest.mock import MagicMock, patch
 from app.core.logging import (
     Logger,
     effective_dev_log_file_raw,
+    get_sync_run_id,
+    new_inline_sync_run_id,
+    new_retry_sync_run_id,
     resolve_dev_log_file_path,
     resolved_dev_log_file_path,
+    sync_log_context,
 )
 
 
@@ -323,6 +327,43 @@ class TestLogFilePathHelpers:
         ):
             result = resolved_dev_log_file_path(mock_cm)
             assert result is not None
+
+
+class TestSyncLogContext:
+    """同步 run_id 上下文与日志格式"""
+
+    def test_get_sync_run_id_default_none(self):
+        assert get_sync_run_id() is None
+
+    def test_sync_log_context_sets_run_id(self):
+        with sync_log_context("sync_1_100"):
+            assert get_sync_run_id() == "sync_1_100"
+        assert get_sync_run_id() is None
+
+    def test_new_inline_sync_run_id_format(self):
+        rid = new_inline_sync_run_id(3)
+        assert rid.startswith("sync_inline_3_")
+
+    def test_new_retry_sync_run_id_format(self):
+        rid = new_retry_sync_run_id(42)
+        assert rid.startswith("retry_42_")
+
+    def test_log_includes_run_id_field(self, capsys):
+        logger = _make_logger()
+        with sync_log_context("sync_test_1"):
+            logger.info("hello sync")
+        captured = capsys.readouterr()
+        assert "[run:sync_test_1]" in captured.out
+        # 各段之间仅单空格，无 run_id 固定宽度填充
+        assert "]  [" not in captured.out
+        assert "[run:sync_test_1]  hello" not in captured.out
+        assert "[run:sync_test_1] hello" in captured.out
+
+    def test_log_without_run_id_omits_field(self, capsys):
+        logger = _make_logger()
+        logger.info("plain message")
+        captured = capsys.readouterr()
+        assert "[run:" not in captured.out
 
 
 class TestLoggerLogToFile:

--- a/tests/utils/test_log_grouping.py
+++ b/tests/utils/test_log_grouping.py
@@ -1,0 +1,107 @@
+"""
+日志分组解析测试
+"""
+
+from app.utils.log_grouping import group_log_lines
+
+
+def _line(run_id: str, level: str, message: str) -> str:
+    return f"[2026/07/16 09:00:01.123] [{level}] [run:{run_id}] {message}"
+
+
+class TestGroupLogLines:
+    def test_group_by_run_id_interleaved(self):
+        lines = [
+            _line("sync_a", "INFO", "同步开始: 番剧A S01E01 (plex)"),
+            _line("sync_b", "INFO", "同步开始: 番剧B S01E02 (emby)"),
+            _line("sync_a", "INFO", "bgm: 番剧A 已标记为看过"),
+            _line("sync_b", "INFO", "bgm: 番剧B 已标记为看过"),
+            _line("sync_a", "INFO", "同步结束: status=success"),
+            _line("sync_b", "INFO", "同步结束: status=success"),
+        ]
+        result = group_log_lines(lines)
+        assert len(result["groups"]) == 2
+        run_ids = {g["run_id"] for g in result["groups"]}
+        assert run_ids == {"sync_a", "sync_b"}
+        for g in result["groups"]:
+            assert g["status"] == "success"
+            assert g["line_count"] == 3
+
+    def test_login_orphan_not_grouped(self):
+        lines = [
+            _line("sync_a", "INFO", "同步开始: 番剧A S01E01 (plex)"),
+            "[2026/07/16 09:00:02.000] [INFO] 用户 admin 登录成功，IP: 127.0.0.1",
+            _line("sync_a", "INFO", "同步结束: status=success"),
+        ]
+        result = group_log_lines(lines)
+        assert len(result["groups"]) == 1
+        assert result["groups"][0]["run_id"] == "sync_a"
+        assert len(result["orphans"]) == 1
+        assert "登录成功" in result["orphans"][0]
+
+    def test_emoji_preserved_in_group(self):
+        lines = [
+            _line("sync_1", "INFO", "同步开始: 番剧A S01E01 (plex)"),
+            _line("sync_1", "INFO", "📚 [Bangumi] GET /v0/subjects/1 成功"),
+        ]
+        result = group_log_lines(lines)
+        assert "📚" in result["groups"][0]["lines"][1]
+
+    def test_heuristic_ambiguous_on_overlap(self):
+        lines = [
+            "[2026/07/16 09:00:01.000] [INFO] 接收到同步请求：番剧A",
+            "[2026/07/16 09:00:02.000] [INFO] 接收到同步请求：番剧B",
+            "[2026/07/16 09:00:03.000] [INFO] bgm: 番剧A 已标记为看过",
+            "[2026/07/16 09:00:04.000] [INFO] bgm: 番剧B 已标记为看过",
+        ]
+        result = group_log_lines(lines)
+        assert len(result["groups"]) >= 1
+        assert any(g.get("ambiguous") for g in result["groups"])
+
+    def test_level_counts(self):
+        lines = [
+            _line("sync_1", "INFO", "同步开始: 番剧A S01E01 (plex)"),
+            _line("sync_1", "DEBUG", "detail"),
+            _line("sync_1", "INFO", "bgm: 番剧A 已标记为看过"),
+            _line("sync_1", "ERROR", "fail"),
+        ]
+        result = group_log_lines(lines)
+        counts = result["groups"][0]["level_counts"]
+        assert counts.get("DEBUG") == 1
+        assert counts.get("INFO") == 2
+        assert counts.get("ERROR") == 1
+
+    def test_truncated_flag(self):
+        lines = [_line("sync_1", "INFO", "同步开始: 番剧A S01E01 (plex)")]
+        result = group_log_lines(lines, truncated_run_ids={"sync_1"})
+        assert result["groups"][0]["truncated"] is True
+
+    def test_title_from_sync_start_line(self):
+        lines = [
+            _line(
+                "retry_1",
+                "INFO",
+                "同步开始: 关于同组的染谷同学是性感女优这件事。 S01E01 (retry-plex)",
+            ),
+            _line("retry_1", "ERROR", "bgm: 未查询到番剧信息，跳过"),
+            _line("retry_1", "INFO", "同步结束: status=error"),
+        ]
+        group = group_log_lines(lines)["groups"][0]
+        assert "染谷" in group["title"]
+        assert group["season"] == 1
+        assert group["episode"] == 1
+        assert group["source"] == "retry-plex"
+
+    def test_duration_ms(self):
+        lines = [
+            "[2026/07/16 09:50:37.165] [INFO] [run:retry_1] 同步开始: 番剧A S01E01 (plex)",
+            "[2026/07/16 09:50:39.135] [INFO] [run:retry_1] 同步结束: status=error",
+        ]
+        group = group_log_lines(lines)["groups"][0]
+        assert group["duration_ms"] == 1970
+
+    def test_unrecognized_group_goes_to_orphans(self):
+        lines = [_line("sync_test_1", "INFO", "hello sync")]
+        result = group_log_lines(lines)
+        assert result["groups"] == []
+        assert len(result["orphans"]) == 1


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
✨ 新功能 (feature)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
为日志页新增**智能分组**能力：将同一次同步产生的日志按 `run_id` 聚合为卡片展示，支持折叠、复制与自动刷新增量更新，并与全站 UI 设计对齐。

**后端**
- `logging.py`：引入 `sync_run_id` ContextVar 与 `sync_log_context()`，日志格式附加 `[run:xxx]`（仅用于内部分组，UI/复制时剥离）
- `task_manager` / `sync_service` / 重试 API：在异步任务与直调、重试路径传播 `run_id`，并记录「同步开始 / 同步结束」边界日志
- 新增 `log_grouping.py`：按 `run_id` 分组，解析番名、季集、来源、状态、耗时；无 `run_id` 的历史日志走启发式分组；登录等系统日志归入 orphans
- `GET /api/logs?grouped=true`：返回 `groups` / `orphans` / `debug_mode` / `stats`，扁平 `content` 仅在 `grouped=false` 时返回

**前端**
- 日志页开关「智能分组」（默认开启），卡片展示同步标题、来源、状态 badge、耗时与行数
- 默认展开最新 3 组及失败组，其余折叠；单卡可手动折叠/展开，状态会保留
- 按 `run_id` 增量更新 DOM，日志未变时不重绘；有更新时保留滚动位置
- 复制按钮本地反馈（✓ / 已复制）；「其他系统日志」固定于查看器底部，默认折叠
- 样式改用 `--app-*` 设计，与 `stats-card` / badge 体系一致；修复 flex 压缩导致卡片底部裁切的问题

**测试**
- 新增 `test_log_grouping.py`、`test_logging.py` 相关用例，并扩展 `test_logs_comprehensive.py` 覆盖分组 API

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 📋 提交前检查清单
<!-- 提交前请逐项勾选：将 `- [ ]` 改为 `- [x]`，或在 GitHub 编辑器的预览中直接勾选。未勾选项视为尚未完成。 -->

### 规范与静态检查
<!-- 请在提交 PR 前完成以下检查 -->
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [x] 如有页面模板变更，已运行 `uv run djlint templates/ --reformat` 格式化模板

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term`且全部通过
- [x] 新功能已在本地测试通过
- [x] 现有功能未受影响

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
