### PR TITLE
fix: 修复重试时因信息缺失导致匹配错误的问题，完善输入持久化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ cython_debug/
 /docker-compose.dev.yml
 .idea/
 config_backups/
+data/
 sync_records.db
 sync_records.db-wal
 sync_records.db-shm

--- a/app/api/sync.py
+++ b/app/api/sync.py
@@ -557,20 +557,126 @@ async def retry_sync_record(
         raise HTTPException(status_code=500, detail=f"重试失败: {str(e)}")
 
 
+def _parse_match_trace(record: dict) -> Optional[dict[str, Any]]:
+    """解析 sync_records.match_trace（JSON 字符串或 dict）。"""
+    raw = record.get("match_trace")
+    if not raw:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _receive_step_from_trace(
+    trace: Optional[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """从 match_trace 中取 receive 步骤。"""
+    if not trace:
+        return None
+    for step in trace.get("steps") or []:
+        if isinstance(step, dict) and step.get("stage") == "receive":
+            return step
+    return None
+
+
+def _pick_trace_value(
+    trace: Optional[dict[str, Any]],
+    receive_step: Optional[dict[str, Any]],
+    trace_key: str,
+    payload_key: str,
+    fallback: Any = None,
+) -> Any:
+    """优先 trace 顶层 request_*，再 receive processed_payload，最后 fallback。"""
+    if trace:
+        value = trace.get(trace_key)
+        if value not in (None, ""):
+            return value
+    if receive_step:
+        payload = receive_step.get("processed_payload") or {}
+        if isinstance(payload, dict):
+            value = payload.get(payload_key)
+            if value not in (None, ""):
+                return value
+    return fallback
+
+
+def _original_fields_from_record(record: dict) -> dict[str, Any]:
+    """从 match_trace 还原原始请求字段，无 trace 时回退 sync_records 列。"""
+    trace = _parse_match_trace(record)
+    receive_step = _receive_step_from_trace(trace)
+
+    title = _pick_trace_value(
+        trace, receive_step, "request_title", "title", record.get("title", "")
+    )
+    ori_title = _pick_trace_value(
+        trace, receive_step, "request_ori_title", "ori_title", record.get("ori_title")
+    )
+    season = _pick_trace_value(
+        trace, receive_step, "request_season", "season", record.get("season", 1)
+    )
+    episode = _pick_trace_value(
+        trace, receive_step, "request_episode", "episode", record.get("episode", 1)
+    )
+    media_type = _pick_trace_value(
+        trace,
+        receive_step,
+        "request_media_type",
+        "media_type",
+        record.get("media_type") or "episode",
+    )
+    release_date = _pick_trace_value(
+        trace, receive_step, "request_release_date", "release_date", ""
+    )
+    user_name = _pick_trace_value(
+        trace,
+        receive_step,
+        "request_user_name",
+        "user_name",
+        record.get("user_name", ""),
+    )
+    sync_action = _pick_trace_value(
+        trace, receive_step, "request_sync_action", "sync_action", None
+    )
+    raw_payload = None
+    if receive_step:
+        raw_payload = receive_step.get("raw_payload")
+
+    return {
+        "title": title or "",
+        "ori_title": ori_title or None,
+        "season": int(season) if season is not None else 1,
+        "episode": int(episode) if episode is not None else 1,
+        "media_type": (media_type or "episode").lower(),
+        "release_date": release_date or "",
+        "user_name": user_name or "",
+        "sync_action": sync_action or None,
+        "raw_payload": raw_payload,
+    }
+
+
 def _build_retry_item(record: dict, retry_source: str) -> CustomItem:
-    """从同步记录构建重试用的 CustomItem"""
-    retry_media = (record.get("media_type") or "episode").lower()
+    """从同步记录构建重试用的 CustomItem（优先 match_trace 原始请求）。"""
+    orig = _original_fields_from_record(record)
+    retry_media = orig["media_type"]
     if retry_media not in ("episode", "movie", "ova", "oad", "real_action"):
         retry_media = "episode"
     return CustomItem(
         media_type=retry_media,
-        title=record.get("title", ""),
-        ori_title=record.get("ori_title") or None,
-        season=record.get("season", 1),
-        episode=record.get("episode", 1),
-        release_date="",
-        user_name=record.get("user_name", ""),
+        title=orig["title"],
+        ori_title=orig["ori_title"],
+        season=orig["season"],
+        episode=orig["episode"],
+        release_date=orig["release_date"],
+        user_name=orig["user_name"],
         source=retry_source,
+        sync_action=orig["sync_action"],
+        raw_payload=orig["raw_payload"],
     )
 
 

--- a/app/services/sync_service/__init__.py
+++ b/app/services/sync_service/__init__.py
@@ -473,6 +473,7 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin, TitleNormalizeM
             request_episode=item.episode,
             request_media_type=item.media_type,
             request_release_date=item.release_date or "",
+            request_sync_action=(item.sync_action or "").strip(),
             request_user_name=item.user_name,
             request_platform_hint=item.source or actual_source,
         )
@@ -492,7 +493,9 @@ class SyncService(TaskManagerMixin, RetryMixin, SeasonInfoMixin, TitleNormalizeM
             "episode": item.episode,
             "media_type": item.media_type,
             "release_date": item.release_date,
+            "sync_action": item.sync_action or "",
         }
+        receive_step.raw_payload = item.raw_payload
 
         # 查找番剧ID及其是否为特定季度ID的标记
         subject_id, is_season_matched_id, subject_find_error = self._find_subject_id(

--- a/app/services/sync_service/match_trace.py
+++ b/app/services/sync_service/match_trace.py
@@ -79,6 +79,7 @@ class MatchTrace:
     request_episode: int = 0
     request_media_type: str = ""
     request_release_date: str = ""
+    request_sync_action: str = ""
     request_user_name: str = ""
     request_platform_hint: str = ""
     normalized_title: str = ""
@@ -133,6 +134,7 @@ class MatchTrace:
             "request_episode": self.request_episode,
             "request_media_type": self.request_media_type,
             "request_release_date": self.request_release_date,
+            "request_sync_action": self.request_sync_action,
             "request_user_name": self.request_user_name,
             "request_platform_hint": self.request_platform_hint,
             "normalized_title": self.normalized_title,

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -407,7 +407,7 @@ function renderReceiveInputTable(step) {
     if (!step || step.stage !== 'receive' || !step.processed_payload) {
         return '';
     }
-    return renderPayloadTable(step.processed_payload, {
+    let html = renderPayloadTable(step.processed_payload, {
         source: '来源',
         user_name: '用户',
         title: '标题',
@@ -416,7 +416,15 @@ function renderReceiveInputTable(step) {
         episode: '集',
         media_type: '媒体类型',
         release_date: '发布日期',
+        sync_action: '同步动作',
     });
+    if (step.raw_payload && typeof step.raw_payload === 'object' && Object.keys(step.raw_payload).length > 0) {
+        html += '<div class="mt-2">'
+            + '<div class="small text-muted mb-1">驱动原始数据</div>'
+            + `<pre class="record-detail-raw-payload mb-0">${escapeHtml(JSON.stringify(step.raw_payload, null, 2))}</pre>`
+            + '</div>';
+    }
+    return html;
 }
 
 // result step 结果表格：状态/集数/链接/消息

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -1001,6 +1001,62 @@ async def test_retry_sync_record_invalid_media_type(
         assert response.status_code == 200
 
 
+@pytest.mark.asyncio
+async def test_retry_sync_record_restores_mark_watching_from_trace(
+    app_with_auth, mock_sync_service, mock_database_manager
+):
+    """重试应从 match_trace 恢复 sync_action=mark_watching"""
+    import json
+
+    trace = {
+        "request_title": "Movie Test",
+        "request_season": 1,
+        "request_episode": 1,
+        "request_media_type": "movie",
+        "request_release_date": "2024-01-15",
+        "request_sync_action": "mark_watching",
+        "request_user_name": "user",
+        "steps": [
+            {
+                "stage": "receive",
+                "processed_payload": {
+                    "sync_action": "mark_watching",
+                    "release_date": "2024-01-15",
+                },
+                "raw_payload": {"event": "media.play"},
+            }
+        ],
+    }
+    mock_database_manager.get_sync_record_by_id.return_value = {
+        "id": 1,
+        "status": "error",
+        "title": "Movie Test",
+        "season": 1,
+        "episode": 1,
+        "source": "plex",
+        "user_name": "user",
+        "media_type": "movie",
+        "match_trace": json.dumps(trace),
+    }
+
+    mock_result = MagicMock()
+    mock_result.status = "success"
+    mock_result.model_dump.return_value = {"status": "success"}
+    mock_sync_service.sync_custom_item.return_value = mock_result
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.post("/api/records/1/retry")
+        assert response.status_code == 200
+
+    retry_item = mock_sync_service.sync_custom_item.call_args[0][0]
+    assert retry_item.sync_action == "mark_watching"
+    assert retry_item.release_date == "2024-01-15"
+    assert retry_item.raw_payload == {"event": "media.play"}
+    assert retry_item.source == "retry-plex"
+
+
 # ========== 测试同步特殊路径 ==========
 
 

--- a/tests/api/test_sync_main_flow.py
+++ b/tests/api/test_sync_main_flow.py
@@ -343,6 +343,77 @@ def test_build_retry_item_preserves_all_media_types():
     assert item.media_type == "episode"
 
 
+def test_build_retry_item_restores_fields_from_match_trace():
+    """_build_retry_item 优先从 match_trace 还原原始请求（含日期与 sync_action）"""
+    import json
+
+    from app.api.sync import _build_retry_item
+
+    trace = {
+        "request_title": "Trace Title",
+        "request_ori_title": "Ori",
+        "request_season": 2,
+        "request_episode": 5,
+        "request_media_type": "episode",
+        "request_release_date": "2024-03-01",
+        "request_sync_action": "mark_watching",
+        "request_user_name": "trace_user",
+        "steps": [
+            {
+                "stage": "receive",
+                "processed_payload": {
+                    "title": "Trace Title",
+                    "release_date": "2024-03-01",
+                    "sync_action": "mark_watching",
+                },
+                "raw_payload": {"event": "play"},
+            }
+        ],
+    }
+    record = {
+        "title": "Column Title",
+        "ori_title": "Col Ori",
+        "season": 1,
+        "episode": 1,
+        "user_name": "col_user",
+        "media_type": "movie",
+        "match_trace": json.dumps(trace),
+    }
+    item = _build_retry_item(record, "retry-plex")
+    assert item.title == "Trace Title"
+    assert item.ori_title == "Ori"
+    assert item.season == 2
+    assert item.episode == 5
+    assert item.media_type == "episode"
+    assert item.release_date == "2024-03-01"
+    assert item.sync_action == "mark_watching"
+    assert item.user_name == "trace_user"
+    assert item.source == "retry-plex"
+    assert item.raw_payload == {"event": "play"}
+
+
+def test_build_retry_item_falls_back_to_record_columns_without_trace():
+    """无 match_trace 时回退 sync_records 列"""
+    from app.api.sync import _build_retry_item
+
+    record = {
+        "title": "Column Title",
+        "ori_title": "Col Ori",
+        "season": 3,
+        "episode": 7,
+        "user_name": "col_user",
+        "media_type": "ova",
+    }
+    item = _build_retry_item(record, "retry-emby")
+    assert item.title == "Column Title"
+    assert item.ori_title == "Col Ori"
+    assert item.season == 3
+    assert item.episode == 7
+    assert item.release_date == ""
+    assert item.sync_action is None
+    assert item.raw_payload is None
+
+
 @pytest.mark.asyncio
 async def test_get_sync_records_db_error(app_root_and_api):
     with patch(

--- a/tests/services/test_sync_pipeline.py
+++ b/tests/services/test_sync_pipeline.py
@@ -132,6 +132,53 @@ def test_pipeline_receive_step_carries_processed_payload(mock_config, mock_datab
     assert receive_step["processed_payload"]["episode"] == 270
 
 
+def test_pipeline_receive_step_carries_raw_payload_and_sync_action(
+    mock_config, mock_database
+):
+    """receive step 应透传 raw_payload 与 sync_action"""
+    service = SyncService()
+
+    item = CustomItem(
+        user_name="testuser",
+        title="剧场版测试",
+        ori_title=None,
+        season=1,
+        episode=1,
+        media_type="movie",
+        release_date="2024-06-01",
+        source="plex",
+        sync_action="mark_watching",
+        raw_payload={"event": "media.play", "metadata": {"title": "剧场版测试"}},
+    )
+
+    with _make_mock_bangumi_api():
+        with patch.object(
+            service,
+            "_get_bangumi_config_for_user",
+            return_value={
+                "username": "testuser",
+                "access_token": "tok",
+                "private": True,
+            },
+        ):
+            result = service.sync_custom_item(item, "custom")
+
+    assert result.status in ("success", "ignored")
+
+    call_args = mock_database.log_sync_record.call_args
+    trace_data = call_args.kwargs.get("match_trace") or {}
+    receive_step = trace_data.get("steps", [])[0]
+    assert receive_step["stage"] == "receive"
+    assert receive_step["processed_payload"]["sync_action"] == "mark_watching"
+    assert receive_step["processed_payload"]["release_date"] == "2024-06-01"
+    assert receive_step["raw_payload"] == {
+        "event": "media.play",
+        "metadata": {"title": "剧场版测试"},
+    }
+    assert trace_data["request_sync_action"] == "mark_watching"
+    assert trace_data["request_release_date"] == "2024-06-01"
+
+
 def test_pipeline_result_step_carries_episode_and_links(mock_config, mock_database):
     """result step 应携带集数 + subject/ep 链接（processed_payload）"""
     service = SyncService()


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
#### 1. 同步时持久化完整输入

- [`app/services/sync_service/match_trace.py`](app/services/sync_service/match_trace.py)：新增 `request_sync_action` 字段
- [`app/services/sync_service/__init__.py`](app/services/sync_service/__init__.py)：receive 步骤写入 `sync_action`、`raw_payload`

#### 2. 重试完整还原

- [`app/api/sync.py`](app/api/sync.py)：新增 `_parse_match_trace`、`_receive_step_from_trace`、`_pick_trace_value`、`_original_fields_from_record`
- `_build_retry_item` 从 `match_trace` 还原全部字段（含 `release_date`、`sync_action`、`raw_payload`），无 trace 时回退表列

#### 3. 前端展示

- [`static/js/app.js`](static/js/app.js)：receive 步骤展示 `sync_action` 与驱动原始数据 JSON


### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
