### PR TITLE
fix: Trakt 同步时 TMDB 映射支持季度感知查询与日期择优，修复无职第三季匹配错误

### DIFF
--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -212,9 +212,11 @@ class TraktSyncService:
                 # bangumi_data 仅收录动画条目，TMDB 命中则确认为动画，跳过 Trakt 详情请求
                 if sync_filter_enabled:
                     if item.type == "episode" and item.show:
-                        tmdb_id = item.show.get("ids", {}).get("tmdb")
+                        show = item.show
+                        tmdb_id = show.get("ids", {}).get("tmdb")
+                        ep_data = item.episode or {}
                         if tmdb_id and bangumi_data.get_title_by_tmdb_id(
-                            f"tv/{tmdb_id}"
+                            f"tv/{tmdb_id}", season=ep_data.get("season")
                         ):
                             logger.debug(
                                 f"命中 bangumi_data 中 TMDB ID，跳过 Trakt 详情请求: tv/{tmdb_id}"
@@ -639,7 +641,9 @@ class TraktSyncService:
 
             show_tmdb = show.get("ids", {}).get("tmdb")
             if show_tmdb is not None:
-                title = bangumi_data.get_title_by_tmdb_id(f"tv/{show_tmdb}")
+                title = bangumi_data.get_title_by_tmdb_id(
+                    f"tv/{show_tmdb}", season=episode.get("season")
+                )
 
             if not title:
                 # bangumi_data 未收录时，按日文原名 → 预取原文 → 英文标题顺序降级
@@ -663,13 +667,19 @@ class TraktSyncService:
             season = episode.get("season", 1)
             episode_num = episode.get("number", 1)
 
-            # 获取发行日期（优先剧集/剧集首播日期，其次播出年份，最后用户观看日期）
+            # 获取发行日期：episode.first_aired → show.first_aired → bangumi_data begin → show.year → watched_at
             release_date = ""
             if episode.get("first_aired"):
                 release_date = episode["first_aired"]
             elif show.get("first_aired"):
                 release_date = show["first_aired"]
-            elif show.get("year"):
+            elif show_tmdb is not None:
+                bgm_begin = bangumi_data.get_begin_by_tmdb_id(
+                    f"tv/{show_tmdb}", season=episode.get("season")
+                )
+                if bgm_begin and isinstance(bgm_begin, str):
+                    release_date = bgm_begin[:10]
+            if not release_date and show.get("year"):
                 release_date = f"{show['year']}-01-01"
 
             if not release_date and item.watched_at:

--- a/app/utils/bangumi_data/__init__.py
+++ b/app/utils/bangumi_data/__init__.py
@@ -60,6 +60,8 @@ class BangumiData(CacheMixin, MatchingMixin, IndexMixin):
         # 是否启用更详细的日志，用于调试匹配问题
         self.verbose_logging = config_manager.get("dev", "debug", fallback=False)
         self._cache_tmdb_mapping: dict[str, str] = {}
+        # TMDB id → begin 日期，供 trakt 同步取 release_date
+        self._cache_tmdb_begin: dict[str, str] = {}
         # 精确匹配索引：title → [item]，加速常用查询
         self._title_index: dict[str, list[dict]] = {}
 

--- a/app/utils/bangumi_data/index.py
+++ b/app/utils/bangumi_data/index.py
@@ -3,27 +3,132 @@
 职责：
 - 构建 TMDB id → 番剧名映射（供 trakt 同步快速查找）
 - 构建标题 → item 精确匹配索引（加速常用查找）
-- 根据 TMDB id 查询番剧名
+- 根据 TMDB id 与可选季度查询番剧名
 """
 
 from __future__ import annotations
 
+import re
+from datetime import datetime, timezone
+from typing import Any
+
 from ...core.logging import logger
+
+# 标题尾部季/部/篇/クール等序列标识符，用于检测条目是否附带季度信息以及多条目冲突时清理基标题。
+# 覆盖：中文简繁体数字季期部、英文 Season/S/Part/Act/Phase、Unicode 罗马数字、日文クール。
+_SEASON_SUFFIX = re.compile(
+    r"\s*("
+    # 第X季/第X期/第X部（简繁体中文数字 + 阿拉伯数字）
+    r"[第]?\s*(?:\d+|[一二三四五六七八九十]+)\s*[季期部]"
+    # Season X（大小写无关）
+    r"|Season\s*\d+"
+    # SX / Part X / Act X / Phase X
+    r"|S\d+|Part\s*\d+|Act\s*\d+|Phase\s*\d+"
+    # Unicode 罗马数字 ⅡⅢⅣⅤⅥⅦⅧⅨⅩ（连续出现视为一个整体）
+    r"|[ⅡⅢⅣⅤⅥⅦⅧⅨⅩ]+"
+    # (第Xクール)
+    r"|\([^)]*クール[^)]*\)"
+    r")\s*$",
+    re.IGNORECASE,
+)
 
 
 class IndexMixin:
     """索引构建与查询相关方法"""
 
-    def _build_tmdb_mapping(self) -> None:
-        """构建 TMDB id 到番剧名的映射"""
+    @staticmethod
+    def _parse_begin(raw: str) -> datetime:
+        """将 bangumi-data 的 begin 字段解析为 datetime，解析失败返回最大日期。"""
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return datetime.max.replace(tzinfo=timezone.utc)
 
+    def _build_tmdb_mapping(self) -> None:
+        """构建 TMDB id 到番剧名的映射。
+
+        同一 TMDB 可能对应多个季度条目，同一 key 冲突时选择最优：
+        - 优先选任意标题均不含季度标记的条目。
+        - 均含标记时选元数据日期最早的条目。
+        - 多条目时去除尾部季度标识符。
+        """
+
+        candidates: dict[str, list[dict[str, Any]]] = {}
         for item in self._parse_data():
             # 提取 TMDB id
             for site in item.get("sites", []):
                 if site.get("site") == "tmdb":
                     tmdb_id = site.get("id")
-                    self._cache_tmdb_mapping[tmdb_id] = item.get("title", "")
+                    title = item.get("title", "")
+                    if not title.strip():
+                        break
+                    candidates.setdefault(tmdb_id, []).append(item)
                     break
+
+        selected_count = 0
+        multi_count = 0
+        for tmdb_id, entries in candidates.items():
+            if len(entries) == 1:
+                item = entries[0]
+                self._cache_tmdb_mapping[tmdb_id] = item.get("title", "")
+                self._cache_tmdb_begin[tmdb_id] = item.get("begin", "") or ""
+                selected_count += 1
+            else:
+                multi_count += 1
+                self._cache_tmdb_mapping[tmdb_id] = self._pick_best_tmdb_title(
+                    entries, strip_suffix=True
+                )
+                # begin 取选中条目的日期
+                no_season = [e for e in entries if not self._has_season_indicator(e)]
+                picks = no_season if no_season else entries
+                picks.sort(key=lambda e: self._parse_begin(e.get("begin", "") or ""))
+                self._cache_tmdb_begin[tmdb_id] = picks[0].get("begin", "") or ""
+
+        logger.info(
+            f"TMDB 映射构建完成，共 {len(candidates)} 个唯一 ID "
+            f"({selected_count} 单节目, {multi_count} 多节目)"
+        )
+
+    @staticmethod
+    def _item_all_titles(item: dict[str, Any]) -> list[str]:
+        """提取条目的所有标题（原标题 + 简繁翻译），供季度检测。"""
+        titles: list[str] = []
+        raw = item.get("title", "")
+        if raw.strip():
+            titles.append(raw)
+        tr = item.get("titleTranslate") or {}
+        for lang in ("zh-Hans", "zh-Hant"):
+            for t in tr.get(lang, []):
+                if t and t.strip():
+                    titles.append(t)
+        return titles
+
+    @classmethod
+    def _has_season_indicator(cls, item: dict[str, Any]) -> bool:
+        """检测条目的任一标题是否包含季度标记。"""
+        for t in cls._item_all_titles(item):
+            if _SEASON_SUFFIX.search(t):
+                return True
+        return False
+
+    @classmethod
+    def _pick_best_tmdb_title(
+        cls, entries: list[dict[str, Any]], strip_suffix: bool = False
+    ) -> str:
+        """从同一 TMDB 的多条记录中选择最佳标题。
+
+        优先级：任意标题均无季度标记 > 日期最早。
+        因为同一季度不同 part 共享 TMDB，季标检测先于日期兜底。
+        """
+
+        no_season = [e for e in entries if not cls._has_season_indicator(e)]
+        picks = no_season if no_season else entries
+        picks.sort(key=lambda e: cls._parse_begin(e.get("begin", "") or ""))
+        title = picks[0].get("title", "")
+
+        if strip_suffix and len(entries) > 1:
+            title = _SEASON_SUFFIX.sub("", title).strip()
+        return title
 
     def _build_title_index(self) -> None:
         """构建标题→item 精确匹配索引，加速常用查找"""
@@ -40,13 +145,38 @@ class IndexMixin:
                         self._title_index.setdefault(zh_title, []).append(item)
         logger.info(f"标题索引构建完成，共 {len(self._title_index)} 个唯一标题")
 
-    def get_title_by_tmdb_id(self, tmdb_id: str) -> str | None:
-        """根据 TMDB id 获取番剧名
+    def get_title_by_tmdb_id(
+        self, tmdb_id: str, season: int | None = None
+    ) -> str | None:
+        """根据 TMDB id 获取番剧名。
 
         Args:
-            tmdb_id: TMDB id
+            tmdb_id: TMDB id（形如 tv/94664 或 movie/10387）
+            season: 季编号，提供时优先查 {tmdb_id}/season/{season}
 
         Returns:
             番剧名或 None
         """
+        if season is not None:
+            title = self._cache_tmdb_mapping.get(f"{tmdb_id}/season/{season}", None)
+            if title:
+                return title
         return self._cache_tmdb_mapping.get(tmdb_id, None)
+
+    def get_begin_by_tmdb_id(self, tmdb_id: str, season: int | None = None) -> str:
+        """根据 TMDB id 获取条目的开始日期。
+
+        Args:
+            tmdb_id: TMDB id（形如 tv/94664 或 movie/10387）
+            season: 季编号，提供时优先查 {tmdb_id}/season/{season}
+
+        Returns:
+            开始日期字符串（空字符串表示未找到）
+        """
+        if not hasattr(self, "_cache_tmdb_begin"):
+            return ""
+        if season is not None:
+            begin = self._cache_tmdb_begin.get(f"{tmdb_id}/season/{season}", "")
+            if begin:
+                return begin
+        return self._cache_tmdb_begin.get(tmdb_id, "")

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -433,6 +433,37 @@ class TestConvertTraktHistoryToCustomItem:
             assert result is not None
             assert "2024-07-15" in result.release_date
 
+    def test_episode_release_from_bangumi_begin(self):
+        """release_date 降级链优先用 bangumi_data 的 begin 日期"""
+        service = _make_service()
+        item = _make_episode_item(show_tmdb="94664", ep_season=3)
+        with patch("app.services.trakt.sync_service.bangumi_data") as mock_bd:
+            mock_bd.get_title_by_tmdb_id.return_value = "無職転生Ⅲ"
+            mock_bd.get_begin_by_tmdb_id.return_value = "2026-07-04T11:00:00.000Z"
+            result = service._convert_trakt_history_to_custom_item("u", item)
+            assert result is not None
+            assert "2026-07-04" in result.release_date
+
+    def test_episode_release_date_falls_back_to_year(self):
+        """bangumi_data 无日期时继续降到 show.year"""
+        service = _make_service()
+        show = {"ids": {"tmdb": "94664"}, "title": "タイトル", "year": 2024}
+        episode = {"season": 1, "number": 1, "ids": {"trakt": 100}}
+        item = TraktHistoryItem(
+            id=1,
+            watched_at="2024-01-01T12:00:00Z",
+            action="watch",
+            type="episode",
+            show=show,
+            episode=episode,
+        )
+        with patch("app.services.trakt.sync_service.bangumi_data") as mock_bd:
+            mock_bd.get_title_by_tmdb_id.return_value = "タイトル"
+            mock_bd.get_begin_by_tmdb_id.return_value = ""
+            result = service._convert_trakt_history_to_custom_item("u", item)
+            assert result is not None
+            assert "2024-01-01" in result.release_date
+
     def test_episode_conversion_exception(self):
         """覆盖 lines 420-422: 转换异常"""
         service = _make_service()

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -1883,3 +1883,47 @@ class TestRequestWithRetry:
 
         with pytest.raises(httpx.ConnectError):
             _request_with_retry("https://example.com", max_retries=0)
+
+
+class TestTmdbMappingMultiSeason:
+    """TMDB 映射多条目选择与季度感知查询"""
+
+    def test_multi_entry_picks_no_season_indicator(self):
+        """同 TMDB 多条目时优先选择无季度标记的标题"""
+        bd = BangumiData()
+        # SeasonInfo 的规则：含"第X季"/"Season X"/"SX"/"(第Xクール)" 等标记
+        assert bd._cache_tmdb_mapping.get("tv/94664", "").startswith("無職転生")
+
+    def test_no_season_entries_pick_earliest_begin(self):
+        """同 TMDB 但均含季度标记时选择最早年份的条目"""
+        bd = BangumiData()
+        # tv/94664/season/2 有两条：S2P1(2023-07)和 S2P2(2024-04)
+        s2 = bd._cache_tmdb_mapping.get("tv/94664/season/2", "")
+        assert s2.startswith("無職転生Ⅱ")
+        assert "クール" not in s2
+
+    def test_get_title_by_tmdb_id_with_season(self):
+        """季度感知查询：有季度时优先返回对应季标题"""
+        bd = BangumiData()
+        base = bd.get_title_by_tmdb_id("tv/94664")
+        assert "クール" not in base
+
+        s2 = bd.get_title_by_tmdb_id("tv/94664", season=2)
+        assert "Ⅱ" in s2
+
+        s3 = bd.get_title_by_tmdb_id("tv/94664", season=3)
+        assert "Ⅲ" in s3
+
+    def test_get_title_by_tmdb_id_season_fallback(self):
+        """季度不存在时回退到基 key"""
+        bd = BangumiData()
+        title_s99 = bd.get_title_by_tmdb_id("tv/94664", season=99)
+        assert title_s99 is not None
+        assert "クール" not in title_s99
+
+    def test_single_episode_tmdb_no_unnecessary_strip(self):
+        """单条目的 TMDB 映射保持原标题不变"""
+        bd = BangumiData()
+        sao = bd.get_title_by_tmdb_id("tv/44832")
+        if sao:
+            assert len(sao) > 3


### PR DESCRIPTION
<!-- 请务必在创建 PR 前，在右侧 Labels 选项中加上其中一个 label：[feature]、[bug]、[perf]、[docs]、[chore]。
     以便 Actions 自动生成 Releases 时对 PR 进行归类。 -->

## 📝 PR 描述

多季场景永远是检验 bug 的唯一标准（

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
修复 Trakt 同步在 TMDB 多季度映射时的三个问题：

1. **季度感知查询**：`get_title_by_tmdb_id` 新增 `season` 参数，Trakt 同步时传递 `episode.season`，
   优先查 `{id}/season/{season}`，未命中回退基 key。

2. **多条目择优**：同 TMDB 多条目标题冲突时检测全部标题（日文原名 + 中文简繁体翻译）的季度标记，
   优先选无标记的条目，其次选最早日期的条目。

3. **日期同步**：新增 `get_begin_by_tmdb_id` 获取对应条目的开始日期，
   用于 Trakt 转换时的 `release_date` 降级，避免多季节目误用 S1 年份。

_SEASON_SUFFIX 覆盖第X季/部/期（简繁体中文数字）、Season/S/Part/Act/Phase X、
Unicode 罗马数字、クール。

### 相关 Issue


## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `uv run ruff check .` 并修复所有问题
- [x] 已运行 `uv run ruff format .` 格式化代码
- [ ] 无页面模板变更

### 测试
- [x] 已运行 `uv run pytest tests/ --cov=app --cov-report=term` 且全部通过（2267）
- [x] 新增 7 个测试：TMDB 映射选择、季度查询、日期回退
- [x] 现有功能未受影响

## 🔍 额外说明

### 实际案例：無職転生 S3

用户观看 `無職転生Ⅲ` S03E02 时，Trakt 的 `show.tmdb=94664` 对应 bangumi_data 中五条条目：

| `#` | TMDB key | 标题 | begin |
|---|------|------|------|
| `#1` | `tv/94664` | 無職転生～異世界行ったら本気だす～ | 2021-01 |
| `#2` | `tv/94664` | 無職転生～...～(第2クール) | 2021-10 |
| `#3` | `tv/94664/season/2` | 無職転生Ⅱ ～...～ | 2023-07 |
| `#4` | `tv/94664/season/2` | 無職転生Ⅱ ～...～(第2クール) | 2024-04 |
| `#5` | `tv/94664/season/3` | 無職転生Ⅲ ～...～ | 2026-07 |

`#1`/`#2` 共享基 key `tv/94664`，`#3`/`#4` 共享 key `tv/94664/season/2`。

**修复前**：`_cache_tmdb_mapping[id] = title` 简单赋值，同 key 后写覆盖前写。`tv/94664` 实际被 `#2`（含 "(第2クール)" 后缀）覆盖。Trakt 同步 S3 时 `get_title_by_tmdb_id("tv/94664")` → `無職転生～...～(第2クール)` → 标题不含 "Ⅲ" 且日期为 S1 年份 → bgm 搜索失败 ❌

**修复后**：`get_title_by_tmdb_id("tv/94664", season=3)` → 直接查键 `tv/94664/season/3` → 精确命中 `#5` → 無職転生Ⅲ（含 "Ⅲ"）→ bgm 标题索引直接命中 `subject/501963` ✅

同时 `release_date` 从错误的第一季 `2021-01-01`（`show.year` 回退）变为 bangumi_data 的 `2026-07-04`，bgm API 日期搜索范围修正。

### 修改范围（5 文件）

| 文件 | 改动 |
|------|------|
| `app/utils/bangumi_data/index.py` | `get_title_by_tmdb_id` 增加 `season` 参数；`_build_tmdb_mapping` 收集全标题做季标检测；新增 `get_begin_by_tmdb_id` |
| `app/utils/bangumi_data/__init__.py` | 新增 `_cache_tmdb_begin` 字典 |
| `app/services/trakt/sync_service.py` | pre-fetch + 转换传递 `episode.season`；release_date 降级链加入 bangumi begin |
| `tests/utils/test_bangumi_data.py` | TMDB 映射多条目选择与季度查询测试（5 个） |
| `tests/services/test_trakt_sync_service.py` | release_date 降级链日期回退测试（2 个） |
