### PR TITLE
【docs】更新 trakt 文档：通过 SSH 端口转发以应对 Trakt 严格校验回调地址

### DIFF
--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -65,13 +65,13 @@ Redirect URI must use HTTPS (HTTP allowed only for loopback hosts)
 
 这是因为 Trakt 要求回调地址必须是 HTTPS，仅对 loopback 地址（`127.0.0.1` / `localhost`）允许 HTTP。可以使用 SSH 端口转发，让 Trakt 以为回调发生在本地，完成一次性授权（授权后即可长期使用，无需保持转发）：
 
-1. **修改回调地址**：在 [Trakt 开发者后台](https://app.trakt.tv/settings/apps/api?mode=media) 和 Bangumi-syncer 的 Trakt 配置页面中，将回调地址均填为 `http://127.0.0.1:8003/api/trakt/auth/callback`
-2. **建立 SSH 转发**：在电脑终端中执行以下命令（将 `用户名` 和 `NAS的局域网IP` 替换为实际值，`8003` 替换为 Bangumi-syncer 实际监听的端口）：
+1. **修改回调地址**：在 [Trakt 开发者后台](https://app.trakt.tv/settings/apps/api?mode=media) 和 Bangumi-syncer 的 Trakt 配置页面中，将回调地址均填为 `http://127.0.0.1:8000/api/trakt/auth/callback`
+2. **建立 SSH 转发**：在电脑终端中执行以下命令（将 `用户名` 和 `NAS的局域网IP` 替换为实际值，`8000` 替换为 Bangumi-syncer 实际监听的端口）：
    ```bash
-   ssh -L 8003:127.0.0.1:8003 用户名@NAS的局域网IP
+   ssh -L 8000:127.0.0.1:8000 用户名@NAS的局域网IP
    ```
    保持该终端窗口不要关闭
-3. **完成授权**：在电脑浏览器中打开 Bangumi-syncer 的 Trakt 配置页面，点击授权按钮，跳转至 Trakt 同意授权后，Trakt 会将浏览器重定向到 `http://127.0.0.1:8003/api/trakt/auth/callback?...`，通过 SSH 转发到达 NAS，授权成功
+3. **完成授权**：在电脑浏览器中打开 Bangumi-syncer 的 Trakt 配置页面，点击授权按钮，跳转至 Trakt 同意授权后，Trakt 会将浏览器重定向到 `http://127.0.0.1:8000/api/trakt/auth/callback?...`，通过 SSH 转发到达 NAS，授权成功
 4. **关闭终端**：授权完成后关闭终端即可，后续应用使用已获取的 Token 正常运行，无需保持转发
 
 ## 注意事项

--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -57,7 +57,7 @@ order: 15
 
 ## Trakt 严格校验回调地址的解决方案
 
-如果你的 NAS / Docker 部署环境不具备公网域名和 HTTPS，在 Trakt 授权时会遇到以下报错：
+Trakt 要求回调地址必须是 HTTPS，仅对 loopback 地址（`127.0.0.1` / `localhost`）允许 HTTP。如果你的部署地址不是 localhost，在授权时会遇到以下报错：
 
 ```
 Redirect URI must use HTTPS (HTTP allowed only for loopback hosts)

--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -55,6 +55,25 @@ order: 15
 - 可在「同步控制」区域查看下次同步时间
 - 支持随时手动触发同步或全量同步
 
+## Trakt 严格校验回调地址的解决方案
+
+如果你的 NAS / Docker 部署环境不具备公网域名和 HTTPS，在 Trakt 授权时会遇到以下报错：
+
+```
+Redirect URI must use HTTPS (HTTP allowed only for loopback hosts)
+```
+
+这是因为 Trakt 要求回调地址必须是 HTTPS，仅对 loopback 地址（`127.0.0.1` / `localhost`）允许 HTTP。可以使用 SSH 端口转发，让 Trakt 以为回调发生在本地，完成一次性授权（授权后即可长期使用，无需保持转发）：
+
+1. **修改回调地址**：在 [Trakt 开发者后台](https://app.trakt.tv/settings/apps/api?mode=media) 和 Bangumi-syncer 的 Trakt 配置页面中，将回调地址均填为 `http://127.0.0.1:8003/api/trakt/auth/callback`
+2. **建立 SSH 转发**：在电脑终端中执行以下命令（将 `用户名` 和 `NAS的局域网IP` 替换为实际值，`8003` 替换为 Bangumi-syncer 实际监听的端口）：
+   ```bash
+   ssh -L 8003:127.0.0.1:8003 用户名@NAS的局域网IP
+   ```
+   保持该终端窗口不要关闭
+3. **完成授权**：在电脑浏览器中打开 Bangumi-syncer 的 Trakt 配置页面，点击授权按钮，跳转至 Trakt 同意授权后，Trakt 会将浏览器重定向到 `http://127.0.0.1:8003/api/trakt/auth/callback?...`，通过 SSH 转发到达 NAS，授权成功
+4. **关闭终端**：授权完成后关闭终端即可，后续应用使用已获取的 Token 正常运行，无需保持转发
+
 ## 注意事项
 
 - 首次全量同步可能需要较长时间（取决于历史记录数量）


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->

📚 文档更新 (docs)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
增加 trakt 授权时，非回环地址作为回调地址时报错`Redirect URI must use HTTPS (HTTP allowed only for loopback hosts)`，可以使用 SSH 端口转发规避

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
nas 上docker 部署时，现在使用local域名或者非回环地址作为回调时，会导致回调失败，在文档中提供一种规避手段。