### PR TITLE
fix: 修复 import_local 路径穿越漏洞 (CWE-22)

### DIFF
--- a/app/api/bangumi_archive.py
+++ b/app/api/bangumi_archive.py
@@ -164,10 +164,12 @@ async def import_local_zip(
             task_id=bangumi_archive.current_task_id,
         )
 
-    # 校验文件名
-    filename = file.filename or "upload.zip"
+    # 校验文件名（剥离路径前缀，防止 CWE-22 路径穿越）
+    filename = Path(file.filename or "upload.zip").name
     if not filename.lower().endswith(".zip"):
         raise HTTPException(status_code=400, detail="仅支持 .zip 文件")
+    if not filename:
+        raise HTTPException(status_code=400, detail="文件名无效")
 
     # 保存到临时文件
     tmp_dir = Path(tempfile.mkdtemp(prefix="bangumi_archive_upload_"))


### PR DESCRIPTION
file.filename 来自 multipart Content-Disposition，Starlette 不做清洗，直接 Path 拼接可被 ../ 穿越到 tmp_dir 之外，导致任意 .zip 文件被覆盖或删除（_cleanup_tmp 在 finally 中 unlink）。

用 Path(file.filename).name 剥离路径前缀，并补充文件名空值校验。

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->


### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
 Closes #213 

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
