### PR TITLE
feat(trakt): 支持 OAuth2 Bearer 凭证模式与邮箱一键登录，规避 Trakt 应用创建/授权限制

### DIFF
--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -222,9 +222,6 @@ async def update_trakt_config(
 
         config = trakt_auth_service.get_user_trakt_config(user_id)
 
-        has_access = bool(
-            update_request.access_token and update_request.access_token.strip()
-        )
         has_refresh = bool(
             update_request.refresh_token and update_request.refresh_token.strip()
         )
@@ -235,11 +232,7 @@ async def update_trakt_config(
         # 必须在调用 validate_and_save_bearer 之前执行，避免「已把 Bearer 凭证
         # 落库却返回 400」的副作用。
         # 1) 提供 Bearer 凭证却要求其他模式：矛盾，直接拒绝
-        if (
-            (has_refresh or has_access)
-            and target_mode is not None
-            and target_mode != "bearer"
-        ):
+        if has_refresh and target_mode is not None and target_mode != "bearer":
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -272,8 +265,8 @@ async def update_trakt_config(
 
         # ---- Bearer 凭证 ----
         # 提供 refresh_token 则立即验证并刷新（旋转式），有效才落库。
-        # 实际只使用并验证 refresh_token（刷新成功即证明凭证对有效，且会换新
-        # access/refresh）；access_token 为可选展示字段，不被使用。
+        # 验证/续期只依赖 refresh_token（刷新成功即证明凭证对有效，且会换新
+        # access/refresh），无需也不接受 access_token。
         if has_refresh:
             result = await validate_and_save_bearer(
                 user_id, update_request.refresh_token.strip()
@@ -285,12 +278,6 @@ async def update_trakt_config(
                 )
             # 验证已落库（auth_type=bearer + 新 token），重新读取最新配置
             config = trakt_auth_service.get_user_trakt_config(user_id)
-        elif has_access:
-            # 只给了 access_token：无法校验/续期，明确提示需要 refresh_token
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Bearer 凭证校验需要 refresh_token（access_token 可选）",
-            )
 
         if not config:
             # 无既有配置且未提供 Bearer 凭证：视为未授权，保持 404

--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -22,6 +22,10 @@ from ..models.trakt import (
     TraktCallbackRequest,
     TraktConfigResponse,
     TraktConfigUpdateRequest,
+    TraktEmailLoginCompleteRequest,
+    TraktEmailLoginCompleteResponse,
+    TraktEmailLoginStartRequest,
+    TraktEmailLoginStartResponse,
     TraktManualSyncRequest,
     TraktManualSyncResponse,
     TraktSyncStatusResponse,
@@ -29,6 +33,7 @@ from ..models.trakt import (
 )
 from ..services.sync_service import sync_service
 from ..services.trakt.auth import trakt_auth_service
+from ..services.trakt.email_login import complete_email_login, start_email_login
 from ..services.trakt.scheduler import trakt_scheduler
 from ..services.trakt.sync_service import trakt_sync_service
 from ..services.trakt.token_refresher import validate_and_save_bearer
@@ -364,6 +369,46 @@ async def update_trakt_api_config(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"更新 API 配置失败: {str(e)}",
         )
+
+
+@router.post("/email-login/start", response_model=TraktEmailLoginStartResponse)
+async def trakt_email_login_start(
+    request: TraktEmailLoginStartRequest,
+    current_user: dict = Depends(deps.get_current_user_flexible),
+) -> TraktEmailLoginStartResponse:
+    """邮箱登录：发送验证码到指定邮箱"""
+    user_id = current_user.get("username", "default_user")
+    result = await start_email_login(user_id, request.email)
+    if not result["success"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=result["message"],
+        )
+    return TraktEmailLoginStartResponse(
+        success=True,
+        message=result["message"],
+        retry_after=result.get("retry_after"),
+    )
+
+
+@router.post("/email-login/complete", response_model=TraktEmailLoginCompleteResponse)
+async def trakt_email_login_complete(
+    request: TraktEmailLoginCompleteRequest,
+    current_user: dict = Depends(deps.get_current_user_flexible),
+) -> TraktEmailLoginCompleteResponse:
+    """邮箱登录：提交验证码，完成后自动获取并存储 Bearer 凭证"""
+    user_id = current_user.get("username", "default_user")
+    result = await complete_email_login(user_id, request.otp)
+    if not result["success"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=result["message"],
+        )
+    return TraktEmailLoginCompleteResponse(
+        success=True,
+        message=result["message"],
+        expires_at=result.get("expires_at"),
+    )
 
 
 @router.get("/sync/status", response_model=TraktSyncStatusResponse)

--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -228,18 +228,55 @@ async def update_trakt_config(
         has_refresh = bool(
             update_request.refresh_token and update_request.refresh_token.strip()
         )
+        auth_type = update_request.auth_type
+        target_mode = normalize_auth_type(auth_type) if auth_type is not None else None
 
-        # Bearer 凭证：非空则立即验证并刷新（旋转式），有效才落库
-        if has_access or has_refresh:
-            if not (has_access and has_refresh):
+        # ---- 凭证模式切换前置校验 ----
+        # 必须在调用 validate_and_save_bearer 之前执行，避免「已把 Bearer 凭证
+        # 落库却返回 400」的副作用。
+        # 1) 提供 Bearer 凭证却要求其他模式：矛盾，直接拒绝
+        if (
+            (has_refresh or has_access)
+            and target_mode is not None
+            and target_mode != "bearer"
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "已提供 Bearer 凭证会保存为 Bearer 模式；如需使用 API 应用模式，"
+                    "请点击「授权 Trakt」完成授权（无需填写 token）"
+                ),
+            )
+        # 2) 切换模式但未提供对应凭证：拒绝（oauth/bearer 数据域不同，不能只改标记）
+        if (
+            target_mode is not None
+            and config is not None
+            and target_mode != config.auth_type
+        ):
+            if target_mode == "oauth":
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Bearer 凭证需同时提供 access_token 与 refresh_token",
+                    detail=(
+                        "切换至 API 应用模式需重新授权，请点击「授权 Trakt」完成授权"
+                    ),
                 )
+            # target_mode == bearer
+            if not has_refresh:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "切换至 Bearer 模式需提供 refresh_token"
+                        "（或使用「通过邮箱登录」）"
+                    ),
+                )
+
+        # ---- Bearer 凭证 ----
+        # 提供 refresh_token 则立即验证并刷新（旋转式），有效才落库。
+        # 实际只使用并验证 refresh_token（刷新成功即证明凭证对有效，且会换新
+        # access/refresh）；access_token 为可选展示字段，不被使用。
+        if has_refresh:
             result = await validate_and_save_bearer(
-                user_id,
-                update_request.access_token.strip(),
-                update_request.refresh_token.strip(),
+                user_id, update_request.refresh_token.strip()
             )
             if not result["success"]:
                 raise HTTPException(
@@ -248,6 +285,12 @@ async def update_trakt_config(
                 )
             # 验证已落库（auth_type=bearer + 新 token），重新读取最新配置
             config = trakt_auth_service.get_user_trakt_config(user_id)
+        elif has_access:
+            # 只给了 access_token：无法校验/续期，明确提示需要 refresh_token
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Bearer 凭证校验需要 refresh_token（access_token 可选）",
+            )
 
         if not config:
             # 无既有配置且未提供 Bearer 凭证：视为未授权，保持 404
@@ -256,33 +299,37 @@ async def update_trakt_config(
                 detail="Trakt 配置未找到，请先完成授权或填写 Bearer 凭证",
             )
 
+        # ---- 更新非凭证字段 ----
         enable = update_request.enabled
         sync_interval = update_request.sync_interval
         sync_filter_enabled = update_request.sync_filter_enabled
-        auth_type = update_request.auth_type
-
-        # 更新配置
+        # 只写 enabled/sync_interval/sync_filter_enabled/auth_type 这些列，
+        # 不触碰 access_token/refresh_token/expires_at：避免用本请求早先读到的
+        # 旧 token 覆盖并发刷新（心跳/定时同步/手动同步）旋转后的新 token。
+        updates: dict = {}
         if enable is not None:
             config.enabled = enable
+            updates["enabled"] = enable
 
         if sync_interval is not None:
             config.sync_interval = sync_interval
+            updates["sync_interval"] = sync_interval
 
         if sync_filter_enabled is not None:
             config.sync_filter_enabled = sync_filter_enabled
+            updates["sync_filter_enabled"] = sync_filter_enabled
 
-        # 凭证模式：切换只改标记（另一模式凭证共用字段，切换时互相覆盖）
         if auth_type is not None:
-            config.auth_type = normalize_auth_type(auth_type)
+            config.auth_type = target_mode
+            updates["auth_type"] = target_mode
 
-        # 保存到数据库
-        success = trakt_auth_service.save_config(config)
-
-        if not success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="保存配置失败",
-            )
+        if updates:
+            success = trakt_auth_service.update_config_fields(user_id, updates)
+            if not success:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="保存配置失败",
+                )
 
         if enable is not None and sync_interval is not None:
             # sync_interval 可能被更新了, 需要先移除旧的作业再添加新的作业
@@ -379,6 +426,15 @@ async def trakt_email_login_start(
     """邮箱登录：发送验证码到指定邮箱"""
     user_id = current_user.get("username", "default_user")
     result = await start_email_login(user_id, request.email)
+    if result.get("rate_limited"):
+        # 冷却限流：429 + retry_after，前端据此启动倒计时而非卡死按钮
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "message": result["message"],
+                "retry_after": result.get("retry_after"),
+            },
+        )
     if not result["success"]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/trakt.py
+++ b/app/api/trakt.py
@@ -13,6 +13,9 @@ from ..core.config import config_manager
 from ..core.logging import logger
 from ..core.public_url import redirect_public
 from ..models.trakt import (
+    TOKEN_STATUS_ACTIVE,
+    TOKEN_STATUS_EXPIRED,
+    TOKEN_STATUS_NOT_CONFIGURED,
     TraktApiConfigUpdateRequest,
     TraktAuthRequest,
     TraktAuthResponse,
@@ -22,11 +25,13 @@ from ..models.trakt import (
     TraktManualSyncRequest,
     TraktManualSyncResponse,
     TraktSyncStatusResponse,
+    normalize_auth_type,
 )
 from ..services.sync_service import sync_service
 from ..services.trakt.auth import trakt_auth_service
 from ..services.trakt.scheduler import trakt_scheduler
 from ..services.trakt.sync_service import trakt_sync_service
+from ..services.trakt.token_refresher import validate_and_save_bearer
 
 router = APIRouter(prefix="/api/trakt", tags=["trakt"])
 
@@ -160,10 +165,20 @@ async def get_trakt_config(
                 redirect_uri=trakt_api_config.get(
                     "redirect_uri", "http://localhost:8000/api/trakt/auth/callback"
                 ),
+                auth_type="oauth",
+                token_configured=False,
+                token_status=TOKEN_STATUS_NOT_CONFIGURED,
             )
 
-        # 检查令牌是否有效
-        is_connected = bool(config.access_token) and not config.is_token_expired()
+        # 连接状态与凭证状态：两种模式均基于 access_token 与 expires_at 计算
+        token_configured = bool(config.access_token)
+        if token_configured and not config.is_token_expired():
+            token_status = TOKEN_STATUS_ACTIVE
+        elif token_configured:
+            token_status = TOKEN_STATUS_EXPIRED
+        else:
+            token_status = TOKEN_STATUS_NOT_CONFIGURED
+        is_connected = token_status == TOKEN_STATUS_ACTIVE
 
         return TraktConfigResponse(
             user_id=config.user_id,
@@ -178,6 +193,9 @@ async def get_trakt_config(
             redirect_uri=trakt_api_config.get(
                 "redirect_uri", "http://localhost:8000/api/trakt/auth/callback"
             ),
+            auth_type=config.auth_type,
+            token_configured=token_configured,
+            token_status=token_status,
         )
 
     except Exception as e:
@@ -199,15 +217,44 @@ async def update_trakt_config(
 
         config = trakt_auth_service.get_user_trakt_config(user_id)
 
+        has_access = bool(
+            update_request.access_token and update_request.access_token.strip()
+        )
+        has_refresh = bool(
+            update_request.refresh_token and update_request.refresh_token.strip()
+        )
+
+        # Bearer 凭证：非空则立即验证并刷新（旋转式），有效才落库
+        if has_access or has_refresh:
+            if not (has_access and has_refresh):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Bearer 凭证需同时提供 access_token 与 refresh_token",
+                )
+            result = await validate_and_save_bearer(
+                user_id,
+                update_request.access_token.strip(),
+                update_request.refresh_token.strip(),
+            )
+            if not result["success"]:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=result["message"],
+                )
+            # 验证已落库（auth_type=bearer + 新 token），重新读取最新配置
+            config = trakt_auth_service.get_user_trakt_config(user_id)
+
         if not config:
+            # 无既有配置且未提供 Bearer 凭证：视为未授权，保持 404
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Trakt 配置未找到，请先完成授权",
+                detail="Trakt 配置未找到，请先完成授权或填写 Bearer 凭证",
             )
 
         enable = update_request.enabled
         sync_interval = update_request.sync_interval
         sync_filter_enabled = update_request.sync_filter_enabled
+        auth_type = update_request.auth_type
 
         # 更新配置
         if enable is not None:
@@ -218,6 +265,10 @@ async def update_trakt_config(
 
         if sync_filter_enabled is not None:
             config.sync_filter_enabled = sync_filter_enabled
+
+        # 凭证模式：切换只改标记（另一模式凭证共用字段，切换时互相覆盖）
+        if auth_type is not None:
+            config.auth_type = normalize_auth_type(auth_type)
 
         # 保存到数据库
         success = trakt_auth_service.save_config(config)
@@ -234,8 +285,15 @@ async def update_trakt_config(
             if enable:
                 trakt_scheduler.add_user_job(user_id, sync_interval)
 
-        # 返回更新后的配置
-        is_connected = bool(config.access_token) and not config.is_token_expired()
+        # 返回更新后的配置（凭证状态与 GET 一致，token 不回显）
+        token_configured = bool(config.access_token)
+        if token_configured and not config.is_token_expired():
+            token_status = TOKEN_STATUS_ACTIVE
+        elif token_configured:
+            token_status = TOKEN_STATUS_EXPIRED
+        else:
+            token_status = TOKEN_STATUS_NOT_CONFIGURED
+        is_connected = token_status == TOKEN_STATUS_ACTIVE
         # 从配置文件获取 API 配置
         trakt_api_config = config_manager.get_trakt_config()
 
@@ -252,6 +310,9 @@ async def update_trakt_config(
             redirect_uri=trakt_api_config.get(
                 "redirect_uri", "http://localhost:8000/api/trakt/auth/callback"
             ),
+            auth_type=config.auth_type,
+            token_configured=token_configured,
+            token_status=token_status,
         )
 
     except HTTPException:

--- a/app/core/database/__init__.py
+++ b/app/core/database/__init__.py
@@ -488,6 +488,10 @@ class DatabaseManager:
         """删除用户的 Trakt 配置"""
         return self._trakt.delete_trakt_config(user_id)
 
+    def update_trakt_config_fields(self, user_id: str, fields: dict) -> bool:
+        """只更新 Trakt 配置的指定字段（不触碰凭证列，避免覆盖并发旋转的 token）。"""
+        return self._trakt.update_trakt_config_fields(user_id, fields)
+
     def save_trakt_sync_history(self, history: dict) -> bool:
         """保存 Trakt 同步历史记录"""
         return self._trakt.save_trakt_sync_history(history)

--- a/app/core/database/connection.py
+++ b/app/core/database/connection.py
@@ -214,7 +214,13 @@ class DatabaseConnection:
         )
 
     def _ensure_trakt_config_auth_type(self, cursor) -> None:
-        """旧库迁移：为 trakt_config 增加凭证模式字段（oauth / bearer）。"""
+        """旧库迁移：为 trakt_config 增加凭证模式字段（oauth / bearer）。
+
+        同时补 sync_filter_enabled（老库可能两个列都缺）：three 处读写路径
+        的 SELECT 同时引用 sync_filter_enabled 与 auth_type，任一缺失都会在
+        首次读写时炸掉，因此两个 ensure 必须都跑。
+        """
+        self._ensure_trakt_config_sync_filter(cursor)
         self._ensure_columns(
             cursor,
             "trakt_config",

--- a/app/core/database/connection.py
+++ b/app/core/database/connection.py
@@ -213,6 +213,15 @@ class DatabaseConnection:
             message="trakt_config 已迁移：增加 sync_filter_enabled 列",
         )
 
+    def _ensure_trakt_config_auth_type(self, cursor) -> None:
+        """旧库迁移：为 trakt_config 增加凭证模式字段（oauth / bearer）。"""
+        self._ensure_columns(
+            cursor,
+            "trakt_config",
+            [("auth_type", "TEXT DEFAULT 'oauth'")],
+            message="trakt_config 已迁移：增加 auth_type 凭证模式字段",
+        )
+
     def _ensure_pending_sync_queue_sync_record_id(self, cursor) -> None:
         """旧库迁移：为 pending_sync_queue 增加 sync_record_id（关联 sync_records 行）。
 
@@ -352,7 +361,8 @@ class DatabaseConnection:
                 sync_filter_enabled BOOLEAN DEFAULT 1,
                 last_sync_time INTEGER,
                 created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
+                updated_at INTEGER NOT NULL,
+                auth_type TEXT DEFAULT 'oauth'
             )
         """)
 

--- a/app/core/database/trakt.py
+++ b/app/core/database/trakt.py
@@ -146,6 +146,51 @@ class TraktRepository(BaseRepository):
         )
         return affected > 0
 
+    def update_trakt_config_fields(self, user_id: str, fields: dict) -> bool:
+        """只更新指定字段（白名单），不触碰 access_token/refresh_token/expires_at。
+
+        用于 API 层保存 enabled / sync_interval / sync_filter_enabled / auth_type
+        等非凭证字段：若用全量 save_trakt_config，会用早先读到的旧 token 覆盖
+        并发刷新（心跳/定时同步/手动同步）旋转后的新 token。
+        """
+        _ALLOWED = {
+            "enabled",
+            "sync_interval",
+            "sync_filter_enabled",
+            "last_sync_time",
+            "auth_type",
+        }
+
+        def _write(conn):
+            cursor = conn.cursor()
+            sets: list[str] = []
+            values: list = []
+            for key, value in fields.items():
+                if key not in _ALLOWED:
+                    continue
+                sets.append(f"{key} = ?")
+                if key in ("enabled", "sync_filter_enabled"):
+                    values.append(1 if value else 0)
+                else:
+                    values.append(value)
+            if not sets:
+                return True
+            sets.append("updated_at = ?")
+            values.append(int(datetime.now().timestamp()))
+            values.append(user_id)
+            cursor.execute(
+                f"UPDATE trakt_config SET {', '.join(sets)} WHERE user_id = ?",
+                values,
+            )
+            return True
+
+        return self._run_write(
+            _write,
+            error_msg="更新 Trakt 配置字段失败",
+            default=False,
+            ensure_schema=self._conn._ensure_trakt_config_auth_type,
+        )
+
     def save_trakt_sync_history(self, history: dict) -> bool:
         """保存 Trakt 同步历史记录"""
 

--- a/app/core/database/trakt.py
+++ b/app/core/database/trakt.py
@@ -37,6 +37,7 @@ class TraktRepository(BaseRepository):
                         sync_interval = ?,
                         sync_filter_enabled = ?,
                         last_sync_time = ?,
+                        auth_type = ?,
                         updated_at = ?
                     WHERE user_id = ?
                 """,
@@ -48,6 +49,7 @@ class TraktRepository(BaseRepository):
                         config.get("sync_interval", "0 */6 * * *"),
                         1 if config.get("sync_filter_enabled", True) else 0,
                         config.get("last_sync_time"),
+                        config.get("auth_type", "oauth"),
                         int(datetime.now().timestamp()),
                         config["user_id"],
                     ),
@@ -57,8 +59,9 @@ class TraktRepository(BaseRepository):
                     """
                     INSERT INTO trakt_config
                     (user_id, access_token, refresh_token, expires_at, enabled,
-                     sync_interval, sync_filter_enabled, last_sync_time, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     sync_interval, sync_filter_enabled, last_sync_time, auth_type,
+                     created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                     (
                         config["user_id"],
@@ -69,6 +72,7 @@ class TraktRepository(BaseRepository):
                         config.get("sync_interval", "0 */6 * * *"),
                         1 if config.get("sync_filter_enabled", True) else 0,
                         config.get("last_sync_time"),
+                        config.get("auth_type", "oauth"),
                         config.get("created_at", int(datetime.now().timestamp())),
                         int(datetime.now().timestamp()),
                     ),
@@ -79,7 +83,7 @@ class TraktRepository(BaseRepository):
             _write,
             error_msg="保存 Trakt 配置失败",
             default=False,
-            ensure_schema=self._conn._ensure_trakt_config_sync_filter,
+            ensure_schema=self._conn._ensure_trakt_config_auth_type,
         )
 
     def get_trakt_config(self, user_id: str) -> Optional[dict]:
@@ -91,7 +95,7 @@ class TraktRepository(BaseRepository):
                 """SELECT id, user_id, access_token, refresh_token,
                           expires_at, enabled, sync_interval,
                           sync_filter_enabled, last_sync_time,
-                          created_at, updated_at
+                          auth_type, created_at, updated_at
                    FROM trakt_config WHERE user_id = ?""",
                 (user_id,),
             )
@@ -101,7 +105,7 @@ class TraktRepository(BaseRepository):
             _read,
             error_msg="获取 Trakt 配置失败",
             default=None,
-            ensure_schema=self._conn._ensure_trakt_config_sync_filter,
+            ensure_schema=self._conn._ensure_trakt_config_auth_type,
         )
         if not row:
             return None
@@ -116,6 +120,7 @@ class TraktRepository(BaseRepository):
             "sync_interval",
             "sync_filter_enabled",
             "last_sync_time",
+            "auth_type",
             "created_at",
             "updated_at",
         ]
@@ -236,7 +241,7 @@ class TraktRepository(BaseRepository):
                 """SELECT id, user_id, access_token, refresh_token,
                           expires_at, enabled, sync_interval,
                           sync_filter_enabled, last_sync_time,
-                          created_at, updated_at
+                          auth_type, created_at, updated_at
                    FROM trakt_config WHERE enabled = 1"""
             )
             return cursor.fetchall()
@@ -245,7 +250,7 @@ class TraktRepository(BaseRepository):
             _read,
             error_msg="获取启用同步的 Trakt 配置失败",
             default=[],
-            ensure_schema=self._conn._ensure_trakt_config_sync_filter,
+            ensure_schema=self._conn._ensure_trakt_config_auth_type,
         )
         if not rows:
             return []
@@ -260,6 +265,7 @@ class TraktRepository(BaseRepository):
             "sync_interval",
             "sync_filter_enabled",
             "last_sync_time",
+            "auth_type",
             "created_at",
             "updated_at",
         ]

--- a/app/models/trakt.py
+++ b/app/models/trakt.py
@@ -247,3 +247,31 @@ class TraktManualSyncResponse(BaseModel):
     success: bool = Field(..., description="是否成功")
     message: str = Field(..., description="消息")
     job_id: Optional[str] = Field(None, description="任务ID")
+
+
+class TraktEmailLoginStartRequest(BaseModel):
+    """Trakt 邮箱登录：发送验证码请求模型"""
+
+    email: str = Field(..., description="Trakt 账号邮箱")
+
+
+class TraktEmailLoginStartResponse(BaseModel):
+    """Trakt 邮箱登录：发送验证码响应模型"""
+
+    success: bool = Field(..., description="是否成功")
+    message: str = Field(..., description="消息")
+    retry_after: Optional[int] = Field(None, description="冷却剩余秒数（限流时）")
+
+
+class TraktEmailLoginCompleteRequest(BaseModel):
+    """Trakt 邮箱登录：提交验证码请求模型"""
+
+    otp: str = Field(..., description="6 位验证码")
+
+
+class TraktEmailLoginCompleteResponse(BaseModel):
+    """Trakt 邮箱登录：提交验证码响应模型"""
+
+    success: bool = Field(..., description="是否成功")
+    message: str = Field(..., description="消息")
+    expires_at: Optional[int] = Field(None, description="凭证过期时间戳")

--- a/app/models/trakt.py
+++ b/app/models/trakt.py
@@ -5,15 +5,30 @@ Trakt.tv 相关数据模型
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# 合法凭证模式
+TRAKT_AUTH_TYPES = ("oauth", "bearer")
+
+# 凭证状态（基于 access_token 与 expires_at 计算，不落库）
+TOKEN_STATUS_ACTIVE = "active"
+TOKEN_STATUS_EXPIRED = "expired"
+TOKEN_STATUS_NOT_CONFIGURED = "not_configured"
+
+
+def normalize_auth_type(value: Optional[str]) -> str:
+    """规范化凭证模式，非法值回退为 oauth。"""
+    return value if value in TRAKT_AUTH_TYPES else "oauth"
 
 
 class TraktConfig(BaseModel):
     """Trakt 配置模型（Pydantic）"""
 
     user_id: str = Field(..., description="用户ID", min_length=1)
-    access_token: str = Field(..., description="访问令牌", min_length=1)
-    refresh_token: Optional[str] = Field(None, description="刷新令牌")
+    access_token: str = Field("", description="访问令牌（加密存储，不回显）")
+    refresh_token: Optional[str] = Field(
+        None, description="刷新令牌（旋转式，加密存储）"
+    )
     expires_at: Optional[int] = Field(None, description="令牌过期时间戳")
     enabled: bool = Field(True, description="是否启用 Trakt 同步")
     sync_interval: str = Field("0 */6 * * *", description="同步间隔 (Cron 表达式)")
@@ -27,6 +42,15 @@ class TraktConfig(BaseModel):
         default_factory=lambda: int(datetime.now().timestamp()),
         description="更新时间戳",
     )
+
+    # 凭证模式（互斥切换：oauth / bearer）。两种模式复用同一组
+    # access_token / refresh_token / expires_at 字段，切换时互相覆盖。
+    auth_type: str = Field("oauth", description="凭证模式: oauth / bearer")
+
+    @field_validator("auth_type")
+    @classmethod
+    def _validate_auth_type(cls, v: str) -> str:
+        return normalize_auth_type(v)
 
     def is_token_expired(self) -> bool:
         """检查访问令牌是否已过期"""
@@ -54,6 +78,7 @@ class TraktConfig(BaseModel):
             "last_sync_time": self.last_sync_time,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "auth_type": self.auth_type,
         }
 
     @classmethod
@@ -72,7 +97,7 @@ class TraktConfig(BaseModel):
 
         return cls(
             user_id=data["user_id"],
-            access_token=data["access_token"],
+            access_token=data.get("access_token", ""),
             refresh_token=data.get("refresh_token"),
             expires_at=data.get("expires_at"),
             enabled=enabled,
@@ -81,6 +106,7 @@ class TraktConfig(BaseModel):
             last_sync_time=data.get("last_sync_time"),
             created_at=data.get("created_at", int(datetime.now().timestamp())),
             updated_at=data.get("updated_at", int(datetime.now().timestamp())),
+            auth_type=normalize_auth_type(data.get("auth_type")),
         )
 
 
@@ -163,6 +189,15 @@ class TraktConfigResponse(BaseModel):
         False, description="Trakt Client Secret 是否已配置（不回传明文）"
     )
     redirect_uri: str = Field("", description="OAuth 回调 URL")
+    # 凭证状态（token 本身绝不回显）
+    auth_type: str = Field("oauth", description="凭证模式: oauth / bearer")
+    token_configured: bool = Field(
+        False, description="是否已配置凭证（access_token 非空）"
+    )
+    token_status: str = Field(
+        "not_configured",
+        description="凭证状态: active / expired / not_configured",
+    )
 
 
 class TraktConfigUpdateRequest(BaseModel):
@@ -171,6 +206,13 @@ class TraktConfigUpdateRequest(BaseModel):
     enabled: Optional[bool] = Field(None, description="是否启用")
     sync_interval: Optional[str] = Field(None, description="同步间隔")
     sync_filter_enabled: Optional[bool] = Field(None, description="是否启用类型过滤")
+    auth_type: Optional[str] = Field(None, description="凭证模式: oauth / bearer")
+    access_token: Optional[str] = Field(
+        None, description="Bearer access_token（留空=不修改；不回显）"
+    )
+    refresh_token: Optional[str] = Field(
+        None, description="Bearer refresh_token（留空=不修改；不回显）"
+    )
 
 
 class TraktApiConfigUpdateRequest(BaseModel):

--- a/app/models/trakt.py
+++ b/app/models/trakt.py
@@ -208,10 +208,7 @@ class TraktConfigUpdateRequest(BaseModel):
     sync_filter_enabled: Optional[bool] = Field(None, description="是否启用类型过滤")
     auth_type: Optional[str] = Field(None, description="凭证模式: oauth / bearer")
     refresh_token: Optional[str] = Field(
-        None, description="Bearer refresh_token（必填；验证/续期依据；不回显）"
-    )
-    access_token: Optional[str] = Field(
-        None, description="Bearer access_token（可选，仅展示用途，不被使用；不回显）"
+        None, description="Bearer refresh_token（验证/续期唯一依据；不回显）"
     )
 
 

--- a/app/models/trakt.py
+++ b/app/models/trakt.py
@@ -207,11 +207,11 @@ class TraktConfigUpdateRequest(BaseModel):
     sync_interval: Optional[str] = Field(None, description="同步间隔")
     sync_filter_enabled: Optional[bool] = Field(None, description="是否启用类型过滤")
     auth_type: Optional[str] = Field(None, description="凭证模式: oauth / bearer")
-    access_token: Optional[str] = Field(
-        None, description="Bearer access_token（留空=不修改；不回显）"
-    )
     refresh_token: Optional[str] = Field(
-        None, description="Bearer refresh_token（留空=不修改；不回显）"
+        None, description="Bearer refresh_token（必填；验证/续期依据；不回显）"
+    )
+    access_token: Optional[str] = Field(
+        None, description="Bearer access_token（可选，仅展示用途，不被使用；不回显）"
     )
 
 

--- a/app/services/trakt/auth.py
+++ b/app/services/trakt/auth.py
@@ -266,6 +266,14 @@ class TraktAuthService:
         """保存或更新 Trakt 配置（API 层入口，避免跨层直访数据库）"""
         return database_manager.save_trakt_config(config.to_dict())
 
+    def update_config_fields(self, user_id: str, fields: dict) -> bool:
+        """更新配置的非凭证字段（enabled/sync_interval/sync_filter_enabled/auth_type）。
+
+                与 save_config 不同：只写指定列，不触碰 access_token/refresh_token/
+        expires_at，避免用早先读到的旧 token 覆盖并发刷新旋转后的新 token。
+        """
+        return database_manager.update_trakt_config_fields(user_id, fields)
+
     def disconnect_trakt(self, user_id: str) -> bool:
         """断开 Trakt 连接，删除配置"""
         success = database_manager.delete_trakt_config(user_id)

--- a/app/services/trakt/client.py
+++ b/app/services/trakt/client.py
@@ -17,15 +17,37 @@ from ...utils.http_base import AsyncHttpClient
 # ===== 数据模型导入 =====
 from .models import TraktCollectionItem, TraktHistoryItem, TraktRatingItem
 
+# trakt 官方静态 client_id（硬编码于前端，实测 apiz 数据域 + oauth/token 刷新均可用）
+TRAKT_API_KEY = "201dc70c5ec6af530f12f079ea1922733f6e1085ad7b02f36d8e011b75bcea7d"
+# trakt 官方 OAuth2 token 刷新端点
+TRAKT_OAUTH_TOKEN_URL = "https://auth.trakt.tv/oauth/token"
+
+
+class TraktAuthError(Exception):
+    """Trakt 认证失败（401）：access token 失效，需刷新凭证后重试。
+
+    与普通 API 错误区分：此异常必须向上传播到同步层，由同步层
+    触发「刷新凭证 → 重建客户端 → 重试」流程，而不是被吞掉返回空数据。
+    """
+
 
 # ===== Trakt 客户端 =====
 class TraktClient:
-    """Trakt.tv API 异步客户端"""
+    """Trakt.tv API 异步客户端
 
-    def __init__(self, access_token: str) -> None:
+    auth_type 决定数据域与 api key：
+    - oauth：api.trakt.tv + 用户注册的 client_id（授权码流程）
+    - bearer：apiz.trakt.tv + trakt 官方静态 client_id（从浏览器粘贴 access/refresh）
+    """
+
+    def __init__(self, access_token: str, auth_type: str = "oauth") -> None:
         self.access_token = access_token
-        self.base_url = "https://api.trakt.tv"
-        self.client_id = config_manager.get_trakt_config().get("client_id", "")
+        if auth_type == "bearer":
+            self.base_url = "https://apiz.trakt.tv"
+            self.client_id = TRAKT_API_KEY
+        else:
+            self.base_url = "https://api.trakt.tv"
+            self.client_id = config_manager.get_trakt_config().get("client_id", "")
 
         # 请求头
         self.headers = {
@@ -113,7 +135,7 @@ class TraktClient:
                     return {}  # 无内容
                 elif response.status_code == 401:
                     logger.error("Trakt 认证失败，令牌可能已过期")
-                    raise ValueError("认证失败")
+                    raise TraktAuthError("Trakt 认证失败（401），令牌可能已过期")
                 elif response.status_code == 429:
                     # 速率限制，等待后重试
                     retry_after_str = response.headers.get("Retry-After", "60")
@@ -133,6 +155,9 @@ class TraktClient:
                         continue
                     return None
 
+            except TraktAuthError:
+                # 401：token 已失效，重试无意义，立即向上传播
+                raise
             except httpx.RequestError as e:
                 logger.error(f"Trakt API 请求错误: {e}")
                 if attempt < self.max_retries - 1:
@@ -212,6 +237,8 @@ class TraktClient:
 
             return history_items
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取观看历史失败: {e}")
             return []
@@ -251,6 +278,8 @@ class TraktClient:
                 # 避免请求过快，小延迟
                 await asyncio.sleep(0.1)
 
+            except TraktAuthError:
+                raise
             except Exception as e:
                 logger.error(f"获取第 {page} 页观看历史失败: {e}")
                 break
@@ -302,6 +331,8 @@ class TraktClient:
 
             return rating_items
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取评分失败: {e}")
             return []
@@ -338,6 +369,8 @@ class TraktClient:
 
             return collection_items
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取收藏失败: {e}")
             return []
@@ -351,6 +384,8 @@ class TraktClient:
 
             return data if isinstance(data, dict) else None
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取用户信息失败: {e}")
             return None
@@ -364,6 +399,8 @@ class TraktClient:
 
             return data if isinstance(data, dict) else None
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取电影 {trakt_id} 信息失败: {e}")
             return None
@@ -383,6 +420,8 @@ class TraktClient:
             data = await self._make_request("GET", endpoint, params)
 
             return data if isinstance(data, dict) else None
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取剧集 {trakt_id} 信息失败: {e}")
             return None
@@ -398,6 +437,8 @@ class TraktClient:
 
             return data if isinstance(data, dict) else None
 
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"获取剧集详情失败: {e}")
             return None
@@ -407,6 +448,8 @@ class TraktClient:
         try:
             data = await self.get_user_profile()
             return data is not None
+        except TraktAuthError:
+            raise
         except Exception as e:
             logger.error(f"测试 Trakt 连接失败: {e}")
             return False
@@ -419,10 +462,12 @@ class TraktClientFactory:
     """Trakt 客户端工厂"""
 
     @staticmethod
-    async def create_client(access_token: str) -> Optional[TraktClient]:
+    async def create_client(
+        access_token: str, auth_type: str = "oauth"
+    ) -> Optional[TraktClient]:
         """创建 Trakt 客户端"""
         try:
-            client = TraktClient(access_token)
+            client = TraktClient(access_token, auth_type=auth_type)
             # 测试连接
             success = await client.test_connection()
             if success:
@@ -430,6 +475,9 @@ class TraktClientFactory:
             else:
                 await client.close()
                 return None
+        except TraktAuthError:
+            # 认证失败：向上传播，由同步层刷新凭证后重试
+            raise
         except Exception as e:
             logger.error(f"创建 Trakt 客户端失败: {e}")
             return None

--- a/app/services/trakt/email_login.py
+++ b/app/services/trakt/email_login.py
@@ -1,7 +1,7 @@
 """
 Trakt 邮箱登录服务（邮箱 + 验证码 → 自动获取 Bearer 凭证）
 
-协议（firefox-reversed 逆向实测，见 docs/trakt-login-protocol.md / trakt-data-api.md）：
+协议（firefox-reversed 逆向实测，见 docs/development/trakt-login-protocol.md）：
 1. ``POST https://auth.trakt.tv/auth/magic``  body: ``email=<urlencoded>``
    → 向邮箱发送登录邮件（6 位 OTP，5 分钟有效，新邮件作废旧 OTP）
 2. ``POST https://auth.trakt.tv/auth/magic/submit``  body: ``email=...&otp=<6位>``
@@ -17,9 +17,12 @@ Trakt 邮箱登录服务（邮箱 + 验证码 → 自动获取 Bearer 凭证）
 设计要点：
 - OTP / session cookie / code / token 全程在服务端流转，前端只传 email 与 otp
 - pending 登录会话存内存（按 user_id 隔离），5 分钟过期，单会话覆盖
-- 发信限流：同一用户 60 秒内不能重复发（Trakt 有 rate limit）
+- OTP 提交失败有次数上限（MAX_OTP_ATTEMPTS），超限作废会话，防止无限重试
+- 发信限流：同一用户 60 秒内不能重复发（Trakt 有 rate limit），冷却期返回 429
+- 并发安全：_pending 的读写由 asyncio.Lock 保护，避免会话被并发覆盖/误删
 """
 
+import asyncio
 import base64
 import hashlib
 import re
@@ -34,7 +37,11 @@ from ...core.logging import logger
 from ...models.trakt import TraktConfig
 from ...utils.http_base import AsyncHttpClient
 from .client import TRAKT_API_KEY
-from .token_refresher import DEFAULT_EXPIRES_IN, USER_AGENT
+from .token_refresher import (
+    DEFAULT_EXPIRES_IN,
+    USER_AGENT,
+    _get_refresh_lock,
+)
 
 # 登录域
 AUTH_BASE = "https://auth.trakt.tv"
@@ -46,6 +53,8 @@ SCOPE = "public openid profile email offline_access"
 PENDING_TTL = 300
 # 同用户发信冷却（秒），防 Trakt rate limit
 RESEND_COOLDOWN = 60
+# OTP 提交失败次数上限（防无限重试 / 暴力尝试），超限作废会话需重新发信
+MAX_OTP_ATTEMPTS = 5
 
 # 响应头中的会话 cookie 名（Better Auth）
 SESSION_COOKIE_NAME = "__Secure-better-auth.session_token"
@@ -61,21 +70,24 @@ class _PendingLogin:
     verifier: str
     state: str
     created_at: float
+    attempts: int = 0  # OTP 提交失败次数（超 MAX_OTP_ATTEMPTS 作废）
 
 
 # 按 user_id 隔离的进行中登录会话（内存态；重启丢失则重新发起即可）
 _pending: dict[str, _PendingLogin] = {}
+# 保护 _pending 读写的锁（start/complete 可并发触发）
+_pending_lock = asyncio.Lock()
 
 
 # ===== PKCE =====
 
 
-def _generate_pkce() -> tuple[str, str]:
-    """生成 PKCE verifier 与 S256 challenge。"""
-    verifier = secrets.token_urlsafe(32)  # 43 字符
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    return verifier, challenge
+def _generate_pkce() -> str:
+    """生成 PKCE verifier（43 字符）。
+
+    S256 challenge 在 _oidc_authorize 中由 verifier 现场计算，无需此处生成。
+    """
+    return secrets.token_urlsafe(32)
 
 
 def _resolve_expires_at(data: dict) -> int:
@@ -195,7 +207,8 @@ async def _oidc_authorize(
             query = parse_qs(urlparse(location).query)
             state_back = query.get("state", [""])[0]
             code = query.get("code", [""])[0]
-            if state_back and state_back != state:
+            # fail-closed：state 缺失或与发起时不匹配一律拒绝
+            if state_back != state:
                 return "", "授权状态校验失败，请重新发起登录"
             if code:
                 return code, ""
@@ -210,7 +223,8 @@ async def _oidc_authorize(
             query = parse_qs(urlparse(data["url"]).query)
             state_back = query.get("state", [""])[0]
             code = query.get("code", [""])[0]
-            if state_back and state_back != state:
+            # fail-closed：state 缺失或与发起时不匹配一律拒绝
+            if state_back != state:
                 return "", "授权状态校验失败，请重新发起登录"
             if code:
                 return code, ""
@@ -281,25 +295,39 @@ def _ensure_media_server_username(user_id: str) -> None:
     )
 
 
-async def _persist_tokens(user_id: str, tokens: dict) -> int:
-    """Bearer 凭证落库（auth_type=bearer + access/refresh/expires_at）。"""
-    config_dict = database_manager.get_trakt_config(user_id)
-    config = (
-        TraktConfig.from_dict(config_dict)
-        if config_dict
-        else TraktConfig(user_id=user_id)
-    )
-    config.auth_type = "bearer"
-    config.access_token = tokens["access_token"]
-    config.refresh_token = tokens["refresh_token"]  # 旋转式，落库新值
-    config.expires_at = _resolve_expires_at(tokens)
-    database_manager.save_trakt_config(config.to_dict())
-    _ensure_media_server_username(user_id)
-    logger.info(
-        f"用户 {user_id} 通过邮箱登录完成，Bearer 凭证已保存，"
-        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
-    )
-    return config.expires_at
+async def _persist_tokens(user_id: str, tokens: dict) -> Optional[int]:
+    """Bearer 凭证落库（auth_type=bearer + access/refresh/expires_at）。
+
+    与刷新共用 per-user 刷新锁：持锁后重读配置再写，避免与心跳/同步的
+    并发旋转互相覆盖。
+
+    Returns:
+        expires_at；响应缺字段时返回 None（不落库，避免 KeyError 500）。
+    """
+    access = tokens.get("access_token") or ""
+    refresh = tokens.get("refresh_token") or ""
+    if not access or not refresh:
+        logger.error(f"用户 {user_id} 邮箱登录：token 响应缺少 access/refresh，不落库")
+        return None
+    lock = await _get_refresh_lock(user_id)
+    async with lock:
+        config_dict = database_manager.get_trakt_config(user_id)
+        config = (
+            TraktConfig.from_dict(config_dict)
+            if config_dict
+            else TraktConfig(user_id=user_id)
+        )
+        config.auth_type = "bearer"
+        config.access_token = access
+        config.refresh_token = refresh  # 旋转式，落库新值
+        config.expires_at = _resolve_expires_at(tokens)
+        database_manager.save_trakt_config(config.to_dict())
+        _ensure_media_server_username(user_id)
+        logger.info(
+            f"用户 {user_id} 通过邮箱登录完成，Bearer 凭证已保存，"
+            f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
+        )
+        return config.expires_at
 
 
 # ===== 对外接口 =====
@@ -309,38 +337,43 @@ async def start_email_login(user_id: str, email: str) -> dict:
     """开始邮箱登录：校验邮箱 → 发验证码 → 记录 PKCE pending 会话。
 
     Returns:
-        {"success": bool, "message": str, "retry_after": Optional[int]}
+        {"success": bool, "message": str, "retry_after": Optional[int],
+         "rate_limited": bool}
     """
     email = (email or "").strip().lower()
     if not _EMAIL_RE.fullmatch(email):
         return {"success": False, "message": "邮箱格式无效", "retry_after": None}
 
     now = time.time()
-    prev = _pending.get(user_id)
-    if prev and now - prev.created_at < RESEND_COOLDOWN:
-        wait = int(RESEND_COOLDOWN - (now - prev.created_at))
-        return {
-            "success": False,
-            "message": f"发送过于频繁，请 {wait} 秒后再试",
-            "retry_after": wait,
-        }
+    # 冷却检查 + 发信 + 写入 pending 持同一把锁原子完成：并发 start 无法在
+    # 冷却检查与真正发信之间插入第二次发信（避免绕过 60s 冷却 / 重复发信）。
+    async with _pending_lock:
+        prev = _pending.get(user_id)
+        if prev and now - prev.created_at < RESEND_COOLDOWN:
+            wait = int(RESEND_COOLDOWN - (now - prev.created_at))
+            return {
+                "success": False,
+                "message": f"发送过于频繁，请 {wait} 秒后再试",
+                "retry_after": wait,
+                "rate_limited": True,
+            }
 
-    verifier, _ = _generate_pkce()
-    ok, err = await _send_magic(email)
-    if not ok:
-        return {
-            "success": False,
-            "message": f"发送验证码失败: {err}",
-            "retry_after": None,
-        }
+        verifier = _generate_pkce()
+        ok, err = await _send_magic(email)
+        if not ok:
+            return {
+                "success": False,
+                "message": f"发送验证码失败: {err}",
+                "retry_after": None,
+            }
 
-    # 只有发信成功才建立 pending（verifier/state 与本次邮件一一对应）
-    _pending[user_id] = _PendingLogin(
-        email=email,
-        verifier=verifier,
-        state=secrets.token_hex(16),
-        created_at=now,
-    )
+        # 只有发信成功才建立 pending（verifier/state 与本次邮件一一对应）
+        _pending[user_id] = _PendingLogin(
+            email=email,
+            verifier=verifier,
+            state=secrets.token_hex(16),
+            created_at=now,
+        )
     return {
         "success": True,
         "message": f"验证码已发送至 {email}，请查收邮件（5 分钟内有效）",
@@ -355,35 +388,50 @@ async def complete_email_login(user_id: str, otp: str) -> dict:
         {"success": bool, "message": str, "expires_at": Optional[int]}
     """
     otp = (otp or "").strip()
-    pending = _pending.get(user_id)
-    if not pending or time.time() - pending.created_at > PENDING_TTL:
-        _pending.pop(user_id, None)
-        return {
-            "success": False,
-            "message": "登录会话已过期，请重新发送验证码",
-            "expires_at": None,
-        }
-    if not (otp.isdigit() and len(otp) == 6):
-        return {
-            "success": False,
-            "message": "请输入 6 位数字验证码",
-            "expires_at": None,
-        }
+    async with _pending_lock:
+        pending = _pending.get(user_id)
+        if not pending or time.time() - pending.created_at > PENDING_TTL:
+            _pending.pop(user_id, None)
+            return {
+                "success": False,
+                "message": "登录会话已过期，请重新发送验证码",
+                "expires_at": None,
+            }
+        if not (otp.isdigit() and len(otp) == 6):
+            return {
+                "success": False,
+                "message": "请输入 6 位数字验证码",
+                "expires_at": None,
+            }
+        # 网络调用前先检查并占用一次提交名额：并发提交在计数更新前无法
+        # 全部打到上游，严格限制 OTP 尝试次数不超过 MAX_OTP_ATTEMPTS
+        if pending.attempts >= MAX_OTP_ATTEMPTS:
+            if _pending.get(user_id) is pending:
+                _pending.pop(user_id, None)
+            return {
+                "success": False,
+                "message": "验证码错误次数过多，请重新发送验证码",
+                "expires_at": None,
+            }
+        pending.attempts += 1
+        session = pending  # 持对象引用，后续不再依赖 dict 中的会话
 
-    ok, err, session_cookie = await _submit_otp(pending.email, otp)
+    ok, err, session_cookie = await _submit_otp(session.email, otp)
     if not ok:
-        # OTP 无效/失败：保留 pending 供用户重试（5 分钟内）
+        # OTP 无效/失败：保留 pending 供重试（次数已在网络调用前占用）
         return {"success": False, "message": err, "expires_at": None}
 
     # OTP 已提交成功：本次会话已消费，无论后续成败都清理 pending
-    _pending.pop(user_id, None)
+    async with _pending_lock:
+        if _pending.get(user_id) is session:
+            _pending.pop(user_id, None)
     try:
         code, err = await _oidc_authorize(
-            session_cookie, pending.state, pending.verifier
+            session_cookie, session.state, session.verifier
         )
         if not code:
             return {"success": False, "message": err, "expires_at": None}
-        tokens, err = await _exchange_code(code, pending.verifier)
+        tokens, err = await _exchange_code(code, session.verifier)
         if not tokens:
             return {"success": False, "message": err, "expires_at": None}
     except Exception as e:  # noqa: BLE001
@@ -391,6 +439,12 @@ async def complete_email_login(user_id: str, otp: str) -> dict:
         return {"success": False, "message": f"登录流程异常: {e}", "expires_at": None}
 
     expires_at = await _persist_tokens(user_id, tokens)
+    if expires_at is None:
+        return {
+            "success": False,
+            "message": "登录响应缺少令牌字段，请重新发送验证码重试",
+            "expires_at": None,
+        }
     return {
         "success": True,
         "message": "登录成功，Bearer 凭证已保存并切换为 Bearer 模式",

--- a/app/services/trakt/email_login.py
+++ b/app/services/trakt/email_login.py
@@ -1,0 +1,398 @@
+"""
+Trakt 邮箱登录服务（邮箱 + 验证码 → 自动获取 Bearer 凭证）
+
+协议（firefox-reversed 逆向实测，见 docs/trakt-login-protocol.md / trakt-data-api.md）：
+1. ``POST https://auth.trakt.tv/auth/magic``  body: ``email=<urlencoded>``
+   → 向邮箱发送登录邮件（6 位 OTP，5 分钟有效，新邮件作废旧 OTP）
+2. ``POST https://auth.trakt.tv/auth/magic/submit``  body: ``email=...&otp=<6位>``
+   → 200 + ``Set-Cookie: __Secure-better-auth.session_token``（Better Auth 会话）
+3. ``GET https://auth.trakt.tv/api/auth/oauth2/authorize``（带会话 cookie + PKCE S256）
+   → 302 Location: ``https://app.trakt.tv/callback?code=...&state=...``（已登录直接发码，无确认页）
+4. ``POST https://auth.trakt.tv/oauth/token``  ``{grant_type: authorization_code, code, code_verifier, ...}``
+   → 200 ``{access_token, refresh_token, expires_in, expires_at, id_token}``
+
+登录成功后自动落库（auth_type=bearer），并像 OAuth 授权一样把当前应用用户名
+追加到激活 Bangumi 账号的 media_server_usernames，避免同步被用户名过滤拦截。
+
+设计要点：
+- OTP / session cookie / code / token 全程在服务端流转，前端只传 email 与 otp
+- pending 登录会话存内存（按 user_id 隔离），5 分钟过期，单会话覆盖
+- 发信限流：同一用户 60 秒内不能重复发（Trakt 有 rate limit）
+"""
+
+import base64
+import hashlib
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import parse_qs, quote, urlparse
+
+from ...core.database import database_manager
+from ...core.logging import logger
+from ...models.trakt import TraktConfig
+from ...utils.http_base import AsyncHttpClient
+from .client import TRAKT_API_KEY
+from .token_refresher import DEFAULT_EXPIRES_IN, USER_AGENT
+
+# 登录域
+AUTH_BASE = "https://auth.trakt.tv"
+# OIDC 授权回调（trakt 官方 web app 的固定回调，授权码从该地址的 query 中解析）
+REDIRECT_URI = "https://app.trakt.tv/callback"
+SCOPE = "public openid profile email offline_access"
+
+# 验证码有效期（与 Trakt 邮件一致）
+PENDING_TTL = 300
+# 同用户发信冷却（秒），防 Trakt rate limit
+RESEND_COOLDOWN = 60
+
+# 响应头中的会话 cookie 名（Better Auth）
+SESSION_COOKIE_NAME = "__Secure-better-auth.session_token"
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+@dataclass
+class _PendingLogin:
+    """一次进行中的邮箱登录会话（PKCE 参数与邮箱，5 分钟过期）。"""
+
+    email: str
+    verifier: str
+    state: str
+    created_at: float
+
+
+# 按 user_id 隔离的进行中登录会话（内存态；重启丢失则重新发起即可）
+_pending: dict[str, _PendingLogin] = {}
+
+
+# ===== PKCE =====
+
+
+def _generate_pkce() -> tuple[str, str]:
+    """生成 PKCE verifier 与 S256 challenge。"""
+    verifier = secrets.token_urlsafe(32)  # 43 字符
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _resolve_expires_at(data: dict) -> int:
+    """从 /oauth/token 响应解析 expires_at（unix 秒），缺省用 expires_in 兜底。"""
+    if data.get("expires_at"):
+        return int(data["expires_at"])
+    return int(time.time()) + int(data.get("expires_in", DEFAULT_EXPIRES_IN))
+
+
+# ===== 协议步骤 =====
+
+
+async def _send_magic(email: str) -> tuple[bool, str]:
+    """① 发送登录邮件。返回 (ok, error)。"""
+    http = (
+        AsyncHttpClient(label="TraktLogin", timeout=30.0, follow_redirects=False)
+        .prefix("📧")
+        .success_tpl("验证码邮件已发送 [{status_code}]")
+        .failure_tpl("发送验证码邮件失败: {error_type}")
+    )
+    try:
+        resp = await http.request(
+            "POST",
+            f"{AUTH_BASE}/auth/magic",
+            data=f"email={quote(email, safe='')}",
+            headers={
+                "content-type": "application/x-www-form-urlencoded",
+                "user-agent": USER_AGENT,
+                "accept": "*/*",
+                "origin": AUTH_BASE,
+                "referer": f"{AUTH_BASE}/signin",
+            },
+        )
+        if resp.status_code == 200:
+            return True, ""
+        return False, f"HTTP {resp.status_code}"
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+    finally:
+        await http.aclose()
+
+
+async def _submit_otp(email: str, otp: str) -> tuple[bool, str, str]:
+    """② 提交 OTP。返回 (ok, error, session_cookie)。"""
+    http = (
+        AsyncHttpClient(label="TraktLogin", timeout=30.0, follow_redirects=False)
+        .prefix("🔑")
+        .success_tpl("验证码提交成功 [{status_code}]")
+        .failure_tpl("验证码提交失败: {error_type}")
+    )
+    try:
+        resp = await http.request(
+            "POST",
+            f"{AUTH_BASE}/auth/magic/submit",
+            data=f"email={quote(email, safe='')}&otp={otp}",
+            headers={
+                "content-type": "application/x-www-form-urlencoded",
+                "user-agent": USER_AGENT,
+                "accept": "*/*",
+                "origin": AUTH_BASE,
+                "referer": f"{AUTH_BASE}/signin",
+            },
+        )
+        if resp.status_code != 200:
+            if resp.status_code == 401:
+                return False, "验证码无效或已过期，请重新输入或重新发送", ""
+            return False, f"HTTP {resp.status_code}", ""
+        for set_cookie in resp.headers.get_list("set-cookie"):
+            if set_cookie.startswith(SESSION_COOKIE_NAME + "="):
+                return True, "", set_cookie.split(";")[0]
+        return False, "登录响应异常：未收到会话 cookie", ""
+    except Exception as e:  # noqa: BLE001
+        return False, str(e), ""
+    finally:
+        await http.aclose()
+
+
+async def _oidc_authorize(
+    session_cookie: str, state: str, verifier: str
+) -> tuple[str, str]:
+    """③ OIDC 授权码流：带会话 cookie 发起 authorize，解析 302 回跳中的 code。
+
+    Returns:
+        (code, error)：code 为空表示失败。
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    params = {
+        "response_type": "code",
+        "client_id": TRAKT_API_KEY,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    http = (
+        AsyncHttpClient(label="TraktLogin", timeout=30.0, follow_redirects=False)
+        .prefix("🔐")
+        .success_tpl("OIDC 授权 [{status_code}]")
+        .failure_tpl("OIDC 授权失败: {error_type}")
+    )
+    try:
+        resp = await http.request(
+            "GET",
+            f"{AUTH_BASE}/api/auth/oauth2/authorize",
+            params=params,
+            headers={
+                "user-agent": USER_AGENT,
+                "accept": "text/html,application/json",
+                "cookie": session_cookie,
+            },
+        )
+        # 1) 302/301 直接跳转：Location 带 code
+        location = resp.headers.get("location", "")
+        if resp.status_code in (301, 302, 303, 307, 308) and location:
+            query = parse_qs(urlparse(location).query)
+            state_back = query.get("state", [""])[0]
+            code = query.get("code", [""])[0]
+            if state_back and state_back != state:
+                return "", "授权状态校验失败，请重新发起登录"
+            if code:
+                return code, ""
+        # 2) 200 + JSON：SvelteKit 服务端返回跳转目标
+        #    {"redirect": true, "url": "https://app.trakt.tv/callback?code=...&state=..."}
+        #    （实测 authorize 用这种方式下发授权码，非 HTTP 302）
+        try:
+            data = resp.json()
+        except Exception:  # noqa: BLE001
+            data = None
+        if isinstance(data, dict) and data.get("url"):
+            query = parse_qs(urlparse(data["url"]).query)
+            state_back = query.get("state", [""])[0]
+            code = query.get("code", [""])[0]
+            if state_back and state_back != state:
+                return "", "授权状态校验失败，请重新发起登录"
+            if code:
+                return code, ""
+        return "", f"授权请求未返回授权码 (HTTP {resp.status_code})"
+    except Exception as e:  # noqa: BLE001
+        return "", f"授权请求异常: {e}"
+    finally:
+        await http.aclose()
+
+
+async def _exchange_code(code: str, verifier: str) -> tuple[Optional[dict], str]:
+    """④ 授权码换 token。返回 (tokens, error)。"""
+    http = (
+        AsyncHttpClient(label="TraktLogin", timeout=30.0)
+        .prefix("🎟️")
+        .success_tpl("令牌换取成功 [{status_code}]")
+        .failure_tpl("令牌换取失败: {error_type}")
+    )
+    try:
+        resp = await http.request(
+            "POST",
+            f"{AUTH_BASE}/oauth/token",
+            json={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+                "client_id": TRAKT_API_KEY,
+                "code_verifier": verifier,
+            },
+            headers={
+                "content-type": "application/json",
+                "user-agent": USER_AGENT,
+            },
+        )
+        if resp.status_code == 200:
+            return resp.json(), ""
+        return None, f"HTTP {resp.status_code}: {(resp.text or '')[:200]}"
+    except Exception as e:  # noqa: BLE001
+        return None, str(e)
+    finally:
+        await http.aclose()
+
+
+# ===== 落库与账号路由 =====
+
+
+def _ensure_media_server_username(user_id: str) -> None:
+    """登录成功后自动将当前用户名追加到激活账号的 media_server_usernames。
+
+    与 OAuth 授权成功逻辑一致（DB 为唯一真相源）：避免 Trakt 同步
+    被 _check_user_permission 的媒体服务器用户名过滤拦截。
+    """
+    from ...core.accounts import get_active_bangumi_account, save_bangumi_account
+
+    acc = get_active_bangumi_account()
+    if not acc:
+        return
+    existing = list(acc.get("media_server_usernames") or [])
+    if user_id in existing:
+        return
+    existing.append(user_id)
+    acc["media_server_usernames"] = existing
+    save_bangumi_account(acc)
+    logger.info(
+        f"Trakt 邮箱登录成功：已自动将用户名 '{user_id}' 追加到 "
+        f"激活 Bangumi 账号 '{acc.get('section_name', '')}' 的 "
+        f"media_server_usernames，确保该用户的 Trakt 同步不被过滤拦截。"
+    )
+
+
+async def _persist_tokens(user_id: str, tokens: dict) -> int:
+    """Bearer 凭证落库（auth_type=bearer + access/refresh/expires_at）。"""
+    config_dict = database_manager.get_trakt_config(user_id)
+    config = (
+        TraktConfig.from_dict(config_dict)
+        if config_dict
+        else TraktConfig(user_id=user_id)
+    )
+    config.auth_type = "bearer"
+    config.access_token = tokens["access_token"]
+    config.refresh_token = tokens["refresh_token"]  # 旋转式，落库新值
+    config.expires_at = _resolve_expires_at(tokens)
+    database_manager.save_trakt_config(config.to_dict())
+    _ensure_media_server_username(user_id)
+    logger.info(
+        f"用户 {user_id} 通过邮箱登录完成，Bearer 凭证已保存，"
+        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
+    )
+    return config.expires_at
+
+
+# ===== 对外接口 =====
+
+
+async def start_email_login(user_id: str, email: str) -> dict:
+    """开始邮箱登录：校验邮箱 → 发验证码 → 记录 PKCE pending 会话。
+
+    Returns:
+        {"success": bool, "message": str, "retry_after": Optional[int]}
+    """
+    email = (email or "").strip().lower()
+    if not _EMAIL_RE.fullmatch(email):
+        return {"success": False, "message": "邮箱格式无效", "retry_after": None}
+
+    now = time.time()
+    prev = _pending.get(user_id)
+    if prev and now - prev.created_at < RESEND_COOLDOWN:
+        wait = int(RESEND_COOLDOWN - (now - prev.created_at))
+        return {
+            "success": False,
+            "message": f"发送过于频繁，请 {wait} 秒后再试",
+            "retry_after": wait,
+        }
+
+    verifier, _ = _generate_pkce()
+    ok, err = await _send_magic(email)
+    if not ok:
+        return {
+            "success": False,
+            "message": f"发送验证码失败: {err}",
+            "retry_after": None,
+        }
+
+    # 只有发信成功才建立 pending（verifier/state 与本次邮件一一对应）
+    _pending[user_id] = _PendingLogin(
+        email=email,
+        verifier=verifier,
+        state=secrets.token_hex(16),
+        created_at=now,
+    )
+    return {
+        "success": True,
+        "message": f"验证码已发送至 {email}，请查收邮件（5 分钟内有效）",
+        "retry_after": None,
+    }
+
+
+async def complete_email_login(user_id: str, otp: str) -> dict:
+    """完成邮箱登录：提交 OTP → OIDC 授权码流 → 自动落库。
+
+    Returns:
+        {"success": bool, "message": str, "expires_at": Optional[int]}
+    """
+    otp = (otp or "").strip()
+    pending = _pending.get(user_id)
+    if not pending or time.time() - pending.created_at > PENDING_TTL:
+        _pending.pop(user_id, None)
+        return {
+            "success": False,
+            "message": "登录会话已过期，请重新发送验证码",
+            "expires_at": None,
+        }
+    if not (otp.isdigit() and len(otp) == 6):
+        return {
+            "success": False,
+            "message": "请输入 6 位数字验证码",
+            "expires_at": None,
+        }
+
+    ok, err, session_cookie = await _submit_otp(pending.email, otp)
+    if not ok:
+        # OTP 无效/失败：保留 pending 供用户重试（5 分钟内）
+        return {"success": False, "message": err, "expires_at": None}
+
+    # OTP 已提交成功：本次会话已消费，无论后续成败都清理 pending
+    _pending.pop(user_id, None)
+    try:
+        code, err = await _oidc_authorize(
+            session_cookie, pending.state, pending.verifier
+        )
+        if not code:
+            return {"success": False, "message": err, "expires_at": None}
+        tokens, err = await _exchange_code(code, pending.verifier)
+        if not tokens:
+            return {"success": False, "message": err, "expires_at": None}
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"用户 {user_id} 邮箱登录流程异常: {e}")
+        return {"success": False, "message": f"登录流程异常: {e}", "expires_at": None}
+
+    expires_at = await _persist_tokens(user_id, tokens)
+    return {
+        "success": True,
+        "message": "登录成功，Bearer 凭证已保存并切换为 Bearer 模式",
+        "expires_at": expires_at,
+    }

--- a/app/services/trakt/scheduler.py
+++ b/app/services/trakt/scheduler.py
@@ -22,7 +22,11 @@ from ..base.notifier_helpers import (
 )
 from .auth import trakt_auth_service
 from .sync_service import trakt_sync_service
-from .token_refresher import heartbeat_all_users
+from .token_refresher import (
+    STATUS_OK as BEARER_REFRESH_OK,
+    heartbeat_all_users,
+    refresh_user_bearer,
+)
 
 
 class TraktScheduler:
@@ -274,10 +278,18 @@ class TraktScheduler:
                 logger.info(f"用户 {user_id} 的 Trakt 同步已禁用，跳过")
                 return
 
-            # 检查令牌是否需要刷新
+            # 检查令牌是否需要刷新（按凭证模式分流：bearer 走 /oauth/token
+            # 旋转刷新，oauth 走既有授权码流程；纯 Bearer 用户无 Client ID/
+            # Secret，不能走 trakt_auth_service.refresh_token）
             if config.is_token_expired():
                 logger.info(f"用户 {user_id} 的 Trakt 令牌已过期，尝试刷新")
-                success = await trakt_auth_service.refresh_token(user_id)
+                if config.auth_type == "bearer":
+                    success = (
+                        await refresh_user_bearer(user_id, force=True)
+                        == BEARER_REFRESH_OK
+                    )
+                else:
+                    success = await trakt_auth_service.refresh_token(user_id)
                 if not success:
                     logger.error(f"用户 {user_id} 的 Trakt 令牌刷新失败，跳过同步")
                     return

--- a/app/services/trakt/scheduler.py
+++ b/app/services/trakt/scheduler.py
@@ -22,6 +22,7 @@ from ..base.notifier_helpers import (
 )
 from .auth import trakt_auth_service
 from .sync_service import trakt_sync_service
+from .token_refresher import heartbeat_all_users
 
 
 class TraktScheduler:
@@ -63,6 +64,9 @@ class TraktScheduler:
             # 为所有启用同步的用户创建定时任务
             self._schedule_all_users()
 
+            # Bearer 凭证每日心跳（自动续期）
+            self._schedule_token_heartbeat()
+
             return True
 
         except Exception as e:
@@ -81,6 +85,36 @@ class TraktScheduler:
         except Exception as e:
             logger.error(f"停止调度器失败: {e}")
             return False
+
+    def _schedule_token_heartbeat(self) -> None:
+        """注册 Bearer 凭证每日心跳任务（自动续期）。
+
+        access_token 7 天过期，refresh_token 旋转式；每日凌晨 4 点检查一次，
+        按 expires_at 智能触发（剩余 <1 天才真正刷新），远低于 7 天窗口，
+        即使个别心跳因网络失败也能在失效前多轮重试。
+        """
+        try:
+            if not self.scheduler or not self.scheduler.running:
+                logger.error("调度器未运行，无法注册 Bearer 心跳任务")
+                return
+            self.scheduler.add_job(
+                func=self._token_heartbeat_wrapper,
+                trigger=CronTrigger(hour="4"),
+                id="trakt_token_heartbeat",
+                name="Trakt Bearer 每日续期心跳",
+                replace_existing=True,
+            )
+            logger.info("Trakt Bearer 每日心跳任务已注册（每天 04:00）")
+        except Exception as e:
+            logger.error(f"注册 Trakt Bearer 心跳任务失败: {e}")
+
+    async def _token_heartbeat_wrapper(self) -> None:
+        """Bearer 心跳任务包装器：处理异常并通知。"""
+        try:
+            await heartbeat_all_users()
+        except Exception as e:
+            logger.error(f"Trakt Bearer 心跳执行失败: {e}")
+            notify_scheduler_failure("trakt", f"Bearer 心跳执行失败: {e}")
 
     def _schedule_all_users(self) -> None:
         """为所有启用同步的用户创建定时任务"""

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -19,8 +19,9 @@ from ...services.notification_service import notification_service
 from ...services.sync_service import sync_service
 from ...utils.media_type_detector import detect_media_type
 from .auth import trakt_auth_service
-from .client import TraktClient, TraktClientFactory
+from .client import TraktAuthError, TraktClient, TraktClientFactory
 from .models import TraktHistoryItem, TraktSyncResult
+from .token_refresher import STATUS_OK as BEARER_REFRESH_OK, refresh_user_bearer
 
 
 class TraktSyncService:
@@ -66,7 +67,7 @@ class TraktSyncService:
         if not config.access_token:
             return TraktSyncResult(
                 success=False,
-                message="Trakt 未授权，请先完成 OAuth 授权",
+                message="Trakt 未配置凭证，请先授权或填写 Bearer 凭证",
                 error_count=1,
                 synced_count=0,
                 skipped_count=0,
@@ -76,8 +77,7 @@ class TraktSyncService:
         # 检查令牌是否过期
         if config.is_token_expired():
             logger.warning(f"用户 {user_id} 的 Trakt 令牌已过期，尝试刷新")
-            success = await trakt_auth_service.refresh_token(user_id)
-            if not success:
+            if not await self._refresh_trakt_token(user_id, config):
                 return TraktSyncResult(
                     success=False,
                     message="Trakt 令牌过期且刷新失败",
@@ -102,52 +102,99 @@ class TraktSyncService:
                 details={},
             )
 
-        client = await TraktClientFactory.create_client(config.access_token)
-        if not client:
-            return TraktSyncResult(
-                success=False,
-                message="创建 Trakt 客户端失败",
-                error_count=1,
-                synced_count=0,
-                skipped_count=0,
-                details={},
-            )
-
+        # 同步主体；遇到 401（TraktAuthError）自动刷新凭证并重建客户端重试一次。
+        # 首次创建客户端也在循环内：创建时 401 同样触发刷新重试。
+        client: Optional[TraktClient] = None
+        auth_retried = False
         try:
-            synced_count = 0
-            skipped_count = 0
-            error_count = 0
-            details = {}
+            while True:
+                try:
+                    if client is None:
+                        client = await TraktClientFactory.create_client(
+                            config.access_token, auth_type=config.auth_type
+                        )
+                        if not client:
+                            return TraktSyncResult(
+                                success=False,
+                                message="创建 Trakt 客户端失败",
+                                error_count=1,
+                                synced_count=0,
+                                skipped_count=0,
+                                details={},
+                            )
 
-            # 同步观看历史（评分与收藏同步暂未实现）
-            if "history" in sync_types:
-                logger.info(f"开始同步用户 {user_id} 的 Trakt 观看历史")
-                history_result = await self._sync_watched_history(
-                    user_id, client, config, full_sync
-                )
-                synced_count += history_result.synced_count
-                skipped_count += history_result.skipped_count
-                error_count += history_result.error_count
-                details["history"] = history_result.details
+                    synced_count = 0
+                    skipped_count = 0
+                    error_count = 0
+                    details = {}
 
-            # 更新最后同步时间（只要没有错误就更新）
-            if error_count == 0 and config is not None:
-                config.last_sync_time = int(time.time())
-                await asyncio.to_thread(
-                    database_manager.save_trakt_config, config.to_dict()
-                )
+                    # 同步观看历史（评分与收藏同步暂未实现）
+                    if "history" in sync_types:
+                        logger.info(f"开始同步用户 {user_id} 的 Trakt 观看历史")
+                        history_result = await self._sync_watched_history(
+                            user_id, client, config, full_sync
+                        )
+                        synced_count += history_result.synced_count
+                        skipped_count += history_result.skipped_count
+                        error_count += history_result.error_count
+                        details["history"] = history_result.details
 
-            success = error_count == 0
+                    # 更新最后同步时间（只要没有错误就更新）
+                    if error_count == 0 and config is not None:
+                        config.last_sync_time = int(time.time())
+                        await asyncio.to_thread(
+                            database_manager.save_trakt_config, config.to_dict()
+                        )
 
-            return TraktSyncResult(
-                success=success,
-                message=f"同步完成: {synced_count} 成功, {skipped_count} 跳过, {error_count} 失败",
-                synced_count=synced_count,
-                skipped_count=skipped_count,
-                error_count=error_count,
-                details=details,
-            )
+                    success = error_count == 0
 
+                    return TraktSyncResult(
+                        success=success,
+                        message=f"同步完成: {synced_count} 成功, {skipped_count} 跳过, {error_count} 失败",
+                        synced_count=synced_count,
+                        skipped_count=skipped_count,
+                        error_count=error_count,
+                        details=details,
+                    )
+                except TraktAuthError:
+                    if auth_retried:
+                        logger.error(f"用户 {user_id} 刷新凭证后仍认证失败")
+                        return TraktSyncResult(
+                            success=False,
+                            message="Trakt 认证失败且刷新后仍失败",
+                            error_count=1,
+                            synced_count=0,
+                            skipped_count=0,
+                            details={},
+                        )
+                    auth_retried = True
+                    logger.warning(f"用户 {user_id} 同步中遇到 401，刷新凭证后重试")
+                    if not await self._refresh_trakt_token(user_id, config):
+                        return TraktSyncResult(
+                            success=False,
+                            message="Trakt 认证失败且刷新失败",
+                            error_count=1,
+                            synced_count=0,
+                            skipped_count=0,
+                            details={},
+                        )
+                    # 重新读取配置并重建客户端（旋转式刷新已换新 token）
+                    config = await asyncio.to_thread(
+                        trakt_auth_service.get_user_trakt_config, user_id
+                    )
+                    if config is None:
+                        return TraktSyncResult(
+                            success=False,
+                            message="Trakt 配置不存在",
+                            error_count=1,
+                            synced_count=0,
+                            skipped_count=0,
+                            details={},
+                        )
+                    if client is not None:
+                        await client.close()
+                    client = None  # 强制重建（刷新已换新 token）
+                    continue
         except Exception as e:
             logger.error(f"同步 Trakt 数据失败: {e}")
             return TraktSyncResult(
@@ -159,7 +206,18 @@ class TraktSyncService:
                 details={},
             )
         finally:
-            await client.close()
+            if client is not None:
+                await client.close()
+
+    async def _refresh_trakt_token(self, user_id: str, config) -> bool:
+        """按凭证模式刷新 Trakt token。
+
+        - oauth：走既有授权码流程（trakt_auth_service）
+        - bearer：用 refresh_token 走官方 /oauth/token 旋转刷新
+        """
+        if config.auth_type == "bearer":
+            return await refresh_user_bearer(user_id) == BEARER_REFRESH_OK
+        return await trakt_auth_service.refresh_token(user_id)
 
     def _filter_already_synced(
         self,
@@ -268,10 +326,14 @@ class TraktSyncService:
             *[_fetch_one(t, it, tid_int) for t, it, tid_int in fetch_tasks],
             return_exceptions=True,
         )
-        for tid, resp in results:
-            if isinstance(resp, Exception):
-                logger.debug(f"获取 Trakt 详情失败: {resp}")
+        for result in results:
+            if isinstance(result, Exception):
+                if isinstance(result, TraktAuthError):
+                    # 401：token 失效，向上传播触发整体刷新重试
+                    raise result
+                logger.debug(f"获取 Trakt 详情失败: {result}")
                 continue
+            tid, resp = result
             if resp:
                 ot = resp.get("original_title")
                 if ot:

--- a/app/services/trakt/sync_service.py
+++ b/app/services/trakt/sync_service.py
@@ -140,10 +140,14 @@ class TraktSyncService:
                         details["history"] = history_result.details
 
                     # 更新最后同步时间（只要没有错误就更新）
+                    # 只写 last_sync_time，不触碰 token 列：避免用本次同步开始时
+                    # 读到的旧 token 覆盖并发刷新（心跳等）旋转后的新 token
                     if error_count == 0 and config is not None:
                         config.last_sync_time = int(time.time())
                         await asyncio.to_thread(
-                            database_manager.save_trakt_config, config.to_dict()
+                            database_manager.update_trakt_config_fields,
+                            config.user_id,
+                            {"last_sync_time": config.last_sync_time},
                         )
 
                     success = error_count == 0
@@ -213,10 +217,13 @@ class TraktSyncService:
         """按凭证模式刷新 Trakt token。
 
         - oauth：走既有授权码流程（trakt_auth_service）
-        - bearer：用 refresh_token 走官方 /oauth/token 旋转刷新
+        - bearer：用 refresh_token 走官方 /oauth/token 旋转刷新。
+          401 路径必须 force=True：本地 expires_at 可能仍认为有效（提前吊销/
+          时钟差/粘贴了已旋转过的 token），按 slack 跳过会把「认证失败」
+          误判成「刷新失败」。
         """
         if config.auth_type == "bearer":
-            return await refresh_user_bearer(user_id) == BEARER_REFRESH_OK
+            return await refresh_user_bearer(user_id, force=True) == BEARER_REFRESH_OK
         return await trakt_auth_service.refresh_token(user_id)
 
     def _filter_already_synced(
@@ -578,6 +585,9 @@ class TraktSyncService:
                 details={"items": details},
             )
 
+        except TraktAuthError:
+            # 401：token 失效，向上传播触发整体刷新重试（不当作普通失败结果）
+            raise
         except Exception as e:
             logger.error(f"同步观看历史失败: {e}")
             notify_source_event(

--- a/app/services/trakt/token_refresher.py
+++ b/app/services/trakt/token_refresher.py
@@ -11,10 +11,17 @@ Trakt Bearer 凭证续期服务（OAuth2 Bearer · apiz.trakt.tv 数据域）
 本服务职责：
 1. 保存凭证时立即验证刷新（validate_and_save_bearer）
 2. 由 TraktScheduler 的每日心跳驱动，对「bearer 模式且启用」的用户按
-   expires_at 智能续期（剩余 <1 天才真正调 /oauth/token）
+   expires_at 智能续期（剩余 <1 天才真正调 /oauth/token）；同步层 401
+   路径以 force=True 强制刷新（本地 expires_at 仍有效但服务端已 401）
 3. 刷新失败（invalid_grant）判定失效并通知
+
+并发安全：refresh_token 为旋转式（旧值作废），心跳/定时同步/手动同步/
+保存凭证可并行触发刷新。所有刷新与保存凭证入口按 user_id 持 per-user
+asyncio.Lock，持锁后重读配置并 double-check，避免两个协程各自读到旧
+refresh 后先后落库把对方新换的 token 盖掉。
 """
 
+import asyncio
 import time
 from typing import Optional
 
@@ -38,6 +45,22 @@ STATUS_OK = "ok"  # 刷新成功（旋转式换新并落库）
 STATUS_EXPIRED = "expired"  # invalid_grant：refresh 失效，需重新填写
 STATUS_FAILED = "failed"  # 网络/服务端错误，非失效，下次心跳重试
 STATUS_SKIPPED = "skipped"  # 无需刷新 / 非 bearer 模式 / 无 refresh_token
+
+# per-user 刷新锁：防止并发（心跳 + 定时/手动同步 + 保存凭证）同时读到
+# 旧 refresh_token，各自旋转后互相覆盖。与 TraktAuthService（oauth 路径）
+# 的 _refresh_locks 设计一致。
+_refresh_locks: dict[str, asyncio.Lock] = {}
+_locks_guard = asyncio.Lock()
+
+
+async def _get_refresh_lock(user_id: str) -> asyncio.Lock:
+    """获取指定用户的刷新锁（per-user，避免不同用户互相阻塞）。"""
+    async with _locks_guard:
+        lock = _refresh_locks.get(user_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _refresh_locks[user_id] = lock
+        return lock
 
 
 async def _call_oauth_token(
@@ -87,105 +110,156 @@ def _resolve_expires_at(data: dict) -> int:
     return int(time.time()) + int(data.get("expires_in", DEFAULT_EXPIRES_IN))
 
 
-async def validate_and_save_bearer(
-    user_id: str, access_token: str, refresh_token: str
-) -> dict:
+def _extract_new_tokens(data: dict) -> Optional[tuple[str, str]]:
+    """从 /oauth/token 响应提取 (access_token, refresh_token)。
+
+    缺字段时返回 None（响应异常，避免 KeyError 500）。
+    """
+    access = data.get("access_token") or ""
+    refresh = data.get("refresh_token") or ""
+    if not access or not refresh:
+        return None
+    return access, refresh
+
+
+async def validate_and_save_bearer(user_id: str, refresh_token: str) -> dict:
     """保存 Bearer 凭证：立即调 /oauth/token 验证并刷新。
 
     - 200：凭证有效，旋转式换新 access/refresh/expires_at 落库（auth_type=bearer）
     - invalid_grant：凭证无效/已过期，不落库
     - 其他错误：不落库，返回错误
 
+    Args:
+        user_id: 用户名。
+        refresh_token: 用户从浏览器粘贴的 refresh_token（access_token 无需
+            单独校验：/oauth/token 刷新成功即证明凭证对有效，且会旋转换新）。
+
     Returns:
         {"success": bool, "message": str, "expires_at": Optional[int]}
     """
-    status, data, err = await _call_oauth_token(refresh_token)
+    lock = await _get_refresh_lock(user_id)
+    async with lock:
+        status, data, err = await _call_oauth_token(refresh_token)
 
-    if status == "invalid_grant":
+        if status == "invalid_grant":
+            return {
+                "success": False,
+                "message": "凭证无效或已过期（invalid_grant），请重新从浏览器复制",
+                "expires_at": None,
+            }
+        if status != "ok":
+            return {
+                "success": False,
+                "message": f"凭证验证失败: {err}",
+                "expires_at": None,
+            }
+
+        new_tokens = _extract_new_tokens(data)
+        if new_tokens is None:
+            return {
+                "success": False,
+                "message": "凭证验证失败: 刷新响应缺少 access_token / refresh_token",
+                "expires_at": None,
+            }
+        access, refresh = new_tokens
+
+        config_dict = database_manager.get_trakt_config(user_id)
+        config = (
+            TraktConfig.from_dict(config_dict)
+            if config_dict
+            else TraktConfig(user_id=user_id)
+        )
+        config.auth_type = "bearer"
+        config.access_token = access
+        config.refresh_token = refresh  # 旋转式，落库新值
+        config.expires_at = _resolve_expires_at(data)
+        database_manager.save_trakt_config(config.to_dict())
+        logger.info(
+            f"用户 {user_id} 的 Trakt Bearer 凭证已验证并保存，"
+            f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
+        )
         return {
-            "success": False,
-            "message": "凭证无效或已过期（invalid_grant），请重新从浏览器复制",
-            "expires_at": None,
-        }
-    if status != "ok":
-        return {
-            "success": False,
-            "message": f"凭证验证失败: {err}",
-            "expires_at": None,
+            "success": True,
+            "message": "凭证有效，已保存",
+            "expires_at": config.expires_at,
         }
 
-    config_dict = database_manager.get_trakt_config(user_id)
-    config = (
-        TraktConfig.from_dict(config_dict)
-        if config_dict
-        else TraktConfig(user_id=user_id)
-    )
-    config.auth_type = "bearer"
-    config.access_token = data["access_token"]
-    config.refresh_token = data["refresh_token"]  # 旋转式，落库新值
-    config.expires_at = _resolve_expires_at(data)
-    database_manager.save_trakt_config(config.to_dict())
-    logger.info(
-        f"用户 {user_id} 的 Trakt Bearer 凭证已验证并保存，"
-        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
-    )
-    return {
-        "success": True,
-        "message": "凭证有效，已保存",
-        "expires_at": config.expires_at,
-    }
 
-
-async def refresh_user_bearer(user_id: str) -> str:
+async def refresh_user_bearer(user_id: str, force: bool = False) -> str:
     """对单个用户执行一次 Bearer 续期检查，并更新存储。
+
+    Args:
+        user_id: 用户名。
+        force: 为 True 时忽略 expires_at 的 slack 判断，强制调 /oauth/token。
+            同步层 401 路径必须 force=True：本地 expires_at 可能仍认为有效
+            （提前吊销 / 时钟差 / 粘贴了已旋转过的 token），此时按 slack
+            跳过会让「认证失败」被误判为「刷新失败」。心跳可继续用 slack。
 
     Returns:
         STATUS_OK / STATUS_EXPIRED / STATUS_FAILED / STATUS_SKIPPED
     """
-    config_dict = database_manager.get_trakt_config(user_id)
-    if not config_dict:
-        return STATUS_SKIPPED
-    config = TraktConfig.from_dict(config_dict)
-    if not config or config.auth_type != "bearer" or not config.refresh_token:
-        return STATUS_SKIPPED
+    lock = await _get_refresh_lock(user_id)
+    async with lock:
+        # 持锁后重读配置，可能已被并发协程刷新
+        config_dict = database_manager.get_trakt_config(user_id)
+        if not config_dict:
+            return STATUS_SKIPPED
+        config = TraktConfig.from_dict(config_dict)
+        if not config or config.auth_type != "bearer" or not config.refresh_token:
+            return STATUS_SKIPPED
 
-    # 按 expires_at 智能触发：剩余 >1 天不刷新（避免无效请求）
-    if config.expires_at and time.time() < config.expires_at - REFRESH_SLACK:
-        return STATUS_SKIPPED
+        # 按 expires_at 智能触发：剩余 >1 天不刷新（避免无效请求）
+        # force=True 时跳过该判断（同步层 401 必须真正调 /oauth/token）
+        if (
+            not force
+            and config.expires_at
+            and time.time() < config.expires_at - REFRESH_SLACK
+        ):
+            return STATUS_SKIPPED
 
-    status, data, err = await _call_oauth_token(config.refresh_token)
+        status, data, err = await _call_oauth_token(config.refresh_token)
 
-    if status == "invalid_grant":
-        # refresh 失效：标记失效（expires_at 置 0）+ 通知，保留配置供重新填写
-        config.expires_at = 0
+        if status == "invalid_grant":
+            # refresh 失效：标记失效（expires_at 置 0）+ 通知，保留配置供重新填写
+            config.expires_at = 0
+            config.updated_at = int(time.time())
+            database_manager.save_trakt_config(config.to_dict())
+            logger.warning(
+                f"用户 {user_id} 的 Trakt Bearer 凭证已失效（invalid_grant），需重新填写"
+            )
+            notify_scheduler_failure(
+                "trakt",
+                f"用户 {user_id} 的 Trakt Bearer 凭证已失效，请重新填写",
+                user_id=user_id,
+            )
+            return STATUS_EXPIRED
+
+        if status != "ok":
+            # 网络/服务端错误：非失效，保留原状态，下次心跳重试
+            logger.warning(
+                f"用户 {user_id} 的 Trakt Bearer 刷新失败（{err}），保留原状态"
+            )
+            return STATUS_FAILED
+
+        new_tokens = _extract_new_tokens(data)
+        if new_tokens is None:
+            logger.warning(
+                f"用户 {user_id} 的 Trakt Bearer 刷新响应缺少 token 字段，保留原状态"
+            )
+            return STATUS_FAILED
+        access, refresh = new_tokens
+
+        # ok：旋转式换新 access/refresh/expires_at 落库
+        config.access_token = access
+        config.refresh_token = refresh
+        config.expires_at = _resolve_expires_at(data)
         config.updated_at = int(time.time())
         database_manager.save_trakt_config(config.to_dict())
-        logger.warning(
-            f"用户 {user_id} 的 Trakt Bearer 凭证已失效（invalid_grant），需重新填写"
+        logger.info(
+            f"用户 {user_id} 的 Trakt Bearer 凭证已续期，"
+            f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
         )
-        notify_scheduler_failure(
-            "trakt",
-            f"用户 {user_id} 的 Trakt Bearer 凭证已失效，请重新填写",
-            user_id=user_id,
-        )
-        return STATUS_EXPIRED
-
-    if status != "ok":
-        # 网络/服务端错误：非失效，保留原状态，下次心跳重试
-        logger.warning(f"用户 {user_id} 的 Trakt Bearer 刷新失败（{err}），保留原状态")
-        return STATUS_FAILED
-
-    # ok：旋转式换新 access/refresh/expires_at 落库
-    config.access_token = data["access_token"]
-    config.refresh_token = data["refresh_token"]
-    config.expires_at = _resolve_expires_at(data)
-    config.updated_at = int(time.time())
-    database_manager.save_trakt_config(config.to_dict())
-    logger.info(
-        f"用户 {user_id} 的 Trakt Bearer 凭证已续期，"
-        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
-    )
-    return STATUS_OK
+        return STATUS_OK
 
 
 async def heartbeat_all_users() -> dict:

--- a/app/services/trakt/token_refresher.py
+++ b/app/services/trakt/token_refresher.py
@@ -1,0 +1,229 @@
+"""
+Trakt Bearer 凭证续期服务（OAuth2 Bearer · apiz.trakt.tv 数据域）
+
+认证链（trakt.tv 已实测验证，见 firefox-reversed 逆向资料）：
+- 数据请求认证 = ``Authorization: Bearer <access_token>``（opaque 32 字符，7 天）
+- 刷新 = ``POST https://auth.trakt.tv/oauth/token``
+  body: ``{"grant_type": "refresh_token", "refresh_token": ..., "client_id": 201dc70c...}``
+- refresh_token 为旋转式：每次刷新旧值立即作废，必须持久化新值
+- 401 表现 = ``WWW-Authenticate: Bearer error="invalid_token"``，刷新后重试即恢复
+
+本服务职责：
+1. 保存凭证时立即验证刷新（validate_and_save_bearer）
+2. 由 TraktScheduler 的每日心跳驱动，对「bearer 模式且启用」的用户按
+   expires_at 智能续期（剩余 <1 天才真正调 /oauth/token）
+3. 刷新失败（invalid_grant）判定失效并通知
+"""
+
+import time
+from typing import Optional
+
+from ...core.database import database_manager
+from ...core.logging import logger
+from ...models.trakt import TraktConfig
+from ...utils.http_base import AsyncHttpClient
+from ..base.notifier_helpers import notify_scheduler_failure
+from .client import TRAKT_API_KEY, TRAKT_OAUTH_TOKEN_URL
+
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0"
+)
+# 剩余 <1 天才触发刷新（access 有效期 7 天）
+REFRESH_SLACK = 86400
+# access_token 默认有效期（秒），响应缺 expires_at 时兜底
+DEFAULT_EXPIRES_IN = 604800
+
+# 心跳结果状态
+STATUS_OK = "ok"  # 刷新成功（旋转式换新并落库）
+STATUS_EXPIRED = "expired"  # invalid_grant：refresh 失效，需重新填写
+STATUS_FAILED = "failed"  # 网络/服务端错误，非失效，下次心跳重试
+STATUS_SKIPPED = "skipped"  # 无需刷新 / 非 bearer 模式 / 无 refresh_token
+
+
+async def _call_oauth_token(
+    refresh_token: str,
+) -> tuple[str, Optional[dict], Optional[str]]:
+    """调用 /oauth/token 刷新。
+
+    Returns:
+        (status, data, error_msg)：status 为 "ok" / "invalid_grant" / "error"
+    """
+    http = (
+        AsyncHttpClient(label="TraktToken", timeout=30.0)
+        .prefix("🔑")
+        .success_tpl("TraktToken refresh [{status_code}]")
+        .failure_tpl("TraktToken refresh 失败: {error_type}")
+    )
+    try:
+        resp = await http.request(
+            "POST",
+            TRAKT_OAUTH_TOKEN_URL,
+            json={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": TRAKT_API_KEY,
+            },
+            headers={
+                "content-type": "application/json",
+                "user-agent": USER_AGENT,
+            },
+        )
+        if resp.status_code == 200:
+            return "ok", resp.json(), None
+        body = resp.text or ""
+        if resp.status_code == 400 and "invalid_grant" in body:
+            return "invalid_grant", None, body[:200]
+        return "error", None, f"HTTP {resp.status_code}: {body[:200]}"
+    except Exception as e:  # noqa: BLE001
+        return "error", None, str(e)
+    finally:
+        await http.aclose()
+
+
+def _resolve_expires_at(data: dict) -> int:
+    """从 /oauth/token 响应解析 expires_at（unix 秒），缺省用 expires_in 兜底。"""
+    if data.get("expires_at"):
+        return int(data["expires_at"])
+    return int(time.time()) + int(data.get("expires_in", DEFAULT_EXPIRES_IN))
+
+
+async def validate_and_save_bearer(
+    user_id: str, access_token: str, refresh_token: str
+) -> dict:
+    """保存 Bearer 凭证：立即调 /oauth/token 验证并刷新。
+
+    - 200：凭证有效，旋转式换新 access/refresh/expires_at 落库（auth_type=bearer）
+    - invalid_grant：凭证无效/已过期，不落库
+    - 其他错误：不落库，返回错误
+
+    Returns:
+        {"success": bool, "message": str, "expires_at": Optional[int]}
+    """
+    status, data, err = await _call_oauth_token(refresh_token)
+
+    if status == "invalid_grant":
+        return {
+            "success": False,
+            "message": "凭证无效或已过期（invalid_grant），请重新从浏览器复制",
+            "expires_at": None,
+        }
+    if status != "ok":
+        return {
+            "success": False,
+            "message": f"凭证验证失败: {err}",
+            "expires_at": None,
+        }
+
+    config_dict = database_manager.get_trakt_config(user_id)
+    config = (
+        TraktConfig.from_dict(config_dict)
+        if config_dict
+        else TraktConfig(user_id=user_id)
+    )
+    config.auth_type = "bearer"
+    config.access_token = data["access_token"]
+    config.refresh_token = data["refresh_token"]  # 旋转式，落库新值
+    config.expires_at = _resolve_expires_at(data)
+    database_manager.save_trakt_config(config.to_dict())
+    logger.info(
+        f"用户 {user_id} 的 Trakt Bearer 凭证已验证并保存，"
+        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
+    )
+    return {
+        "success": True,
+        "message": "凭证有效，已保存",
+        "expires_at": config.expires_at,
+    }
+
+
+async def refresh_user_bearer(user_id: str) -> str:
+    """对单个用户执行一次 Bearer 续期检查，并更新存储。
+
+    Returns:
+        STATUS_OK / STATUS_EXPIRED / STATUS_FAILED / STATUS_SKIPPED
+    """
+    config_dict = database_manager.get_trakt_config(user_id)
+    if not config_dict:
+        return STATUS_SKIPPED
+    config = TraktConfig.from_dict(config_dict)
+    if not config or config.auth_type != "bearer" or not config.refresh_token:
+        return STATUS_SKIPPED
+
+    # 按 expires_at 智能触发：剩余 >1 天不刷新（避免无效请求）
+    if config.expires_at and time.time() < config.expires_at - REFRESH_SLACK:
+        return STATUS_SKIPPED
+
+    status, data, err = await _call_oauth_token(config.refresh_token)
+
+    if status == "invalid_grant":
+        # refresh 失效：标记失效（expires_at 置 0）+ 通知，保留配置供重新填写
+        config.expires_at = 0
+        config.updated_at = int(time.time())
+        database_manager.save_trakt_config(config.to_dict())
+        logger.warning(
+            f"用户 {user_id} 的 Trakt Bearer 凭证已失效（invalid_grant），需重新填写"
+        )
+        notify_scheduler_failure(
+            "trakt",
+            f"用户 {user_id} 的 Trakt Bearer 凭证已失效，请重新填写",
+            user_id=user_id,
+        )
+        return STATUS_EXPIRED
+
+    if status != "ok":
+        # 网络/服务端错误：非失效，保留原状态，下次心跳重试
+        logger.warning(f"用户 {user_id} 的 Trakt Bearer 刷新失败（{err}），保留原状态")
+        return STATUS_FAILED
+
+    # ok：旋转式换新 access/refresh/expires_at 落库
+    config.access_token = data["access_token"]
+    config.refresh_token = data["refresh_token"]
+    config.expires_at = _resolve_expires_at(data)
+    config.updated_at = int(time.time())
+    database_manager.save_trakt_config(config.to_dict())
+    logger.info(
+        f"用户 {user_id} 的 Trakt Bearer 凭证已续期，"
+        f"有效期至 {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(config.expires_at))}"
+    )
+    return STATUS_OK
+
+
+async def heartbeat_all_users() -> dict:
+    """每日心跳：对所有「bearer 模式且启用」的用户按 expires_at 智能续期。
+
+    Returns:
+        {"checked": n, "ok": n, "expired": n, "failed": n, "skipped": n}
+    """
+    results = {"checked": 0, "ok": 0, "expired": 0, "failed": 0, "skipped": 0}
+    try:
+        configs = database_manager.get_trakt_configs_with_sync_enabled()
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"Trakt Bearer 心跳：读取启用配置失败: {e}")
+        return results
+
+    for cfg in configs:
+        config = TraktConfig.from_dict(cfg)
+        if not config or config.auth_type != "bearer" or not config.refresh_token:
+            continue
+        results["checked"] += 1
+        try:
+            status = await refresh_user_bearer(config.user_id)
+            if status == STATUS_OK:
+                results["ok"] += 1
+            elif status == STATUS_EXPIRED:
+                results["expired"] += 1
+            elif status == STATUS_SKIPPED:
+                results["skipped"] += 1
+            else:
+                results["failed"] += 1
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"用户 {config.user_id} 的 Bearer 续期异常: {e}")
+            results["failed"] += 1
+
+    logger.info(
+        "Trakt Bearer 每日心跳完成: "
+        f"检查 {results['checked']} 个用户, "
+        f"{results['ok']} 续期, {results['expired']} 失效, "
+        f"{results['failed']} 失败, {results['skipped']} 跳过"
+    )
+    return results

--- a/app/utils/http_base.py
+++ b/app/utils/http_base.py
@@ -28,13 +28,40 @@ import json as _json
 import time
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 import httpx
 
 from ..core.logging import logger
 from .http_client import create_async_client, create_sync_client
 from .retry import RETRY_EXCEPTIONS, RETRY_STATUS_CODES, compute_backoff_delay
+
+# ===== 敏感信息脱敏 =====
+# 键名（头 / JSON / 表单字段）包含以下子串即视为敏感，DEBUG 详情日志中值置 ***。
+# 避免 email_login / token 刷新等请求把 OTP、cookie、access/refresh token
+# 写进日志（log.txt）。
+_SENSITIVE_KEY_PARTS = (
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "otp",
+    "verifier",
+    "cookie",
+    "authorization",
+    "api_key",
+    "apikey",
+)
+# 精确匹配的敏感键（避免 "code" 子串误伤 status_code / country_code 等）
+_SENSITIVE_EXACT_KEYS = {"code", "state", "id_token"}
+
+
+def _is_sensitive_key(name: str) -> bool:
+    """判断键名是否敏感（头 / JSON 键 / 表单字段名）。"""
+    low = str(name).lower()
+    return low in _SENSITIVE_EXACT_KEYS or any(
+        part in low for part in _SENSITIVE_KEY_PARTS
+    )
 
 
 class HttpClientBase:
@@ -153,8 +180,84 @@ class HttpClientBase:
         host = urlparse(url).hostname or ""
         return "[ECH] " if is_ech_host(host) else ""
 
+    # ===== 敏感信息脱敏（DEBUG 详情日志不得泄漏 token/验证码/会话） =====
+
+    def _redact_url_query(self, value: Any) -> Any:
+        """对 URL 字符串中的敏感 query 参数（code/state 等）脱敏。
+
+        授权回调的 code/state 出现在 302 Location 头与 JSON url 字段里，
+        仅按键名脱敏覆盖不到，必须对 URL query 逐项处理。
+        """
+        if not isinstance(value, str) or "?" not in value:
+            return value
+        try:
+            parts = urlparse(value)
+            if not parts.query:
+                return value
+            pairs = parse_qsl(parts.query, keep_blank_values=True)
+            query = "&".join(
+                f"{k}=***" if _is_sensitive_key(k) else f"{k}={v}" for k, v in pairs
+            )
+            return urlunparse(
+                (
+                    parts.scheme,
+                    parts.netloc,
+                    parts.path,
+                    parts.params,
+                    query,
+                    parts.fragment,
+                )
+            )
+        except ValueError:
+            return value
+
+    def _redact_headers(self, headers: Any) -> dict:
+        """请求/响应头脱敏：Authorization / Cookie / Set-Cookie 等敏感头值置 ***；
+        URL 型头值（如 Location）中的 code/state 参数脱敏。"""
+        return {
+            k: ("***" if _is_sensitive_key(k) else self._redact_url_query(v))
+            for k, v in dict(headers).items()
+        }
+
+    def _redact_body(self, body: Any) -> Any:
+        """请求体脱敏：dict 按敏感键置 *** 并对 URL 型字符串值脱敏；
+        表单串按 k=v 解析后逐项脱敏。"""
+        if isinstance(body, dict):
+            return {
+                k: ("***" if _is_sensitive_key(k) else self._redact_url_query(v))
+                for k, v in body.items()
+            }
+        if isinstance(body, str):
+            pairs = []
+            for pair in body.split("&"):
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
+                    pairs.append(f"{k}=***" if _is_sensitive_key(k) else pair)
+                else:
+                    pairs.append(pair)
+            return "&".join(pairs)
+        return body
+
+    def _redact_response_body(self, text: str) -> str:
+        """响应体脱敏：JSON 对象的敏感键（如 /oauth/token 的 access/refresh）置 ***，
+        URL 型字符串值（如授权回跳 url）中的 code/state 参数脱敏。"""
+        if not text:
+            return "<空>"
+        try:
+            data = _json.loads(text)
+        except (ValueError, TypeError):
+            return text[:500]
+        if isinstance(data, dict):
+            try:
+                return _json.dumps(
+                    self._redact_body(data), ensure_ascii=False, default=str
+                )[:500]
+            except (TypeError, ValueError):
+                return text[:500]
+        return text[:500]
+
     def _log_request(self, method: str, url: str, **kwargs: Any) -> None:
-        """DEBUG: 请求详情（method, url, headers, params, body）"""
+        """DEBUG: 请求详情（method, url, headers, params, body，敏感字段脱敏）"""
         if self._silent_request:
             return
         parts: list[str] = [
@@ -163,30 +266,30 @@ class HttpClientBase:
 
         headers = kwargs.get("headers")
         if headers:
-            parts.append(f"  Headers: {dict(headers)}")
+            parts.append(f"  Headers: {self._redact_headers(headers)}")
 
         params = kwargs.get("params")
         if params:
-            parts.append(f"  Params: {dict(params)}")
+            parts.append(f"  Params: {self._redact_body(params)}")
 
         json_body = kwargs.get("json")
         if json_body is not None:
             try:
                 parts.append(
                     f"  Body(JSON): "
-                    f"{_json.dumps(json_body, ensure_ascii=False, default=str)[:500]}"
+                    f"{_json.dumps(self._redact_body(json_body), ensure_ascii=False, default=str)[:500]}"
                 )
             except (TypeError, ValueError):
                 parts.append("  Body(JSON): <无法序列化>")
 
         data_body = kwargs.get("data")
         if data_body is not None:
-            parts.append(f"  Body(Form): {data_body}")
+            parts.append(f"  Body(Form): {self._redact_body(data_body)}")
 
         logger.debug("\n".join(parts))
 
     def _log_success(self, response: httpx.Response, method: str, url: str) -> None:
-        """DEBUG: 成功摘要（prefix + 技术信息）+ 响应详情"""
+        """DEBUG: 成功摘要（prefix + 技术信息）+ 响应详情（敏感字段脱敏）"""
         if self._silent_request:
             return
         elapsed = response.elapsed.total_seconds()
@@ -199,9 +302,8 @@ class HttpClientBase:
         parts: list[str] = [
             f"{self._ech_tag(url)}[{self._label}] 响应 ← {response.status_code} ({elapsed:.2f}s)"
         ]
-        parts.append(f"  Headers: {dict(response.headers)}")
-        body = response.text[:500] if response.text else "<空>"
-        parts.append(f"  Body: {body}")
+        parts.append(f"  Headers: {self._redact_headers(response.headers)}")
+        parts.append(f"  Body: {self._redact_response_body(response.text)}")
         logger.debug("\n".join(parts))
 
     def _log_failure(self, error: Exception, method: str, url: str) -> None:

--- a/docs/development/trakt-login-protocol.md
+++ b/docs/development/trakt-login-protocol.md
@@ -1,0 +1,135 @@
+---
+title: 📧 Trakt 邮箱登录协议
+order: 11
+---
+
+# 📧 Trakt 邮箱登录协议
+
+`app/services/trakt/email_login.py` 实现的「邮箱 + 验证码一键登录」所依赖的
+Trakt 认证协议逆向说明。该链路让**非会员/无法创建 OAuth 应用**的用户也能拿到
+Bearer 凭证（access_token / refresh_token），从而使用 `apiz.trakt.tv` 数据域
+同步，无需 Client ID / Secret / 回调地址。
+
+> 本页面向维护者，属于逆向协议文档。用户侧使用说明见
+> [Trakt 使用文档](/usage/trakt)「Bearer 凭证模式」一节。
+
+## 背景
+
+- Trakt 限制免费用户：非会员无法创建 OAuth 应用，且授权应用数量受限。
+- 网页版（app.trakt.tv）登录后，前端会持有 `access_token` / `refresh_token`，
+  数据请求通过 `Authorization: Bearer <access_token>` 认证。
+- 本项目复用 Trakt 官方静态 client_id（`TRAKT_API_KEY`）与官方 OAuth2 token
+  端点，通过「邮箱登录」在服务端复刻网页版登录流程，自动换取并落库凭证。
+
+## 认证链（4 步）
+
+整体流程见 `email_login.py`，各步骤协议细节如下。
+
+### ① 发送登录邮件
+
+```
+POST https://auth.trakt.tv/auth/magic
+Content-Type: application/x-www-form-urlencoded
+
+email=<urlencoded>
+```
+
+- 向邮箱发送一封含 **6 位 OTP** 的登录邮件，**5 分钟**有效。
+- 同一邮箱重复发信会**作废旧 OTP**（以最新邮件为准）。
+- 响应头 `Set-Cookie: __Secure-better-auth.session_token=...`（Better Auth 会话）。
+
+### ② 提交 OTP
+
+```
+POST https://auth.trakt.tv/auth/magic/submit
+Content-Type: application/x-www-form-urlencoded
+
+email=<urlencoded>&otp=<6位>
+```
+
+- `200`：OTP 有效，响应头 `Set-Cookie: __Secure-better-auth.session_token=<value>`
+  为已登录会话 cookie，后续 authorize 请求需携带。
+- `401`：OTP 无效或已过期（服务端对错误 OTP 返回 401，可据此区分重试与重发）。
+
+### ③ OIDC 授权码流（PKCE S256）
+
+```
+GET https://auth.trakt.tv/api/auth/oauth2/authorize
+Cookie: __Secure-better-auth.session_token=<value>
+
+response_type=code
+client_id=<TRAKT_API_KEY>
+redirect_uri=https://app.trakt.tv/callback
+scope=public openid profile email offline_access
+code_challenge=<S256(verifier)>
+code_challenge_method=S256
+state=<随机>
+```
+
+- 已登录（带会话 cookie）时直接下发授权码，无确认页。
+- 授权码通过两种方式之一回传：
+  - **302 跳转**：`Location: https://app.trakt.tv/callback?code=...&state=...`
+  - **200 + JSON**（SvelteKit 实测路径）：
+    `{"redirect": true, "url": "https://app.trakt.tv/callback?code=...&state=..."}`
+- 必须校验回跳中的 `state` 与发起时一致（**fail-closed**，缺失或不等一律拒绝），
+  防止 CSRF / 授权码注入。
+
+### ④ 授权码换 token
+
+```
+POST https://auth.trakt.tv/oauth/token
+Content-Type: application/json
+
+{
+  "grant_type": "authorization_code",
+  "code": <授权码>,
+  "redirect_uri": "https://app.trakt.tv/callback",
+  "client_id": <TRAKT_API_KEY>,
+  "code_verifier": <PKCE verifier>
+}
+```
+
+- `200` 响应：
+  `{access_token, refresh_token, expires_in, expires_at, token_type, scope, id_token}`。
+- `access_token` 约 7 天有效；`refresh_token` 为**旋转式**（每次刷新旧值立即作废）。
+
+## 凭证续期（Bearer 模式）
+
+`app/services/trakt/token_refresher.py` 实现续期：
+
+```
+POST https://auth.trakt.tv/oauth/token
+Content-Type: application/json
+
+{
+  "grant_type": "refresh_token",
+  "refresh_token": <refresh_token>,
+  "client_id": <TRAKT_API_KEY>
+}
+```
+
+- `200`：旋转换新 `access_token` / `refresh_token` / `expires_at`，落库新值。
+- `400` + body 含 `invalid_grant`：refresh 已失效（旋转作废 / 被吊销），
+  判定凭证失效并通知用户重新填写。
+- 数据请求 401 时：`Authorization: Bearer <access_token>` 失效，刷新后重试即恢复。
+
+## 实现要点（对应评审修复）
+
+| 关注点 | 实现 |
+| --- | --- |
+| 并发旋转安全 | 按 user_id 持 `asyncio.Lock`，刷新/保存凭证持锁后重读配置 double-check，防止并发互相覆盖新 token |
+| 401 强制刷新 | 同步层 401 路径以 `force=True` 调刷新，忽略本地 `expires_at` 的 slack 判断 |
+| 心跳智能续期 | 每日心跳按 `expires_at` 剩余 <1 天才真正调 `/oauth/token` |
+| OTP 防爆破 | 提交失败计数，超 `MAX_OTP_ATTEMPTS`（5 次）作废会话需重发 |
+| 发信限流 | 同一用户 60s 冷却，冷却期返回 429 + `retry_after` |
+| state 校验 | 回跳 `state` 缺失或与发起时不一致一律拒绝（fail-closed） |
+| 密钥防泄漏 | `AsyncHttpClient` DEBUG 日志对 Authorization / Cookie / Set-Cookie / token / otp / code / verifier 等字段脱敏 |
+
+## 相关代码
+
+| 文件 | 职责 |
+| --- | --- |
+| `app/services/trakt/email_login.py` | 邮箱登录 4 步协议（发信 → OTP → OIDC → 换 token） |
+| `app/services/trakt/token_refresher.py` | Bearer 凭证验证保存 / 续期 / 心跳 |
+| `app/services/trakt/client.py` | `TRAKT_API_KEY`、`TRAKT_OAUTH_TOKEN_URL`、`TraktClient`（apiz 数据域） |
+| `app/api/trakt.py` | `POST /api/trakt/email-login/start` 与 `/complete` 端点 |

--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -40,7 +40,7 @@ order: 15
 ## Bearer 凭证模式（备选，无需创建 Trakt 应用）
 
 不想创建 Trakt 应用 / 无法配置回调地址时，可改用 **Bearer 凭证模式**：
-直接提供 Trakt 账号的 access_token 与 refresh_token，数据走官方数据域
+直接提供 Trakt 账号的 refresh_token，数据走官方数据域
 `apiz.trakt.tv`，无需 Client ID / Secret / 回调地址。
 
 ### 方式一：通过邮箱一键登录（推荐）
@@ -64,8 +64,7 @@ Trakt 同步记录能正确路由。
 2. 按 F12 打开开发者工具 → Application → Local Storage
 3. 展开 `https://auth.trakt.tv`，找到 `oidc.user:https://auth.trakt.tv:201dc70c...`
    键，复制其中的 `refresh_token`
-4. 在「Bearer 凭证」卡片中粘贴并保存（只需 refresh_token；access_token 可选，
-   保存时后端会用它验证并自动换新）
+4. 在「Bearer 凭证」卡片中粘贴并保存（只需 refresh_token，保存时后端会自动换取新的 access/refresh）
 
 ::: tip 凭证说明
 - 只需提供 **refresh_token**：保存时后端会立即验证并旋转刷新，自动换取新的
@@ -81,7 +80,7 @@ Trakt 同步记录能正确路由。
 API 应用与 Bearer 两种模式数据域不同（api.trakt.tv / apiz.trakt.tv），
 **切换必须提供对应模式的新凭证，不能复用另一模式的 token**：
 
-- 切换至 **Bearer**：需同时填写 access_token 与 refresh_token（或用「通过邮箱登录」）后保存
+- 切换至 **Bearer**：需填写 refresh_token（或用「通过邮箱登录」）后保存
 - 切换至 **API 应用**：需重新点击「授权 Trakt」完成 OAuth 授权
 
 仅切换界面上的 radio 而未保存不会改变已保存的模式。

--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -63,13 +63,28 @@ Trakt 同步记录能正确路由。
 1. 用浏览器登录 [app.trakt.tv](https://app.trakt.tv)
 2. 按 F12 打开开发者工具 → Application → Local Storage
 3. 展开 `https://auth.trakt.tv`，找到 `oidc.user:https://auth.trakt.tv:201dc70c...`
-   键，复制其中 `access_token` 与 `refresh_token`
-4. 在「Bearer 凭证」卡片中分别粘贴到两个输入框并保存
+   键，复制其中的 `refresh_token`
+4. 在「Bearer 凭证」卡片中粘贴并保存（只需 refresh_token；access_token 可选，
+   保存时后端会用它验证并自动换新）
 
 ::: tip 凭证说明
-- 保存时后端会立即验证并刷新凭证；refresh_token 为旋转式，旧值立即作废
+- 只需提供 **refresh_token**：保存时后端会立即验证并旋转刷新，自动换取新的
+  access_token / refresh_token；refresh_token 为旋转式，旧值立即作废
+  （保存后你刚从浏览器复制的那份 refresh_token 不再可用）
 - 已配置时输入框留空表示不修改；token 绝不回显
 - 凭证剩余不足 1 天时，每日定时任务会自动续期，无需手动刷新
+- 同一邮箱 60 秒内重复发信会被限流（429，前端自动倒计时）；验证码连续输错
+  5 次会话作废，需重新发送
+:::
+
+::: warning 凭证模式切换
+API 应用与 Bearer 两种模式数据域不同（api.trakt.tv / apiz.trakt.tv），
+**切换必须提供对应模式的新凭证，不能复用另一模式的 token**：
+
+- 切换至 **Bearer**：需同时填写 access_token 与 refresh_token（或用「通过邮箱登录」）后保存
+- 切换至 **API 应用**：需重新点击「授权 Trakt」完成 OAuth 授权
+
+仅切换界面上的 radio 而未保存不会改变已保存的模式。
 :::
 
 ## 4. 同步配置

--- a/docs/usage/trakt.md
+++ b/docs/usage/trakt.md
@@ -37,6 +37,41 @@ order: 15
 授权成功后，系统会自动把你登录本程序的用户名追加到**当前激活的 Bangumi 账号**的「媒体服务器用户名」列表里（如果尚未存在），并在成功页弹出提示。这是为了让 Trakt 同步的观看记录能正确路由到对应的 Bangumi 账号，避免被用户名过滤拦截。如果你不希望如此，可在「Bangumi 账号配置」里手动移除该用户名。
 :::
 
+## Bearer 凭证模式（备选，无需创建 Trakt 应用）
+
+不想创建 Trakt 应用 / 无法配置回调地址时，可改用 **Bearer 凭证模式**：
+直接提供 Trakt 账号的 access_token 与 refresh_token，数据走官方数据域
+`apiz.trakt.tv`，无需 Client ID / Secret / 回调地址。
+
+### 方式一：通过邮箱一键登录（推荐）
+
+1. 进入「Trakt 配置」页面，在顶部「凭证模式」卡片选择 **Bearer Token**
+2. 在「Bearer 凭证」卡片点击 **通过邮箱登录**
+3. 弹窗中输入 **Trakt 账号邮箱** 并点击「发送验证码」
+4. 到邮箱查收 **6 位验证码**（5 分钟内有效），输入后点击「登录并保存」
+5. 登录成功会自动获取并保存 Access Token / Refresh Token，并切换为
+   Bearer 模式；token 全程在服务端流转，不会回显到页面
+
+::: tip 自动补充用户名
+邮箱登录成功后，同样会自动把你登录本程序的用户名追加到激活的 Bangumi
+账号的「媒体服务器用户名」列表（与 API 应用模式授权成功行为一致），确保
+Trakt 同步记录能正确路由。
+:::
+
+### 方式二：从浏览器手动粘贴
+
+1. 用浏览器登录 [app.trakt.tv](https://app.trakt.tv)
+2. 按 F12 打开开发者工具 → Application → Local Storage
+3. 展开 `https://auth.trakt.tv`，找到 `oidc.user:https://auth.trakt.tv:201dc70c...`
+   键，复制其中 `access_token` 与 `refresh_token`
+4. 在「Bearer 凭证」卡片中分别粘贴到两个输入框并保存
+
+::: tip 凭证说明
+- 保存时后端会立即验证并刷新凭证；refresh_token 为旋转式，旧值立即作废
+- 已配置时输入框留空表示不修改；token 绝不回显
+- 凭证剩余不足 1 天时，每日定时任务会自动续期，无需手动刷新
+:::
+
 ## 4. 同步配置
 
 - **启用同步**：开启定时同步功能

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -78,6 +78,12 @@ class TraktConfigPage {
             this.saveApiConfig();
         });
 
+        // 保存凭证配置表单
+        document.getElementById('auth-mode-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.saveAuthMode();
+        });
+
         // 手动同步按钮
         document.getElementById('manual-sync-button').addEventListener('click', () => {
             this.triggerManualSync(false);
@@ -207,6 +213,15 @@ class TraktConfigPage {
             authButton.disabled = false;
             disconnectButton.disabled = true;
             syncSaveButton.disabled = true;
+            // 无配置时仍允许填写 Bearer 凭证直接创建（不依赖 OAuth 授权）
+            const authModeSaveButton = document.querySelector('#auth-mode-form button[type="submit"]');
+            if (authModeSaveButton) {
+                authModeSaveButton.disabled = false;
+            }
+            const bearerStatusInfo = document.getElementById('bearer-status-info');
+            if (bearerStatusInfo) {
+                bearerStatusInfo.innerHTML = '<span class="text-muted"><i class="bi bi-dash-circle me-1"></i>未配置 Bearer 凭证</span>';
+            }
             return;
         }
 
@@ -249,6 +264,103 @@ class TraktConfigPage {
             ? '已配置，留空则不修改'
             : '从 trakt.tv/oauth/applications 获取';
         redirectUri.value = config.redirect_uri || 'http://localhost:8000/api/trakt/auth/callback';
+
+        // 凭证模式
+        const authTypeOauth = document.getElementById('auth-type-oauth');
+        const authTypeBearer = document.getElementById('auth-type-bearer');
+        const authModeSaveButton = document.querySelector('#auth-mode-form button[type="submit"]');
+        const accessTokenInput = document.getElementById('bearer-access-token');
+        const refreshTokenInput = document.getElementById('bearer-refresh-token');
+        const bearerStatusInfo = document.getElementById('bearer-status-info');
+
+        if (authTypeOauth && authTypeBearer) {
+            authTypeOauth.checked = config.auth_type !== 'bearer';
+            authTypeBearer.checked = config.auth_type === 'bearer';
+        }
+        if (authModeSaveButton) {
+            authModeSaveButton.disabled = false;
+        }
+        // 不回显 token；已配置时留空表示不修改
+        if (accessTokenInput) {
+            accessTokenInput.value = '';
+            accessTokenInput.placeholder = config.token_configured
+                ? '已配置，留空则不修改'
+                : '粘贴 access_token（32 字符）';
+        }
+        if (refreshTokenInput) {
+            refreshTokenInput.value = '';
+            refreshTokenInput.placeholder = config.token_configured
+                ? '已配置，留空则不修改'
+                : '粘贴 refresh_token（32 字符）';
+        }
+        if (bearerStatusInfo) {
+            bearerStatusInfo.innerHTML = this.renderTokenStatus(config);
+        }
+    }
+
+    /**
+     * 渲染 Bearer 凭证状态信息（token 本身绝不回显）
+     */
+    renderTokenStatus(config) {
+        if (!config || !config.token_configured) {
+            return '<span class="text-muted"><i class="bi bi-dash-circle me-1"></i>未配置 Bearer 凭证</span>';
+        }
+
+        const status = config.token_status || 'not_configured';
+        const expiresAt = config.token_expires_at;
+
+        let icon = '<i class="bi bi-check-circle text-success me-1"></i>';
+        let statusText = '有效';
+        if (status === 'expired') {
+            icon = '<i class="bi bi-exclamation-triangle-fill text-warning me-1"></i>';
+            statusText = '已失效，请重新填写';
+        }
+
+        const parts = [`<span>${icon}${statusText}</span>`];
+        if (expiresAt) {
+            const remainDays = Math.ceil((expiresAt - Math.floor(Date.now() / 1000)) / 86400);
+            parts.push(`<span class="ms-2 text-muted">剩余 ${remainDays > 0 ? remainDays : 0} 天</span>`);
+        }
+        return parts.join('');
+    }
+
+    /**
+     * 保存凭证模式与 Bearer 凭证（留空表示不修改）
+     */
+    async saveAuthMode() {
+        const authType = document.querySelector('input[name="auth_type"]:checked');
+        if (!authType) {
+            this.showNotification('请选择凭证模式', 'warning');
+            return;
+        }
+        const accessToken = document.getElementById('bearer-access-token');
+        const refreshToken = document.getElementById('bearer-refresh-token');
+
+        const config = {
+            auth_type: authType.value
+        };
+        // 留空表示不修改；非空则一并提交（后端会同时校验两值并立即验证）
+        if (accessToken && accessToken.value.trim()) {
+            config.access_token = accessToken.value.trim();
+        }
+        if (refreshToken && refreshToken.value.trim()) {
+            config.refresh_token = refreshToken.value.trim();
+        }
+
+        try {
+            const result = await apiFetch('/api/trakt/config', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(config)
+            });
+            this.showNotification('凭证配置保存成功', 'success');
+            this.updateConfigDisplay(result);
+        } catch (error) {
+            console.error('保存凭证配置失败:', error);
+            this.showNotification(`保存凭证配置失败: ${error.message}`, 'danger');
+        }
     }
 
 

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -301,14 +301,11 @@ class TraktConfigPage {
             syncSaveButton.disabled = false;
         }
 
-        // 连接状态：Bearer 模式不走 OAuth 授权，但保留「授权 Trakt」按钮作为
-        // 切换到 API 应用模式的入口（点击后走 OAuth 重新授权）；文案给出指引
-        if (authButton && config.auth_type === 'bearer') {
+        // 连接状态：Bearer 模式常驻隐藏「授权 Trakt」（OAuth 授权与 bearer 无关）；
+        // 仅当用户把模式切到 API 应用（从 bearer 切回 oauth）时显示，作为重新授权
+        // 入口。可见性由 toggleCredentialCards → updateAuthButtonVisibility 统一管理。
+        if (authButton) {
             authButton.classList.remove('d-none');
-            authButton.textContent = '授权 Trakt（切换至 API 应用）';
-        } else if (authButton) {
-            authButton.classList.remove('d-none');
-            authButton.textContent = '授权 Trakt';
         }
 
         syncEnabled.checked = config.enabled;
@@ -330,7 +327,6 @@ class TraktConfigPage {
         const authTypeOauth = document.getElementById('auth-type-oauth');
         const authTypeBearer = document.getElementById('auth-type-bearer');
         const authModeSaveButton = document.querySelector('#auth-mode-form button[type="submit"]');
-        const accessTokenInput = document.getElementById('bearer-access-token');
         const refreshTokenInput = document.getElementById('bearer-refresh-token');
         const bearerStatusInfo = document.getElementById('bearer-status-info');
 
@@ -352,12 +348,6 @@ class TraktConfigPage {
         }
         this.toggleCredentialCards();
         // 不回显 token；已配置时留空表示不修改
-        if (accessTokenInput) {
-            accessTokenInput.value = '';
-            accessTokenInput.placeholder = config.token_configured
-                ? '已配置，留空则不修改'
-                : '粘贴 access_token（32 字符）';
-        }
         if (refreshTokenInput) {
             refreshTokenInput.value = '';
             refreshTokenInput.placeholder = config.token_configured
@@ -437,23 +427,14 @@ class TraktConfigPage {
     }
 
     /**
-     * 保存 Bearer 凭证（refresh_token 必填，access_token 可选；
-     * 后端只使用并验证 refresh_token，成功后会旋转换新）
+     * 保存 Bearer 凭证（只需 refresh_token：后端用它验证并旋转刷新）
      */
     async saveBearerCred() {
-        const accessToken = document.getElementById('bearer-access-token');
         const refreshToken = document.getElementById('bearer-refresh-token');
 
-        const config = {};
-        // refresh_token 必填（后端校验与续期的依据）；access_token 可选
-        if (refreshToken && refreshToken.value.trim()) {
-            config.refresh_token = refreshToken.value.trim();
-        }
-        if (accessToken && accessToken.value.trim()) {
-            config.access_token = accessToken.value.trim();
-        }
-        if (!config.refresh_token) {
-            this.showNotification('请填写 Refresh Token（Access Token 可选）', 'warning');
+        const refresh = (refreshToken && refreshToken.value.trim()) || '';
+        if (!refresh) {
+            this.showNotification('请填写 Refresh Token', 'warning');
             return;
         }
 
@@ -463,7 +444,7 @@ class TraktConfigPage {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify(config)
+                body: JSON.stringify({ refresh_token: refresh })
             });
             this.showNotification('Bearer 凭证保存成功', 'success');
             this.updateConfigDisplay(result);
@@ -680,6 +661,33 @@ class TraktConfigPage {
     }
 
     /**
+     * 控制「授权 Trakt」按钮可见性：
+     * - Bearer 模式常驻隐藏（OAuth 授权与 bearer 无关，避免误导）
+     * - 仅当用户把凭证模式切到 API 应用（从 bearer 切回 oauth）时显示，
+     *   作为重新授权（切换）入口
+     */
+    updateAuthButtonVisibility() {
+        const authButton = document.getElementById('auth-button');
+        if (!authButton) {
+            return;
+        }
+        const radio = document.querySelector('input[name="auth_type"]:checked');
+        const selected = radio ? radio.value : this._savedAuthType;
+        const switchingToOauth =
+            selected === 'oauth' && this._savedAuthType === 'bearer';
+        authButton.classList.toggle('d-none', selected === 'bearer');
+        if (selected === 'bearer') {
+            return;
+        }
+        authButton.textContent = switchingToOauth
+            ? '授权 Trakt（切换至 API 应用）'
+            : '授权 Trakt';
+        if (switchingToOauth) {
+            authButton.disabled = false;
+        }
+    }
+
+    /**
      * 根据当前选中的凭证模式按需显示凭证相关卡片：
      * API 应用（oauth）→ 显示「API 配置」卡片；Bearer → 显示「Bearer 凭证」卡片。
      * 同时给出模式切换的操作指引（与已保存模式不一致时）。
@@ -708,6 +716,7 @@ class TraktConfigPage {
                 hint.classList.add('d-none');
             }
         }
+        this.updateAuthButtonVisibility();
     }
 
 

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -97,6 +97,33 @@ class TraktConfigPage {
             });
         });
 
+        // 邮箱登录弹窗
+        document.getElementById('email-login-send-btn').addEventListener('click', () => {
+            this.sendEmailCode();
+        });
+        document.getElementById('email-login-submit-btn').addEventListener('click', () => {
+            this.completeEmailLogin();
+        });
+        document.getElementById('email-login-resend-btn').addEventListener('click', () => {
+            this.sendEmailCode();
+        });
+        const emailOtpInput = document.getElementById('email-login-otp');
+        if (emailOtpInput) {
+            emailOtpInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    this.completeEmailLogin();
+                }
+            });
+        }
+        // 弹窗关闭时重置为步骤 1
+        const emailLoginModalEl = document.getElementById('email-login-modal');
+        if (emailLoginModalEl) {
+            emailLoginModalEl.addEventListener('hidden.bs.modal', () => {
+                this.resetEmailLoginModal();
+            });
+        }
+
         // 手动同步按钮
         document.getElementById('manual-sync-button').addEventListener('click', () => {
             this.triggerManualSync(false);
@@ -408,6 +435,175 @@ class TraktConfigPage {
         } catch (error) {
             console.error('保存 Bearer 凭证失败:', error);
             this.showNotification(`保存 Bearer 凭证失败: ${error.message}`, 'danger');
+        }
+    }
+
+    /**
+     * 邮箱登录：发送验证码（弹窗步骤 1）
+     */
+    async sendEmailCode() {
+        const emailInput = document.getElementById('email-login-email');
+        const email = (emailInput && emailInput.value.trim()) || '';
+        if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+            this.showEmailLoginError('请输入有效的邮箱地址');
+            return;
+        }
+        this.hideEmailLoginError();
+        const sendBtn = document.getElementById('email-login-send-btn');
+        const resendBtn = document.getElementById('email-login-resend-btn');
+        if (sendBtn) {
+            sendBtn.disabled = true;
+        }
+        if (resendBtn) {
+            resendBtn.disabled = true;
+        }
+        try {
+            const result = await apiFetch('/api/trakt/email-login/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email })
+            });
+            // 成功：进入步骤 2
+            const sentTo = document.getElementById('email-login-sent-to');
+            if (sentTo) {
+                sentTo.textContent = email;
+            }
+            this.showEmailLoginStep(2);
+            this.startResendCountdown((result && result.retry_after) || 60);
+        } catch (error) {
+            this.showEmailLoginError(error.message || '发送验证码失败');
+            if (sendBtn) {
+                sendBtn.disabled = false;
+            }
+        }
+    }
+
+    /**
+     * 邮箱登录：提交验证码，完成登录（弹窗步骤 2）
+     */
+    async completeEmailLogin() {
+        const otpInput = document.getElementById('email-login-otp');
+        const otp = (otpInput && otpInput.value.trim()) || '';
+        if (!/^\d{6}$/.test(otp)) {
+            this.showEmailLoginError('请输入 6 位数字验证码');
+            return;
+        }
+        this.hideEmailLoginError();
+        const submitBtn = document.getElementById('email-login-submit-btn');
+        if (submitBtn) {
+            submitBtn.disabled = true;
+        }
+        try {
+            const result = await apiFetch('/api/trakt/email-login/complete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ otp })
+            });
+            this.showNotification((result && result.message) || '登录成功，Bearer 凭证已保存', 'success');
+            // 关闭弹窗并刷新页面状态（Bearer 模式 + active）
+            const modalEl = document.getElementById('email-login-modal');
+            if (modalEl) {
+                const modal = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+                modal.hide();
+            }
+            this.loadConfig();
+        } catch (error) {
+            this.showEmailLoginError(error.message || '登录失败，请重试');
+        } finally {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+            }
+        }
+    }
+
+    /**
+     * 邮箱登录：重发验证码冷却倒计时（重新发送按钮禁用期间显示剩余秒数）
+     */
+    startResendCountdown(seconds) {
+        const resendBtn = document.getElementById('email-login-resend-btn');
+        const sendBtn = document.getElementById('email-login-send-btn');
+        let remain = Math.max(1, parseInt(seconds, 10) || 60);
+        const tick = () => {
+            if (resendBtn) {
+                resendBtn.disabled = true;
+                resendBtn.textContent = `重新发送（${remain}s）`;
+            }
+            remain -= 1;
+            if (remain < 0) {
+                if (resendBtn) {
+                    resendBtn.disabled = false;
+                    resendBtn.textContent = '重新发送';
+                }
+                if (sendBtn) {
+                    sendBtn.disabled = false;
+                }
+                if (this._emailLoginCountdown) {
+                    clearTimeout(this._emailLoginCountdown);
+                    this._emailLoginCountdown = null;
+                }
+                return;
+            }
+            this._emailLoginCountdown = setTimeout(tick, 1000);
+        };
+        tick();
+    }
+
+    /**
+     * 邮箱登录：切换弹窗步骤（1 输入邮箱 / 2 输入验证码）
+     */
+    showEmailLoginStep(step) {
+        const step1 = document.getElementById('email-login-step-1');
+        const step2 = document.getElementById('email-login-step-2');
+        if (step1) {
+            step1.classList.toggle('d-none', step !== 1);
+        }
+        if (step2) {
+            step2.classList.toggle('d-none', step !== 2);
+        }
+        if (step === 2) {
+            const otpInput = document.getElementById('email-login-otp');
+            if (otpInput) {
+                otpInput.focus();
+            }
+        }
+    }
+
+    /**
+     * 邮箱登录：错误提示
+     */
+    showEmailLoginError(message) {
+        const el = document.getElementById('email-login-error');
+        if (el) {
+            el.textContent = message;
+            el.classList.remove('d-none');
+        }
+    }
+
+    hideEmailLoginError() {
+        const el = document.getElementById('email-login-error');
+        if (el) {
+            el.classList.add('d-none');
+        }
+    }
+
+    /**
+     * 邮箱登录：弹窗关闭时重置为步骤 1
+     */
+    resetEmailLoginModal() {
+        if (this._emailLoginCountdown) {
+            clearTimeout(this._emailLoginCountdown);
+            this._emailLoginCountdown = null;
+        }
+        this.hideEmailLoginError();
+        this.showEmailLoginStep(1);
+        const resendBtn = document.getElementById('email-login-resend-btn');
+        const sendBtn = document.getElementById('email-login-send-btn');
+        if (resendBtn) {
+            resendBtn.disabled = true;
+            resendBtn.textContent = '重新发送';
+        }
+        if (sendBtn) {
+            sendBtn.disabled = false;
         }
     }
 

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -8,6 +8,10 @@ class TraktConfigPage {
         this.pageSize = APP_TABLE_PAGE_SIZE;
         this.authWindow = null;
         this.authPollInterval = null;
+        // 凭证模式 radio 是否有未保存的改动（避免保存其他配置时被服务器值弹回）
+        this._authModeDirty = false;
+        // 服务器端已保存的凭证模式（保存凭证模式失败时用于回滚）
+        this._savedAuthType = 'oauth';
 
         // 存储实例到全局变量
         window.traktConfigPage = this;
@@ -90,9 +94,11 @@ class TraktConfigPage {
             this.saveBearerCred();
         });
 
-        // 凭证模式切换时按需显示凭证相关卡片
+        // 凭证模式切换时按需显示凭证相关卡片；记录未保存状态，避免
+        // 之后保存同步配置等操作把 radio 弹回服务器端旧值
         document.querySelectorAll('input[name="auth_type"]').forEach((radio) => {
             radio.addEventListener('change', () => {
+                this._authModeDirty = true;
                 this.toggleCredentialCards();
             });
         });
@@ -295,6 +301,16 @@ class TraktConfigPage {
             syncSaveButton.disabled = false;
         }
 
+        // 连接状态：Bearer 模式不走 OAuth 授权，但保留「授权 Trakt」按钮作为
+        // 切换到 API 应用模式的入口（点击后走 OAuth 重新授权）；文案给出指引
+        if (authButton && config.auth_type === 'bearer') {
+            authButton.classList.remove('d-none');
+            authButton.textContent = '授权 Trakt（切换至 API 应用）';
+        } else if (authButton) {
+            authButton.classList.remove('d-none');
+            authButton.textContent = '授权 Trakt';
+        }
+
         syncEnabled.checked = config.enabled;
         syncInterval.value = config.sync_interval || '0 */6 * * *';
         
@@ -319,8 +335,13 @@ class TraktConfigPage {
         const bearerStatusInfo = document.getElementById('bearer-status-info');
 
         if (authTypeOauth && authTypeBearer) {
-            authTypeOauth.checked = config.auth_type !== 'bearer';
-            authTypeBearer.checked = config.auth_type === 'bearer';
+            // 服务器端已保存的模式（用于保存失败时回滚）
+            this._savedAuthType = config.auth_type === 'bearer' ? 'bearer' : 'oauth';
+            // 有未保存的模式改动时不弹回 radio（避免保存其他配置时被覆盖）
+            if (!this._authModeDirty) {
+                authTypeOauth.checked = config.auth_type !== 'bearer';
+                authTypeBearer.checked = config.auth_type === 'bearer';
+            }
         }
         if (authModeSaveButton) {
             authModeSaveButton.disabled = false;
@@ -375,7 +396,7 @@ class TraktConfigPage {
     }
 
     /**
-     * 保存凭证模式（oauth / bearer，切换只改模式标记）
+     * 保存凭证模式（oauth / bearer；切换需提供对应模式凭证，由后端校验）
      */
     async saveAuthMode() {
         const authType = document.querySelector('input[name="auth_type"]:checked');
@@ -394,31 +415,45 @@ class TraktConfigPage {
                     auth_type: authType.value
                 })
             });
+            this._authModeDirty = false;
+            this._savedAuthType = result.auth_type === 'bearer' ? 'bearer' : 'oauth';
             this.showNotification('凭证模式保存成功', 'success');
             this.updateConfigDisplay(result);
         } catch (error) {
             console.error('保存凭证模式失败:', error);
+            // 模式切换被后端拒绝（如切 bearer 未提供凭证 / 切 oauth 未重新授权）：
+            // 回滚 radio 到已保存模式并恢复对应卡片，避免界面与库不一致
+            this._authModeDirty = false;
+            const saved = this._savedAuthType;
+            const oauthRadio = document.getElementById('auth-type-oauth');
+            const bearerRadio = document.getElementById('auth-type-bearer');
+            if (oauthRadio && bearerRadio) {
+                oauthRadio.checked = saved !== 'bearer';
+                bearerRadio.checked = saved === 'bearer';
+            }
+            this.toggleCredentialCards();
             this.showNotification(`保存凭证模式失败: ${error.message}`, 'danger');
         }
     }
 
     /**
-     * 保存 Bearer 凭证（留空表示不修改；非空则后端同时校验两值并立即验证）
+     * 保存 Bearer 凭证（refresh_token 必填，access_token 可选；
+     * 后端只使用并验证 refresh_token，成功后会旋转换新）
      */
     async saveBearerCred() {
         const accessToken = document.getElementById('bearer-access-token');
         const refreshToken = document.getElementById('bearer-refresh-token');
 
         const config = {};
-        // 留空表示不修改；非空则一并提交（后端会同时校验两值并立即验证）
-        if (accessToken && accessToken.value.trim()) {
-            config.access_token = accessToken.value.trim();
-        }
+        // refresh_token 必填（后端校验与续期的依据）；access_token 可选
         if (refreshToken && refreshToken.value.trim()) {
             config.refresh_token = refreshToken.value.trim();
         }
-        if (!config.access_token && !config.refresh_token) {
-            this.showNotification('请填写 Bearer 凭证（Access Token 与 Refresh Token）', 'warning');
+        if (accessToken && accessToken.value.trim()) {
+            config.access_token = accessToken.value.trim();
+        }
+        if (!config.refresh_token) {
+            this.showNotification('请填写 Refresh Token（Access Token 可选）', 'warning');
             return;
         }
 
@@ -440,6 +475,7 @@ class TraktConfigPage {
 
     /**
      * 邮箱登录：发送验证码（弹窗步骤 1）
+     * 冷却限流（429）时携带 retry_after 启动倒计时，失败时重新启用按钮。
      */
     async sendEmailCode() {
         const emailInput = document.getElementById('email-login-email');
@@ -458,23 +494,59 @@ class TraktConfigPage {
             resendBtn.disabled = true;
         }
         try {
-            const result = await apiFetch('/api/trakt/email-login/start', {
+            // returnResponse：需要读取 429 的 retry_after 与错误 detail
+            const response = await apiFetch('/api/trakt/email-login/start', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email })
+                body: JSON.stringify({ email }),
+                returnResponse: true,
             });
+            let data = {};
+            try {
+                data = await response.json();
+            } catch (_) { /* 非 JSON 错误体 */ }
+
+            if (!response.ok) {
+                // 429 冷却：detail 为 {message, retry_after}，启动倒计时而非卡死按钮
+                const detail = data.detail;
+                const isRateLimited = response.status === 429;
+                const retryAfter =
+                    detail && typeof detail === 'object' ? detail.retry_after : null;
+                this.showEmailLoginError(
+                    (detail && (typeof detail === 'object' ? detail.message : detail)) ||
+                        `发送失败（${response.status}）`
+                );
+                this.enableEmailSendButtons();
+                if (isRateLimited && retryAfter) {
+                    this.startResendCountdown(Number(retryAfter));
+                }
+                return;
+            }
+
             // 成功：进入步骤 2
             const sentTo = document.getElementById('email-login-sent-to');
             if (sentTo) {
                 sentTo.textContent = email;
             }
             this.showEmailLoginStep(2);
-            this.startResendCountdown((result && result.retry_after) || 60);
+            this.startResendCountdown((data && data.retry_after) || 60);
         } catch (error) {
             this.showEmailLoginError(error.message || '发送验证码失败');
-            if (sendBtn) {
-                sendBtn.disabled = false;
-            }
+            this.enableEmailSendButtons();
+        }
+    }
+
+    /**
+     * 邮箱登录：重新启用发送/重发按钮（非限流失败时）
+     */
+    enableEmailSendButtons() {
+        const sendBtn = document.getElementById('email-login-send-btn');
+        const resendBtn = document.getElementById('email-login-resend-btn');
+        if (sendBtn) {
+            sendBtn.disabled = false;
+        }
+        if (resendBtn) {
+            resendBtn.disabled = false;
         }
     }
 
@@ -609,7 +681,8 @@ class TraktConfigPage {
 
     /**
      * 根据当前选中的凭证模式按需显示凭证相关卡片：
-     * API 应用（oauth）→ 显示「API 配置」卡片；Bearer → 显示「Bearer 凭证」卡片
+     * API 应用（oauth）→ 显示「API 配置」卡片；Bearer → 显示「Bearer 凭证」卡片。
+     * 同时给出模式切换的操作指引（与已保存模式不一致时）。
      */
     toggleCredentialCards() {
         const authType = document.querySelector('input[name="auth_type"]:checked');
@@ -621,6 +694,19 @@ class TraktConfigPage {
         const apiConfigCard = document.getElementById('api-config-card');
         if (apiConfigCard) {
             apiConfigCard.classList.toggle('d-none', isBearer);
+        }
+        const hint = document.getElementById('auth-mode-hint');
+        if (hint) {
+            const selected = authType ? authType.value : this._savedAuthType;
+            if (selected !== this._savedAuthType) {
+                hint.textContent =
+                    selected === 'bearer'
+                        ? '切换至 Bearer 模式需在下方卡片填写 Refresh Token（或使用「通过邮箱登录」）并保存，否则无法完成切换。'
+                        : '切换至 API 应用模式需重新授权，请点击「授权 Trakt」完成授权。';
+                hint.classList.remove('d-none');
+            } else {
+                hint.classList.add('d-none');
+            }
         }
     }
 

--- a/static/js/trakt/config.js
+++ b/static/js/trakt/config.js
@@ -78,10 +78,23 @@ class TraktConfigPage {
             this.saveApiConfig();
         });
 
-        // 保存凭证配置表单
+        // 保存凭证模式表单
         document.getElementById('auth-mode-form').addEventListener('submit', (e) => {
             e.preventDefault();
             this.saveAuthMode();
+        });
+
+        // 保存 Bearer 凭证表单
+        document.getElementById('bearer-cred-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.saveBearerCred();
+        });
+
+        // 凭证模式切换时按需显示凭证相关卡片
+        document.querySelectorAll('input[name="auth_type"]').forEach((radio) => {
+            radio.addEventListener('change', () => {
+                this.toggleCredentialCards();
+            });
         });
 
         // 手动同步按钮
@@ -218,10 +231,15 @@ class TraktConfigPage {
             if (authModeSaveButton) {
                 authModeSaveButton.disabled = false;
             }
+            const bearerCredSaveButton = document.querySelector('#bearer-cred-form button[type="submit"]');
+            if (bearerCredSaveButton) {
+                bearerCredSaveButton.disabled = false;
+            }
             const bearerStatusInfo = document.getElementById('bearer-status-info');
             if (bearerStatusInfo) {
                 bearerStatusInfo.innerHTML = '<span class="text-muted"><i class="bi bi-dash-circle me-1"></i>未配置 Bearer 凭证</span>';
             }
+            this.toggleCredentialCards();
             return;
         }
 
@@ -280,6 +298,11 @@ class TraktConfigPage {
         if (authModeSaveButton) {
             authModeSaveButton.disabled = false;
         }
+        const bearerCredSaveButton = document.querySelector('#bearer-cred-form button[type="submit"]');
+        if (bearerCredSaveButton) {
+            bearerCredSaveButton.disabled = false;
+        }
+        this.toggleCredentialCards();
         // 不回显 token；已配置时留空表示不修改
         if (accessTokenInput) {
             accessTokenInput.value = '';
@@ -325,7 +348,7 @@ class TraktConfigPage {
     }
 
     /**
-     * 保存凭证模式与 Bearer 凭证（留空表示不修改）
+     * 保存凭证模式（oauth / bearer，切换只改模式标记）
      */
     async saveAuthMode() {
         const authType = document.querySelector('input[name="auth_type"]:checked');
@@ -333,18 +356,43 @@ class TraktConfigPage {
             this.showNotification('请选择凭证模式', 'warning');
             return;
         }
+
+        try {
+            const result = await apiFetch('/api/trakt/config', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    auth_type: authType.value
+                })
+            });
+            this.showNotification('凭证模式保存成功', 'success');
+            this.updateConfigDisplay(result);
+        } catch (error) {
+            console.error('保存凭证模式失败:', error);
+            this.showNotification(`保存凭证模式失败: ${error.message}`, 'danger');
+        }
+    }
+
+    /**
+     * 保存 Bearer 凭证（留空表示不修改；非空则后端同时校验两值并立即验证）
+     */
+    async saveBearerCred() {
         const accessToken = document.getElementById('bearer-access-token');
         const refreshToken = document.getElementById('bearer-refresh-token');
 
-        const config = {
-            auth_type: authType.value
-        };
+        const config = {};
         // 留空表示不修改；非空则一并提交（后端会同时校验两值并立即验证）
         if (accessToken && accessToken.value.trim()) {
             config.access_token = accessToken.value.trim();
         }
         if (refreshToken && refreshToken.value.trim()) {
             config.refresh_token = refreshToken.value.trim();
+        }
+        if (!config.access_token && !config.refresh_token) {
+            this.showNotification('请填写 Bearer 凭证（Access Token 与 Refresh Token）', 'warning');
+            return;
         }
 
         try {
@@ -355,11 +403,28 @@ class TraktConfigPage {
                 },
                 body: JSON.stringify(config)
             });
-            this.showNotification('凭证配置保存成功', 'success');
+            this.showNotification('Bearer 凭证保存成功', 'success');
             this.updateConfigDisplay(result);
         } catch (error) {
-            console.error('保存凭证配置失败:', error);
-            this.showNotification(`保存凭证配置失败: ${error.message}`, 'danger');
+            console.error('保存 Bearer 凭证失败:', error);
+            this.showNotification(`保存 Bearer 凭证失败: ${error.message}`, 'danger');
+        }
+    }
+
+    /**
+     * 根据当前选中的凭证模式按需显示凭证相关卡片：
+     * API 应用（oauth）→ 显示「API 配置」卡片；Bearer → 显示「Bearer 凭证」卡片
+     */
+    toggleCredentialCards() {
+        const authType = document.querySelector('input[name="auth_type"]:checked');
+        const isBearer = authType && authType.value === 'bearer';
+        const bearerCard = document.getElementById('bearer-cred-card');
+        if (bearerCard) {
+            bearerCard.classList.toggle('d-none', !isBearer);
+        }
+        const apiConfigCard = document.getElementById('api-config-card');
+        if (apiConfigCard) {
+            apiConfigCard.classList.toggle('d-none', isBearer);
         }
     }
 

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -39,10 +39,14 @@
                             </label>
                         </div>
                         <div class="form-text">
-                            两种凭证互斥；切换只改模式标记，另一模式凭证字段会被覆盖。
-                            API 应用模式需先在「API 配置」卡片填写应用凭证后点击「授权 Trakt」；
-                            选择 Bearer 后请在下方「Bearer 凭证」卡片填写凭证（保存时立即验证并自动刷新）。
+                            两种凭证互斥且数据域不同（API 应用走 api.trakt.tv，Bearer 走
+                            apiz.trakt.tv），切换需提供对应模式的新凭证，不能复用另一模式的 token：
+                            API 应用模式需先在「API 配置」卡片填写应用凭证后点击「授权 Trakt」重新授权；
+                            Bearer 模式需在下方「Bearer 凭证」卡片填写凭证（或「通过邮箱登录」）后保存。
+                            未保存就切换 radio 不会改变已保存的模式。
                         </div>
+                        <div id="auth-mode-hint"
+                             class="alert alert-warning alert-sm small mt-2 mb-0 d-none"></div>
                     </div>
                 </div>
                 <div class="text-end">
@@ -114,21 +118,25 @@
             <form id="bearer-cred-form">
                 <div class="row mb-3">
                     <div class="col-md-6">
-                        <label for="bearer-access-token" class="form-label">Access Token</label>
-                        <input type="password"
-                               class="form-control"
-                               id="bearer-access-token"
-                               name="access_token"
-                               placeholder="粘贴 access_token（32 字符）"
-                               autocomplete="off">
-                        <label for="bearer-refresh-token" class="form-label mt-2">Refresh Token</label>
+                        <label for="bearer-refresh-token" class="form-label">Refresh Token</label>
                         <input type="password"
                                class="form-control"
                                id="bearer-refresh-token"
                                name="refresh_token"
                                placeholder="粘贴 refresh_token（32 字符）"
+                               autocomplete="off"
+                               required>
+                        <label for="bearer-access-token" class="form-label mt-2">Access Token（可选）</label>
+                        <input type="password"
+                               class="form-control"
+                               id="bearer-access-token"
+                               name="access_token"
+                               placeholder="可选，仅备选粘贴；保存后会自动获取"
                                autocomplete="off">
-                        <div class="form-text">不会回显；已配置时留空表示不修改</div>
+                        <div class="form-text">
+                            只需 <strong>Refresh Token</strong>：保存时后端会用它验证并旋转刷新，
+                            自动换取新的 access/refresh。不会回显；已配置时留空表示不修改。
+                        </div>
                     </div>
                     <div class="col-md-6">
                         <div id="bearer-status-info" class="small"></div>
@@ -161,11 +169,18 @@
                                         <code>oidc.user:https://auth.trakt.tv:201dc70c...</code> 键
                                     </li>
                                     <li>
-                                        复制其中 <code>access_token</code> 与 <code>refresh_token</code> 的值分别粘贴到上方两个输入框
+                                        复制其中的 <code>refresh_token</code> 粘贴到上方输入框（
+                                        <code>access_token</code> 可留空，保存时会自动获取）
                                     </li>
                                 </ol>
-                                <div class="mb-0">保存时后端会立即验证并刷新凭证（refresh 为旋转式，旧值作废）。</div>
+                                <div class="mb-0">保存时后端会立即验证并旋转刷新凭证（refresh 为旋转式，旧值作废）。</div>
                             </div>
+                        </div>
+                        <div class="alert alert-warning alert-sm small mt-2 mb-2">
+                            <i class="bi bi-exclamation-triangle me-1"></i>
+                            <strong>保存会立即旋转 refresh_token：</strong>你刚从浏览器复制的那份
+                            refresh_token 会在保存瞬间作废（Trakt 官网会话也可能被踢下线），
+                            保存成功后请使用系统自动保存的新凭证。
                         </div>
                     </div>
                 </div>

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -133,6 +133,15 @@
                     <div class="col-md-6">
                         <div id="bearer-status-info" class="small"></div>
                         <div class="mt-2">
+                            <button type="button"
+                                    class="btn btn-outline-primary btn-sm"
+                                    id="email-login-btn"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#email-login-modal">
+                                <i class="bi bi-box-arrow-in-right me-1"></i>通过邮箱登录
+                            </button>
+                        </div>
+                        <div class="mt-2">
                             <button class="btn btn-outline-secondary btn-sm"
                                     type="button"
                                     data-bs-toggle="collapse"
@@ -408,6 +417,76 @@
                             <button class="btn btn-outline-secondary ms-2" data-bs-dismiss="modal">取消</button>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- 邮箱登录弹窗 -->
+    <div class="modal fade"
+         id="email-login-modal"
+         tabindex="-1"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h6 class="modal-title">
+                        <i class="bi bi-envelope me-2"></i>Trakt 邮箱登录
+                    </h6>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <!-- 步骤 1：输入邮箱 -->
+                    <div id="email-login-step-1">
+                        <p class="text-muted small mb-3">
+                            输入 Trakt 账号邮箱，我们将发送一封含 6 位验证码的登录邮件（5 分钟内有效）。
+                            若该邮箱尚未注册 Trakt 账号，将自动创建。
+                        </p>
+                        <div class="mb-3">
+                            <label for="email-login-email" class="form-label">邮箱地址</label>
+                            <input type="email"
+                                   class="form-control"
+                                   id="email-login-email"
+                                   placeholder="you@example.com"
+                                   autocomplete="off">
+                        </div>
+                        <div class="text-end">
+                            <button type="button" class="btn btn-primary" id="email-login-send-btn">
+                                <i class="bi bi-send me-1"></i>发送验证码
+                            </button>
+                        </div>
+                    </div>
+                    <!-- 步骤 2：输入验证码 -->
+                    <div id="email-login-step-2" class="d-none">
+                        <p class="text-muted small mb-3">
+                            验证码已发送至 <strong id="email-login-sent-to"></strong>，请查收邮件并输入。
+                        </p>
+                        <div class="mb-3">
+                            <label for="email-login-otp" class="form-label">6 位验证码</label>
+                            <input type="text"
+                                   class="form-control"
+                                   id="email-login-otp"
+                                   placeholder="123456"
+                                   maxlength="6"
+                                   inputmode="numeric"
+                                   autocomplete="one-time-code">
+                        </div>
+                        <div class="text-end">
+                            <button type="button"
+                                    class="btn btn-outline-secondary me-2"
+                                    id="email-login-resend-btn"
+                                    disabled>
+                                <i class="bi bi-arrow-clockwise me-1"></i>重新发送
+                            </button>
+                            <button type="button" class="btn btn-primary" id="email-login-submit-btn">
+                                <i class="bi bi-box-arrow-in-right me-1"></i>登录并保存
+                            </button>
+                        </div>
+                    </div>
+                    <!-- 错误提示 -->
+                    <div id="email-login-error" class="alert alert-danger d-none mt-3 mb-0"></div>
                 </div>
             </div>
         </div>

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -4,8 +4,57 @@
 {% block page_title %}Trakt.tv 配置{% endblock %}
 {% block content %}
     <p class="app-page-intro">配置 Trakt.tv 数据同步到 Bangumi</p>
-    <!-- API 配置卡片 -->
+    <!-- 凭证模式卡片 -->
     <div class="card mb-4">
+        <div class="card-header py-3">
+            <h6 class="mb-0 card-header-title">
+                <i class="bi bi-shield-lock me-2 card-header-icon"></i>凭证模式
+            </h6>
+        </div>
+        <div class="card-body">
+            <form id="auth-mode-form">
+                <div class="row mb-3">
+                    <div class="col-md-8">
+                        <label class="form-label">选择凭证模式</label>
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="radio"
+                                   name="auth_type"
+                                   id="auth-type-oauth"
+                                   value="oauth">
+                            <label class="form-check-label" for="auth-type-oauth">
+                                API 应用
+                                <span class="text-muted small">（推荐，令牌自动续期）</span>
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="radio"
+                                   name="auth_type"
+                                   id="auth-type-bearer"
+                                   value="bearer">
+                            <label class="form-check-label" for="auth-type-bearer">
+                                Bearer Token
+                                <span class="text-muted small">（从浏览器粘贴，自动续期）</span>
+                            </label>
+                        </div>
+                        <div class="form-text">
+                            两种凭证互斥；切换只改模式标记，另一模式凭证字段会被覆盖。
+                            API 应用模式需先在「API 配置」卡片填写应用凭证后点击「授权 Trakt」；
+                            选择 Bearer 后请在下方「Bearer 凭证」卡片填写凭证（保存时立即验证并自动刷新）。
+                        </div>
+                    </div>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-primary" disabled>
+                        <i class="bi bi-save me-1"></i>保存凭证模式
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <!-- API 配置卡片（仅 API 应用模式下显示） -->
+    <div class="card mb-4 d-none" id="api-config-card">
         <div class="card-header py-3">
             <h6 class="mb-0 card-header-title">
                 <i class="bi bi-key me-2 card-header-icon"></i>API 配置
@@ -54,95 +103,66 @@
             </form>
         </div>
     </div>
-    <!-- 凭证模式卡片 -->
-    <div class="card mb-4">
+    <!-- Bearer 凭证卡片（仅 Bearer 模式下显示） -->
+    <div class="card mb-4 d-none" id="bearer-cred-card">
         <div class="card-header py-3">
             <h6 class="mb-0 card-header-title">
-                <i class="bi bi-shield-lock me-2 card-header-icon"></i>凭证模式
+                <i class="bi bi-key me-2 card-header-icon"></i>Bearer 凭证
             </h6>
         </div>
         <div class="card-body">
-            <form id="auth-mode-form">
+            <form id="bearer-cred-form">
                 <div class="row mb-3">
                     <div class="col-md-6">
-                        <label class="form-label">凭证模式</label>
-                        <div class="form-check">
-                            <input class="form-check-input"
-                                   type="radio"
-                                   name="auth_type"
-                                   id="auth-type-oauth"
-                                   value="oauth">
-                            <label class="form-check-label" for="auth-type-oauth">
-                                OAuth 授权
-                                <span class="text-muted small">（推荐，令牌自动续期）</span>
-                            </label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input"
-                                   type="radio"
-                                   name="auth_type"
-                                   id="auth-type-bearer"
-                                   value="bearer">
-                            <label class="form-check-label" for="auth-type-bearer">
-                                Bearer Token
-                                <span class="text-muted small">（从浏览器粘贴，自动续期）</span>
-                            </label>
-                        </div>
-                        <div class="form-text">
-                            两种凭证互斥；切换只改模式标记，另一模式凭证字段会被覆盖。
-                            Bearer 凭证保存时会立即验证并自动刷新。
-                        </div>
+                        <label for="bearer-access-token" class="form-label">Access Token</label>
+                        <input type="password"
+                               class="form-control"
+                               id="bearer-access-token"
+                               name="access_token"
+                               placeholder="粘贴 access_token（32 字符）"
+                               autocomplete="off">
+                        <label for="bearer-refresh-token" class="form-label mt-2">Refresh Token</label>
+                        <input type="password"
+                               class="form-control"
+                               id="bearer-refresh-token"
+                               name="refresh_token"
+                               placeholder="粘贴 refresh_token（32 字符）"
+                               autocomplete="off">
+                        <div class="form-text">不会回显；已配置时留空表示不修改</div>
                     </div>
                     <div class="col-md-6">
-                        <div id="bearer-input-group">
-                            <label for="bearer-access-token" class="form-label">Access Token</label>
-                            <input type="password"
-                                   class="form-control"
-                                   id="bearer-access-token"
-                                   name="access_token"
-                                   placeholder="粘贴 access_token（32 字符）"
-                                   autocomplete="off">
-                            <label for="bearer-refresh-token" class="form-label mt-2">Refresh Token</label>
-                            <input type="password"
-                                   class="form-control"
-                                   id="bearer-refresh-token"
-                                   name="refresh_token"
-                                   placeholder="粘贴 refresh_token（32 字符）"
-                                   autocomplete="off">
-                            <div class="form-text">不会回显；已配置时留空表示不修改</div>
-                            <div class="mt-2">
-                                <button class="btn btn-outline-secondary btn-sm"
-                                        type="button"
-                                        data-bs-toggle="collapse"
-                                        data-bs-target="#bearer-help">
-                                    <i class="bi bi-question-circle me-1"></i>如何获取 token？
-                                </button>
-                            </div>
-                            <div class="collapse mt-2" id="bearer-help">
-                                <div class="small text-muted border rounded p-2">
-                                    <ol class="mb-2 ps-3">
-                                        <li>
-                                            用浏览器登录 <a href="https://app.trakt.tv" target="_blank" rel="noopener">app.trakt.tv</a>
-                                        </li>
-                                        <li>按 F12 打开开发者工具 → Application → Local Storage</li>
-                                        <li>
-                                            展开 <code>https://auth.trakt.tv</code>，找到
-                                            <code>oidc.user:https://auth.trakt.tv:201dc70c...</code> 键
-                                        </li>
-                                        <li>
-                                            复制其中 <code>access_token</code> 与 <code>refresh_token</code> 的值分别粘贴到上方两个输入框
-                                        </li>
-                                    </ol>
-                                    <div class="mb-0">保存时后端会立即验证并刷新凭证（refresh 为旋转式，旧值作废）。</div>
-                                </div>
+                        <div id="bearer-status-info" class="small"></div>
+                        <div class="mt-2">
+                            <button class="btn btn-outline-secondary btn-sm"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#bearer-help">
+                                <i class="bi bi-question-circle me-1"></i>如何获取 token？
+                            </button>
+                        </div>
+                        <div class="collapse mt-2" id="bearer-help">
+                            <div class="small text-muted border rounded p-2">
+                                <ol class="mb-2 ps-3">
+                                    <li>
+                                        用浏览器登录 <a href="https://app.trakt.tv" target="_blank" rel="noopener">app.trakt.tv</a>
+                                    </li>
+                                    <li>按 F12 打开开发者工具 → Application → Local Storage</li>
+                                    <li>
+                                        展开 <code>https://auth.trakt.tv</code>，找到
+                                        <code>oidc.user:https://auth.trakt.tv:201dc70c...</code> 键
+                                    </li>
+                                    <li>
+                                        复制其中 <code>access_token</code> 与 <code>refresh_token</code> 的值分别粘贴到上方两个输入框
+                                    </li>
+                                </ol>
+                                <div class="mb-0">保存时后端会立即验证并刷新凭证（refresh 为旋转式，旧值作废）。</div>
                             </div>
                         </div>
-                        <div id="bearer-status-info" class="mt-2 small"></div>
                     </div>
                 </div>
                 <div class="text-end">
                     <button type="submit" class="btn btn-primary" disabled>
-                        <i class="bi bi-save me-1"></i>保存凭证配置
+                        <i class="bi bi-save me-1"></i>保存 Bearer 凭证
                     </button>
                 </div>
             </form>

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -126,13 +126,6 @@
                                placeholder="粘贴 refresh_token（32 字符）"
                                autocomplete="off"
                                required>
-                        <label for="bearer-access-token" class="form-label mt-2">Access Token（可选）</label>
-                        <input type="password"
-                               class="form-control"
-                               id="bearer-access-token"
-                               name="access_token"
-                               placeholder="可选，仅备选粘贴；保存后会自动获取"
-                               autocomplete="off">
                         <div class="form-text">
                             只需 <strong>Refresh Token</strong>：保存时后端会用它验证并旋转刷新，
                             自动换取新的 access/refresh。不会回显；已配置时留空表示不修改。
@@ -169,8 +162,7 @@
                                         <code>oidc.user:https://auth.trakt.tv:201dc70c...</code> 键
                                     </li>
                                     <li>
-                                        复制其中的 <code>refresh_token</code> 粘贴到上方输入框（
-                                        <code>access_token</code> 可留空，保存时会自动获取）
+                                        复制其中的 <code>refresh_token</code> 粘贴到上方输入框并保存
                                     </li>
                                 </ol>
                                 <div class="mb-0">保存时后端会立即验证并旋转刷新凭证（refresh 为旋转式，旧值作废）。</div>

--- a/templates/trakt/config.html
+++ b/templates/trakt/config.html
@@ -54,6 +54,100 @@
             </form>
         </div>
     </div>
+    <!-- 凭证模式卡片 -->
+    <div class="card mb-4">
+        <div class="card-header py-3">
+            <h6 class="mb-0 card-header-title">
+                <i class="bi bi-shield-lock me-2 card-header-icon"></i>凭证模式
+            </h6>
+        </div>
+        <div class="card-body">
+            <form id="auth-mode-form">
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <label class="form-label">凭证模式</label>
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="radio"
+                                   name="auth_type"
+                                   id="auth-type-oauth"
+                                   value="oauth">
+                            <label class="form-check-label" for="auth-type-oauth">
+                                OAuth 授权
+                                <span class="text-muted small">（推荐，令牌自动续期）</span>
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="radio"
+                                   name="auth_type"
+                                   id="auth-type-bearer"
+                                   value="bearer">
+                            <label class="form-check-label" for="auth-type-bearer">
+                                Bearer Token
+                                <span class="text-muted small">（从浏览器粘贴，自动续期）</span>
+                            </label>
+                        </div>
+                        <div class="form-text">
+                            两种凭证互斥；切换只改模式标记，另一模式凭证字段会被覆盖。
+                            Bearer 凭证保存时会立即验证并自动刷新。
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div id="bearer-input-group">
+                            <label for="bearer-access-token" class="form-label">Access Token</label>
+                            <input type="password"
+                                   class="form-control"
+                                   id="bearer-access-token"
+                                   name="access_token"
+                                   placeholder="粘贴 access_token（32 字符）"
+                                   autocomplete="off">
+                            <label for="bearer-refresh-token" class="form-label mt-2">Refresh Token</label>
+                            <input type="password"
+                                   class="form-control"
+                                   id="bearer-refresh-token"
+                                   name="refresh_token"
+                                   placeholder="粘贴 refresh_token（32 字符）"
+                                   autocomplete="off">
+                            <div class="form-text">不会回显；已配置时留空表示不修改</div>
+                            <div class="mt-2">
+                                <button class="btn btn-outline-secondary btn-sm"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#bearer-help">
+                                    <i class="bi bi-question-circle me-1"></i>如何获取 token？
+                                </button>
+                            </div>
+                            <div class="collapse mt-2" id="bearer-help">
+                                <div class="small text-muted border rounded p-2">
+                                    <ol class="mb-2 ps-3">
+                                        <li>
+                                            用浏览器登录 <a href="https://app.trakt.tv" target="_blank" rel="noopener">app.trakt.tv</a>
+                                        </li>
+                                        <li>按 F12 打开开发者工具 → Application → Local Storage</li>
+                                        <li>
+                                            展开 <code>https://auth.trakt.tv</code>，找到
+                                            <code>oidc.user:https://auth.trakt.tv:201dc70c...</code> 键
+                                        </li>
+                                        <li>
+                                            复制其中 <code>access_token</code> 与 <code>refresh_token</code> 的值分别粘贴到上方两个输入框
+                                        </li>
+                                    </ol>
+                                    <div class="mb-0">保存时后端会立即验证并刷新凭证（refresh 为旋转式，旧值作废）。</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div id="bearer-status-info" class="mt-2 small"></div>
+                    </div>
+                </div>
+                <div class="text-end">
+                    <button type="submit" class="btn btn-primary" disabled>
+                        <i class="bi bi-save me-1"></i>保存凭证配置
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
     <!-- 连接状态卡片 -->
     <div class="card mb-4">
         <div class="card-header py-3">

--- a/tests/api/test_trakt.py
+++ b/tests/api/test_trakt.py
@@ -255,6 +255,20 @@ async def test_update_trakt_config_bearer_fields(
     mock_database_manager,
 ):
     """更新凭证模式与 Bearer 凭证（保存时验证并刷新）"""
+    # 首次读取为 oauth 配置；validate_and_save_bearer 落库后重读为 bearer 配置
+    config = mock_trakt_auth_service.get_user_trakt_config.return_value
+    config.auth_type = "oauth"
+    reloaded = MagicMock()
+    reloaded.auth_type = "bearer"
+    reloaded.user_id = "testuser"
+    reloaded.access_token = "new-token"
+    reloaded.is_token_expired.return_value = False
+    reloaded.expires_at = 1_700_000_000
+    reloaded.enabled = True
+    reloaded.sync_interval = "0 */6 * * *"
+    reloaded.sync_filter_enabled = True
+    reloaded.last_sync_time = None
+    mock_trakt_auth_service.get_user_trakt_config.side_effect = [config, reloaded]
     with patch(
         "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
     ) as mock_validate:
@@ -275,10 +289,8 @@ async def test_update_trakt_config_bearer_fields(
                 },
             )
         assert response.status_code == 200
-        mock_validate.assert_awaited_once_with("testuser", "access-tok", "refresh-tok")
-        config = mock_trakt_auth_service.get_user_trakt_config.return_value
-        assert config.auth_type == "bearer"
-        mock_trakt_auth_service.save_config.assert_called_once()
+        mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
+        mock_trakt_auth_service.update_config_fields.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -332,7 +344,7 @@ async def test_update_trakt_config_bearer_invalid_400(
                 },
             )
         assert response.status_code == 400
-        mock_trakt_auth_service.save_config.assert_not_called()
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -358,7 +370,213 @@ async def test_update_trakt_config_bearer_blank_keeps_existing(
         mock_validate.assert_not_called()
         config = mock_trakt_auth_service.get_user_trakt_config.return_value
         assert config.auth_type == "oauth"
-        mock_trakt_auth_service.save_config.assert_called_once()
+        mock_trakt_auth_service.update_config_fields.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_switch_to_bearer_without_tokens_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """只切模式不提供新凭证：拒绝（避免拿 oauth 凭证打 apiz 域）"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"auth_type": "bearer"},
+            )
+        assert response.status_code == 400
+        assert "Bearer 模式" in response.json()["detail"]
+        mock_validate.assert_not_called()
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_switch_to_oauth_from_bearer_requires_reauth(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """bearer → oauth 只改标记：拒绝，要求重新授权"""
+    config = mock_trakt_auth_service.get_user_trakt_config.return_value
+    config.auth_type = "bearer"
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"auth_type": "oauth"},
+            )
+        assert response.status_code == 400
+        assert "重新授权" in response.json()["detail"]
+        mock_validate.assert_not_called()
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_switch_to_bearer_with_tokens_ok(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """切到 bearer 且本次提供凭证：校验通过后保存"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        mock_validate.return_value = {
+            "success": True,
+            "message": "凭证有效，已保存",
+            "expires_at": 1_700_000_000,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={
+                    "auth_type": "bearer",
+                    "access_token": "access-tok",
+                    "refresh_token": "refresh-tok",
+                },
+            )
+        assert response.status_code == 200
+        mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
+        mock_trakt_auth_service.update_config_fields.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bearer_tokens_with_oauth_mode_rejected_no_side_effect(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """提交 Bearer 凭证却要求 oauth 模式：在落库前拒绝（无副作用）"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={
+                    "auth_type": "oauth",
+                    "access_token": "access-tok",
+                    "refresh_token": "refresh-tok",
+                },
+            )
+        assert response.status_code == 400
+        # 关键：validate 不应被调用（否则 Bearer 凭证已落库却返回 400）
+        mock_validate.assert_not_called()
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_bearer_refresh_only(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """仅提供 refresh_token（access 可选）：正常验证并保存"""
+    config = mock_trakt_auth_service.get_user_trakt_config.return_value
+    config.auth_type = "oauth"
+    reloaded = MagicMock()
+    reloaded.auth_type = "bearer"
+    reloaded.user_id = "testuser"
+    reloaded.access_token = "new-token"
+    reloaded.is_token_expired.return_value = False
+    reloaded.expires_at = 1_700_000_000
+    reloaded.enabled = True
+    reloaded.sync_interval = "0 */6 * * *"
+    reloaded.sync_filter_enabled = True
+    reloaded.last_sync_time = None
+    mock_trakt_auth_service.get_user_trakt_config.side_effect = [config, reloaded]
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        mock_validate.return_value = {
+            "success": True,
+            "message": "凭证有效，已保存",
+            "expires_at": 1_700_000_000,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"refresh_token": "refresh-tok"},
+            )
+        assert response.status_code == 200
+        mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
+
+
+@pytest.mark.asyncio
+async def test_update_bearer_access_only_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """仅提供 access_token（无 refresh）：无法校验/续期，400 且不落库"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"access_token": "access-tok"},
+            )
+        assert response.status_code == 400
+        assert "refresh_token" in response.json()["detail"]
+        mock_validate.assert_not_called()
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_non_credential_fields_not_touching_tokens(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """只更新非凭证字段：update_config_fields 收到白名单字段，不含 token 列"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.put(
+            "/api/trakt/config",
+            json={"enabled": True, "sync_interval": "0 */6 * * *"},
+        )
+    assert response.status_code == 200
+    mock_trakt_auth_service.update_config_fields.assert_called_once()
+    user_id, updates = mock_trakt_auth_service.update_config_fields.call_args[0]
+    assert user_id == "testuser"
+    assert set(updates.keys()) == {"enabled", "sync_interval"}
+    assert "access_token" not in updates
+    assert "refresh_token" not in updates
+    assert "expires_at" not in updates
 
 
 @pytest.mark.asyncio
@@ -446,8 +664,9 @@ async def test_update_trakt_config_creates_bearer_when_no_config(
                 },
             )
         assert response.status_code == 200
-        mock_validate.assert_awaited_once_with("testuser", "access-tok", "refresh-tok")
-        mock_trakt_auth_service.save_config.assert_called_once()
+        mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
+        # 无其他字段更新：凭证已由 validate_and_save_bearer 落库，无需再写
+        mock_trakt_auth_service.update_config_fields.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -480,7 +699,7 @@ async def test_update_trakt_config_save_failure(
     mock_database_manager,
 ):
     """测试更新 Trakt 配置保存失败"""
-    mock_trakt_auth_service.save_config.return_value = False
+    mock_trakt_auth_service.update_config_fields.return_value = False
 
     async with AsyncClient(
         transport=ASGITransport(app=app_with_auth), base_url="http://test"
@@ -592,6 +811,153 @@ async def test_update_trakt_api_config_exception(app_with_auth, mock_config_mana
             json={"client_id": "new"},
         )
         assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_email_login_start_success(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """邮箱登录：发送验证码成功 → 200 + retry_after 字段"""
+    with patch("app.api.trakt.start_email_login", new_callable=AsyncMock) as mock_start:
+        mock_start.return_value = {
+            "success": True,
+            "message": "验证码已发送至 u@example.com，请查收邮件（5 分钟内有效）",
+            "retry_after": None,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/trakt/email-login/start",
+                json={"email": "u@example.com"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["message"]
+        mock_start.assert_awaited_once()
+        assert mock_start.await_args[0][0] == "testuser"
+        assert mock_start.await_args[0][1] == "u@example.com"
+
+
+@pytest.mark.asyncio
+async def test_email_login_start_rate_limited_429(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """邮箱登录：冷却限流 → 429 + detail 携带 retry_after"""
+    with patch("app.api.trakt.start_email_login", new_callable=AsyncMock) as mock_start:
+        mock_start.return_value = {
+            "success": False,
+            "message": "发送过于频繁，请 58 秒后再试",
+            "retry_after": 58,
+            "rate_limited": True,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/trakt/email-login/start",
+                json={"email": "u@example.com"},
+            )
+        assert response.status_code == 429
+        detail = response.json()["detail"]
+        assert detail["retry_after"] == 58
+        assert "过于频繁" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_email_login_start_invalid_email_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """邮箱登录：邮箱无效 → 400"""
+    with patch("app.api.trakt.start_email_login", new_callable=AsyncMock) as mock_start:
+        mock_start.return_value = {
+            "success": False,
+            "message": "邮箱格式无效",
+            "retry_after": None,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/trakt/email-login/start",
+                json={"email": "not-an-email"},
+            )
+        assert response.status_code == 400
+        assert "邮箱格式无效" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_email_login_complete_success(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """邮箱登录：提交验证码成功 → 200 + expires_at"""
+    with patch(
+        "app.api.trakt.complete_email_login", new_callable=AsyncMock
+    ) as mock_complete:
+        mock_complete.return_value = {
+            "success": True,
+            "message": "登录成功，Bearer 凭证已保存并切换为 Bearer 模式",
+            "expires_at": 1_700_000_000,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/trakt/email-login/complete",
+                json={"otp": "123456"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["expires_at"] == 1_700_000_000
+        mock_complete.assert_awaited_once()
+        assert mock_complete.await_args[0][0] == "testuser"
+        assert mock_complete.await_args[0][1] == "123456"
+
+
+@pytest.mark.asyncio
+async def test_email_login_complete_failure_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """邮箱登录：验证码无效 → 400"""
+    with patch(
+        "app.api.trakt.complete_email_login", new_callable=AsyncMock
+    ) as mock_complete:
+        mock_complete.return_value = {
+            "success": False,
+            "message": "验证码无效或已过期，请重新输入或重新发送",
+            "expires_at": None,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/trakt/email-login/complete",
+                json={"otp": "000000"},
+            )
+        assert response.status_code == 400
+        assert "验证码无效" in response.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_trakt.py
+++ b/tests/api/test_trakt.py
@@ -2,6 +2,7 @@
 Trakt API测试
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,10 +46,12 @@ def mock_trakt_auth_service():
             user_id="test_user",
             enabled=True,
             sync_interval="0 */6 * * *",
+            sync_filter_enabled=True,
             last_sync_time=None,
             access_token="test_token",
             is_token_expired=lambda: False,
             expires_at=None,
+            auth_type="oauth",
             to_dict=lambda: {},
         )
         mock_auth.disconnect_trakt.return_value = True
@@ -241,6 +244,210 @@ async def test_update_trakt_config(
             json={"enabled": True, "sync_interval": "0 */6 * * *"},
         )
         assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_update_trakt_config_bearer_fields(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """更新凭证模式与 Bearer 凭证（保存时验证并刷新）"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        mock_validate.return_value = {
+            "success": True,
+            "message": "凭证有效，已保存",
+            "expires_at": 1_700_000_000,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={
+                    "auth_type": "bearer",
+                    "access_token": "access-tok",
+                    "refresh_token": "refresh-tok",
+                },
+            )
+        assert response.status_code == 200
+        mock_validate.assert_awaited_once_with("testuser", "access-tok", "refresh-tok")
+        config = mock_trakt_auth_service.get_user_trakt_config.return_value
+        assert config.auth_type == "bearer"
+        mock_trakt_auth_service.save_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_trakt_config_bearer_partial_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """只提供 access 或 refresh 其一 → 400"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"auth_type": "bearer", "access_token": "only-access"},
+            )
+        assert response.status_code == 400
+        mock_validate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_trakt_config_bearer_invalid_400(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """凭证验证失败 → 400 且不保存"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        mock_validate.return_value = {
+            "success": False,
+            "message": "凭证无效或已过期（invalid_grant），请重新从浏览器复制",
+            "expires_at": None,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={
+                    "access_token": "bad-access",
+                    "refresh_token": "bad-refresh",
+                },
+            )
+        assert response.status_code == 400
+        mock_trakt_auth_service.save_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_trakt_config_bearer_blank_keeps_existing(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """token 留空表示不修改（不触发验证，保留现有凭证）"""
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={"auth_type": "oauth", "access_token": "", "refresh_token": ""},
+            )
+        assert response.status_code == 200
+        mock_validate.assert_not_called()
+        config = mock_trakt_auth_service.get_user_trakt_config.return_value
+        assert config.auth_type == "oauth"
+        mock_trakt_auth_service.save_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_trakt_config_bearer_status(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """GET 返回 Bearer 凭证状态，但不回显 token 本身"""
+    config = mock_trakt_auth_service.get_user_trakt_config.return_value
+    config.auth_type = "bearer"
+    config.access_token = "secret-token"
+    config.expires_at = 1_700_000_000
+    config.is_token_expired = lambda: False
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/trakt/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["auth_type"] == "bearer"
+        assert data["token_configured"] is True
+        assert data["token_status"] == "active"
+        assert data["token_expires_at"] == 1_700_000_000
+        # token 值绝不回显
+        assert "access_token" not in data
+        assert "secret-token" not in json.dumps(data)
+
+
+@pytest.mark.asyncio
+async def test_get_trakt_config_bearer_expired_status(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """凭证过期时 token_status 为 expired"""
+    config = mock_trakt_auth_service.get_user_trakt_config.return_value
+    config.auth_type = "bearer"
+    config.access_token = "tok"
+    config.expires_at = 1_000_000_000
+    config.is_token_expired = lambda: True
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/trakt/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["token_status"] == "expired"
+        assert data["is_connected"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_trakt_config_creates_bearer_when_no_config(
+    app_with_auth,
+    mock_trakt_auth_service,
+    mock_trakt_scheduler,
+    mock_config_manager,
+    mock_database_manager,
+):
+    """无既有配置时可通过 Bearer 凭证直接创建（不依赖 OAuth 授权）"""
+    existing = mock_trakt_auth_service.get_user_trakt_config.return_value
+    mock_trakt_auth_service.get_user_trakt_config.side_effect = [None, existing]
+    with patch(
+        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
+    ) as mock_validate:
+        mock_validate.return_value = {
+            "success": True,
+            "message": "凭证有效，已保存",
+            "expires_at": 1_700_000_000,
+        }
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_auth), base_url="http://test"
+        ) as client:
+            response = await client.put(
+                "/api/trakt/config",
+                json={
+                    "access_token": "access-tok",
+                    "refresh_token": "refresh-tok",
+                },
+            )
+        assert response.status_code == 200
+        mock_validate.assert_awaited_once_with("testuser", "access-tok", "refresh-tok")
+        mock_trakt_auth_service.save_config.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_trakt.py
+++ b/tests/api/test_trakt.py
@@ -284,36 +284,12 @@ async def test_update_trakt_config_bearer_fields(
                 "/api/trakt/config",
                 json={
                     "auth_type": "bearer",
-                    "access_token": "access-tok",
                     "refresh_token": "refresh-tok",
                 },
             )
         assert response.status_code == 200
         mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
         mock_trakt_auth_service.update_config_fields.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_update_trakt_config_bearer_partial_400(
-    app_with_auth,
-    mock_trakt_auth_service,
-    mock_trakt_scheduler,
-    mock_config_manager,
-    mock_database_manager,
-):
-    """只提供 access 或 refresh 其一 → 400"""
-    with patch(
-        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
-    ) as mock_validate:
-        async with AsyncClient(
-            transport=ASGITransport(app=app_with_auth), base_url="http://test"
-        ) as client:
-            response = await client.put(
-                "/api/trakt/config",
-                json={"auth_type": "bearer", "access_token": "only-access"},
-            )
-        assert response.status_code == 400
-        mock_validate.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -339,7 +315,6 @@ async def test_update_trakt_config_bearer_invalid_400(
             response = await client.put(
                 "/api/trakt/config",
                 json={
-                    "access_token": "bad-access",
                     "refresh_token": "bad-refresh",
                 },
             )
@@ -364,7 +339,7 @@ async def test_update_trakt_config_bearer_blank_keeps_existing(
         ) as client:
             response = await client.put(
                 "/api/trakt/config",
-                json={"auth_type": "oauth", "access_token": "", "refresh_token": ""},
+                json={"auth_type": "oauth", "refresh_token": ""},
             )
         assert response.status_code == 200
         mock_validate.assert_not_called()
@@ -449,7 +424,6 @@ async def test_switch_to_bearer_with_tokens_ok(
                 "/api/trakt/config",
                 json={
                     "auth_type": "bearer",
-                    "access_token": "access-tok",
                     "refresh_token": "refresh-tok",
                 },
             )
@@ -477,7 +451,6 @@ async def test_bearer_tokens_with_oauth_mode_rejected_no_side_effect(
                 "/api/trakt/config",
                 json={
                     "auth_type": "oauth",
-                    "access_token": "access-tok",
                     "refresh_token": "refresh-tok",
                 },
             )
@@ -526,31 +499,6 @@ async def test_update_bearer_refresh_only(
             )
         assert response.status_code == 200
         mock_validate.assert_awaited_once_with("testuser", "refresh-tok")
-
-
-@pytest.mark.asyncio
-async def test_update_bearer_access_only_400(
-    app_with_auth,
-    mock_trakt_auth_service,
-    mock_trakt_scheduler,
-    mock_config_manager,
-    mock_database_manager,
-):
-    """仅提供 access_token（无 refresh）：无法校验/续期，400 且不落库"""
-    with patch(
-        "app.api.trakt.validate_and_save_bearer", new_callable=AsyncMock
-    ) as mock_validate:
-        async with AsyncClient(
-            transport=ASGITransport(app=app_with_auth), base_url="http://test"
-        ) as client:
-            response = await client.put(
-                "/api/trakt/config",
-                json={"access_token": "access-tok"},
-            )
-        assert response.status_code == 400
-        assert "refresh_token" in response.json()["detail"]
-        mock_validate.assert_not_called()
-        mock_trakt_auth_service.update_config_fields.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -659,7 +607,6 @@ async def test_update_trakt_config_creates_bearer_when_no_config(
             response = await client.put(
                 "/api/trakt/config",
                 json={
-                    "access_token": "access-tok",
                     "refresh_token": "refresh-tok",
                 },
             )

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -760,6 +760,58 @@ class TestDatabaseDockerAndTrakt:
                 enabled = db.get_trakt_configs_with_sync_enabled()
                 assert enabled[0]["access_token"] == "secret-at"
 
+    def test_update_trakt_config_fields_does_not_touch_tokens(
+        self, temp_dir, reset_singletons
+    ):
+        """部分字段更新：只写白名单列，不覆盖既有 token（防并发旋转被旧值覆盖）"""
+        with patch("app.core.database.logger"):
+            with patch(
+                "app.core.config_secret_crypto._master_secret",
+                return_value="test-secret-key-for-trakt-token",
+            ):
+                from app.core.database import DatabaseManager
+
+                db_path = temp_dir / "trakt_partial.db"
+                db = DatabaseManager(str(db_path))
+                now = 1_700_000_000
+                db.save_trakt_config(
+                    {
+                        "user_id": "u1",
+                        "access_token": "orig-at",
+                        "refresh_token": "orig-rt",
+                        "expires_at": now,
+                        "enabled": True,
+                        "sync_interval": "0 */6 * * *",
+                        "last_sync_time": None,
+                        "created_at": now,
+                        "updated_at": now,
+                    }
+                )
+
+                # 只更新非凭证字段，并尝试注入 token 列（应被白名单忽略）
+                assert (
+                    db.update_trakt_config_fields(
+                        "u1",
+                        {
+                            "enabled": False,
+                            "sync_interval": "0 */12 * * *",
+                            "auth_type": "bearer",
+                            "access_token": "EVIL-NEW-TOKEN",
+                            "refresh_token": "EVIL-NEW-REFRESH",
+                            "expires_at": 1,
+                        },
+                    )
+                    is True
+                )
+                row = db.get_trakt_config("u1")
+                assert row["enabled"] is False
+                assert row["sync_interval"] == "0 */12 * * *"
+                assert row["auth_type"] == "bearer"
+                # token 列保持不变
+                assert row["access_token"] == "orig-at"
+                assert row["refresh_token"] == "orig-rt"
+                assert row["expires_at"] == now
+
     def test_feiniu_watermark_invalid_meta_resets(self, temp_dir, reset_singletons):
         db_path = temp_dir / "wm_bad.db"
         with patch("app.core.database.logger"):

--- a/tests/models/test_trakt.py
+++ b/tests/models/test_trakt.py
@@ -35,6 +35,50 @@ def test_trakt_config_from_dict_none():
     assert TraktConfig.from_dict(None) is None
 
 
+def test_trakt_config_bearer_fields_roundtrip():
+    """Bearer 凭证字段（复用 access/refresh/expires_at）to_dict / from_dict 往返一致"""
+    cfg = TraktConfig(
+        user_id="u1",
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=1_700_000_000,
+        auth_type="bearer",
+    )
+    d = cfg.to_dict()
+    assert d["auth_type"] == "bearer"
+    assert d["access_token"] == "access-token"
+    assert d["refresh_token"] == "refresh-token"
+    assert d["expires_at"] == 1_700_000_000
+
+    restored = TraktConfig.from_dict(d)
+    assert restored.auth_type == "bearer"
+    assert restored.access_token == "access-token"
+    assert restored.refresh_token == "refresh-token"
+    assert restored.expires_at == 1_700_000_000
+
+
+def test_trakt_config_auth_type_defaults_and_validation():
+    """auth_type 默认值与非法的回退逻辑"""
+    cfg = TraktConfig(user_id="u1")
+    assert cfg.auth_type == "oauth"
+
+    # 非法值回退 oauth
+    assert TraktConfig(user_id="u1", auth_type="hack").auth_type == "oauth"
+    assert TraktConfig(user_id="u1", auth_type="cookie").auth_type == "oauth"
+
+    # from_dict 同样回退
+    restored = TraktConfig.from_dict(
+        {"user_id": "u1", "access_token": "t", "auth_type": "hack"}
+    )
+    assert restored.auth_type == "oauth"
+
+    # bearer 模式保留
+    restored_b = TraktConfig.from_dict(
+        {"user_id": "u1", "access_token": "t", "auth_type": "bearer"}
+    )
+    assert restored_b.auth_type == "bearer"
+
+
 def test_trakt_config_from_dict_enabled_variants():
     base = {
         "user_id": "u",

--- a/tests/services/test_trakt_email_login.py
+++ b/tests/services/test_trakt_email_login.py
@@ -1,5 +1,6 @@
 """Trakt 邮箱登录服务测试（邮箱 + 验证码 → 自动获取 Bearer 凭证）。"""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -147,6 +148,7 @@ class TestStartEmailLogin:
             assert second["success"] is False
             assert "过于频繁" in second["message"]
             assert second["retry_after"] is not None
+            assert second.get("rate_limited") is True
             # 发信应只被调用一次（第二次被限流拦截）
             assert email_login._send_magic.await_count == 1
 
@@ -204,6 +206,41 @@ class TestOidcAuthorize:
                 "redirect": True,
                 "url": "https://app.trakt.tv/callback?code=CODE123&state=WRONG",
             },
+        )
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize("cookie", "state123", "verifier")
+
+            assert code == ""
+            assert "状态校验失败" in err
+
+    @pytest.mark.asyncio
+    async def test_json_redirect_missing_state_rejected(self):
+        """JSON 跳转负载缺 state（空值）：fail-closed 拒绝"""
+        resp = _FakeResp(
+            status=200,
+            payload={
+                "redirect": True,
+                "url": "https://app.trakt.tv/callback?code=CODE123",
+            },
+        )
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize("cookie", "state123", "verifier")
+
+            assert code == ""
+            assert "状态校验失败" in err
+
+    @pytest.mark.asyncio
+    async def test_redirect_302_missing_state_rejected(self):
+        """302 Location 缺 state：fail-closed 拒绝"""
+        resp = _FakeResp(
+            status=302,
+            location="https://app.trakt.tv/callback?code=CODE302",
         )
         with patch(
             "app.services.trakt.email_login.AsyncHttpClient",
@@ -311,6 +348,98 @@ class TestCompleteEmailLogin:
             assert "u1" in email_login._pending  # 保留，可重试
 
     @pytest.mark.asyncio
+    async def test_otp_attempt_limit_invalidates_session(self):
+        """OTP 连续失败超过上限：会话作废，需重新发送验证码。
+
+        名额在网络调用前占用（并发提交也无法绕过上限），因此第
+        MAX+1 次提交会被拒绝。
+        """
+        from app.services.trakt.email_login import MAX_OTP_ATTEMPTS
+
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(False, "验证码无效或已过期，请重新输入或重新发送", ""),
+            ),
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            # 前 MAX 次：均打到上游（无效 OTP，保留会话）
+            for _ in range(MAX_OTP_ATTEMPTS):
+                result = await complete_email_login("u1", "000000")
+                assert "次数过多" not in result["message"]
+
+            # 第 MAX+1 次：达到上限，拒绝并作废会话
+            result = await complete_email_login("u1", "000000")
+
+            assert result["success"] is False
+            assert "次数过多" in result["message"]
+            assert "u1" not in email_login._pending  # 会话已作废
+
+    @pytest.mark.asyncio
+    async def test_concurrent_otp_submit_cannot_exceed_limit(self):
+        """并发提交 OTP：名额在网络调用前占用，上游调用次数不超过上限。"""
+        from app.services.trakt.email_login import MAX_OTP_ATTEMPTS
+
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(False, "验证码无效或已过期，请重新输入或重新发送", ""),
+            ) as mock_submit,
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            # 并发发起远超上限的提交，全部并发执行
+            results = await asyncio.gather(
+                *[
+                    complete_email_login("u1", "000000")
+                    for _ in range(MAX_OTP_ATTEMPTS * 3)
+                ]
+            )
+
+            # 打到上游的调用不超过上限
+            assert mock_submit.await_count <= MAX_OTP_ATTEMPTS
+            # 至少有一次「次数过多」拒绝
+            assert any("次数过多" in r["message"] for r in results)
+            # 会话最终作废
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_otp_attempts_below_limit_keeps_pending(self):
+        """OTP 失败未达上限：会话保留，可继续重试"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(False, "验证码无效或已过期，请重新输入或重新发送", ""),
+            ),
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "000000")
+
+            assert result["success"] is False
+            assert email_login._pending["u1"].attempts == 1
+            assert "u1" in email_login._pending
+
+    @pytest.mark.asyncio
     async def test_full_success_saves_bearer(self):
         """完整成功链路：提交 OTP → OIDC → 落库 + 追加媒体用户名 + 清理 pending"""
         with (
@@ -393,6 +522,63 @@ class TestCompleteEmailLogin:
             assert "授权" in result["message"]
             mock_db.save_trakt_config.assert_not_called()
             assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_exchange_response_missing_tokens_not_saved(self):
+        """token 响应缺 access/refresh 字段：不落库，返回明确错误"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(True, "", "__Secure-better-auth.session_token=abc123"),
+            ),
+            patch(
+                "app.services.trakt.email_login._oidc_authorize",
+                new_callable=AsyncMock,
+                return_value=("code123", ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._exchange_code",
+                new_callable=AsyncMock,
+                return_value=({"expires_in": 3600}, ""),
+            ),
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is False
+            assert "缺少令牌字段" in result["message"]
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persist_tokens_uses_refresh_lock(self):
+        """邮箱登录落库与刷新共用 per-user 锁（防止并发旋转互相覆盖）"""
+        lock = asyncio.Lock()
+        with (
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.email_login._get_refresh_lock",
+                new_callable=AsyncMock,
+                return_value=lock,
+            ) as mock_lock,
+            patch("app.services.trakt.email_login._ensure_media_server_username"),
+        ):
+            mock_db.get_trakt_config.return_value = None
+
+            expires_at = await email_login._persist_tokens("u1", _token_response())
+
+            assert expires_at is not None
+            mock_lock.assert_awaited_once_with("u1")
+            assert not lock.locked()  # 落库后已释放
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["auth_type"] == "bearer"
 
     @pytest.mark.asyncio
     async def test_exchange_failure_clears_pending(self):

--- a/tests/services/test_trakt_email_login.py
+++ b/tests/services/test_trakt_email_login.py
@@ -1,0 +1,471 @@
+"""Trakt 邮箱登录服务测试（邮箱 + 验证码 → 自动获取 Bearer 凭证）。"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.trakt import email_login
+from app.services.trakt.email_login import (
+    _oidc_authorize,
+    complete_email_login,
+    start_email_login,
+)
+
+
+class _FakeResp:
+    """模拟 httpx.Response（仅提供 _oidc_authorize 用到的属性）。"""
+
+    def __init__(self, status=200, location=None, payload=None):
+        self.status_code = status
+        self.headers = {"location": location} if location else {}
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttp:
+    """模拟 AsyncHttpClient（链式配置 + request + aclose）。"""
+
+    def __init__(self, resp):
+        self._resp = resp
+
+    def prefix(self, *a, **k):
+        return self
+
+    def success_tpl(self, *a, **k):
+        return self
+
+    def failure_tpl(self, *a, **k):
+        return self
+
+    async def request(self, *a, **k):
+        return self._resp
+
+    async def aclose(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_pending():
+    """每个用例前清空模块级 pending 会话，避免用例间污染。"""
+    email_login._pending.clear()
+    yield
+    email_login._pending.clear()
+
+
+def _token_response(**over):
+    d = {
+        "access_token": "newaccess32characterslongenough123",
+        "refresh_token": "newrefresh32characterslongenough456",
+        "expires_in": 604800,
+        "expires_at": int(time.time()) + 604800,
+        "token_type": "bearer",
+        "id_token": "jwt",
+    }
+    d.update(over)
+    return d
+
+
+def _make_config_dict(**over):
+    d = {
+        "user_id": "u1",
+        "access_token": "",
+        "refresh_token": None,
+        "expires_at": None,
+        "enabled": 1,
+        "sync_interval": "0 */6 * * *",
+        "sync_filter_enabled": 1,
+        "last_sync_time": None,
+        "auth_type": "oauth",
+        "created_at": 1,
+        "updated_at": 1,
+    }
+    d.update(over)
+    return d
+
+
+class TestStartEmailLogin:
+    @pytest.mark.asyncio
+    async def test_invalid_email_rejected(self):
+        """邮箱格式无效：不发信，直接失败"""
+        with patch(
+            "app.services.trakt.email_login._send_magic", new_callable=AsyncMock
+        ) as mock_send:
+            result = await start_email_login("u1", "not-an-email")
+
+            assert result["success"] is False
+            assert "邮箱格式无效" in result["message"]
+            mock_send.assert_not_called()
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_send_success_creates_pending(self):
+        """发信成功：建立 pending 会话并返回成功"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ):
+            result = await start_email_login("u1", "  User@Example.COM ")
+
+            assert result["success"] is True
+            assert "验证码已发送" in result["message"]
+            pending = email_login._pending["u1"]
+            assert pending.email == "user@example.com"  # 已 trim + 小写
+            assert pending.verifier
+            assert pending.state
+
+    @pytest.mark.asyncio
+    async def test_send_failure_no_pending(self):
+        """发信失败：不建立 pending"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(False, "HTTP 500"),
+        ):
+            result = await start_email_login("u1", "user@example.com")
+
+            assert result["success"] is False
+            assert "发送验证码失败" in result["message"]
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_within_cooldown(self):
+        """60 秒内重复发信：限流拒绝，返回 retry_after"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ):
+            first = await start_email_login("u1", "user@example.com")
+            assert first["success"] is True
+
+            second = await start_email_login("u1", "user@example.com")
+
+            assert second["success"] is False
+            assert "过于频繁" in second["message"]
+            assert second["retry_after"] is not None
+            # 发信应只被调用一次（第二次被限流拦截）
+            assert email_login._send_magic.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resend_after_cooldown_overwrites_pending(self):
+        """冷却结束后重发：覆盖旧 pending（新 verifier/state）"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ):
+            first = await start_email_login("u1", "user@example.com")
+            assert first["success"] is True
+            old = email_login._pending["u1"]
+            # 伪造时间流逝，越过冷却窗口
+            email_login._pending["u1"].created_at = time.time() - 120
+
+            second = await start_email_login("u1", "other@example.com")
+
+            assert second["success"] is True
+            new_pending = email_login._pending["u1"]
+            assert new_pending.email == "other@example.com"
+            assert new_pending.verifier != old.verifier
+
+
+class TestOidcAuthorize:
+    @pytest.mark.asyncio
+    async def test_json_redirect_payload_returns_code(self):
+        """200 + JSON 跳转负载（SvelteKit 实测）：从 url 提取 code 并校验 state"""
+        state = "state123"
+        resp = _FakeResp(
+            status=200,
+            payload={
+                "redirect": True,
+                "url": f"https://app.trakt.tv/callback?code=CODE123&state={state}",
+            },
+        )
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize(
+                "__Secure-better-auth.session_token=x", state, "verifier"
+            )
+
+            assert code == "CODE123"
+            assert err == ""
+
+    @pytest.mark.asyncio
+    async def test_json_redirect_state_mismatch_rejected(self):
+        """JSON 跳转负载中 state 不匹配：拒绝"""
+        resp = _FakeResp(
+            status=200,
+            payload={
+                "redirect": True,
+                "url": "https://app.trakt.tv/callback?code=CODE123&state=WRONG",
+            },
+        )
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize("cookie", "state123", "verifier")
+
+            assert code == ""
+            assert "状态校验失败" in err
+
+    @pytest.mark.asyncio
+    async def test_redirect_302_location_returns_code(self):
+        """302 + Location 带 code（兼容路径）"""
+        state = "state123"
+        resp = _FakeResp(
+            status=302,
+            location=f"https://app.trakt.tv/callback?code=CODE302&state={state}",
+        )
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize("cookie", state, "verifier")
+
+            assert code == "CODE302"
+            assert err == ""
+
+    @pytest.mark.asyncio
+    async def test_no_code_returns_error(self):
+        """既无 302 也无可用 JSON：返回错误"""
+        resp = _FakeResp(status=500, payload={})
+        with patch(
+            "app.services.trakt.email_login.AsyncHttpClient",
+            return_value=_FakeHttp(resp),
+        ):
+            code, err = await _oidc_authorize("cookie", "state123", "verifier")
+
+            assert code == ""
+            assert "未返回授权码" in err
+
+
+class TestCompleteEmailLogin:
+    @pytest.mark.asyncio
+    async def test_no_pending_session(self):
+        """无进行中会话：提示重新发送验证码"""
+        result = await complete_email_login("u1", "123456")
+
+        assert result["success"] is False
+        assert "已过期" in result["message"] or "重新发送" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_pending_expired(self):
+        """会话超过 5 分钟：过期并清理"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ):
+            await start_email_login("u1", "user@example.com")
+            email_login._pending["u1"].created_at = time.time() - 301
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is False
+            assert "已过期" in result["message"]
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_otp_format_invalid(self):
+        """OTP 非 6 位数字：校验失败，保留 pending"""
+        with patch(
+            "app.services.trakt.email_login._send_magic",
+            new_callable=AsyncMock,
+            return_value=(True, ""),
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "12ab")
+
+            assert result["success"] is False
+            assert "6 位数字" in result["message"]
+            assert "u1" in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_otp_invalid_keeps_pending(self):
+        """OTP 无效（401）：失败但保留 pending 供重试"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(False, "验证码无效或已过期，请重新输入或重新发送", ""),
+            ),
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "000000")
+
+            assert result["success"] is False
+            assert "无效" in result["message"]
+            assert "u1" in email_login._pending  # 保留，可重试
+
+    @pytest.mark.asyncio
+    async def test_full_success_saves_bearer(self):
+        """完整成功链路：提交 OTP → OIDC → 落库 + 追加媒体用户名 + 清理 pending"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(True, "", "__Secure-better-auth.session_token=abc123"),
+            ),
+            patch(
+                "app.services.trakt.email_login._oidc_authorize",
+                new_callable=AsyncMock,
+                return_value=("code123", ""),
+            ) as mock_oidc,
+            patch(
+                "app.services.trakt.email_login._exchange_code",
+                new_callable=AsyncMock,
+                return_value=(_token_response(), ""),
+            ),
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.email_login._ensure_media_server_username"
+            ) as mock_ensure,
+        ):
+            mock_db.get_trakt_config.return_value = None
+            await start_email_login("u1", "user@example.com")
+            pending = email_login._pending["u1"]
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is True
+            assert "Bearer 凭证已保存" in result["message"]
+            assert result["expires_at"] is not None
+            # OIDC 拿到的是当前会话的 state
+            mock_oidc.assert_awaited_once_with(
+                "__Secure-better-auth.session_token=abc123",
+                pending.state,
+                pending.verifier,
+            )
+            # 落库：auth_type=bearer + 新 token
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["auth_type"] == "bearer"
+            assert saved["access_token"] == "newaccess32characterslongenough123"
+            assert saved["refresh_token"] == "newrefresh32characterslongenough456"
+            assert saved["expires_at"] is not None
+            mock_ensure.assert_called_once_with("u1")
+            # pending 已清理
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_oidc_failure_clears_pending(self):
+        """OTP 成功后 OIDC 失败：报错并清理 pending（会话已消费）"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(True, "", "__Secure-better-auth.session_token=abc123"),
+            ),
+            patch(
+                "app.services.trakt.email_login._oidc_authorize",
+                new_callable=AsyncMock,
+                return_value=("", "授权请求未返回授权码 (HTTP 401)"),
+            ),
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is False
+            assert "授权" in result["message"]
+            mock_db.save_trakt_config.assert_not_called()
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_exchange_failure_clears_pending(self):
+        """换取 token 失败：报错并清理 pending，不落库"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(True, "", "__Secure-better-auth.session_token=abc123"),
+            ),
+            patch(
+                "app.services.trakt.email_login._oidc_authorize",
+                new_callable=AsyncMock,
+                return_value=("code123", ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._exchange_code",
+                new_callable=AsyncMock,
+                return_value=(None, "HTTP 500: oops"),
+            ),
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+        ):
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is False
+            assert "HTTP 500" in result["message"]
+            mock_db.save_trakt_config.assert_not_called()
+            assert "u1" not in email_login._pending
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_config(self):
+        """已有配置：覆盖保存为 bearer 模式"""
+        with (
+            patch(
+                "app.services.trakt.email_login._send_magic",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._submit_otp",
+                new_callable=AsyncMock,
+                return_value=(True, "", "__Secure-better-auth.session_token=abc123"),
+            ),
+            patch(
+                "app.services.trakt.email_login._oidc_authorize",
+                new_callable=AsyncMock,
+                return_value=("code123", ""),
+            ),
+            patch(
+                "app.services.trakt.email_login._exchange_code",
+                new_callable=AsyncMock,
+                return_value=(_token_response(), ""),
+            ),
+            patch("app.services.trakt.email_login.database_manager") as mock_db,
+            patch("app.services.trakt.email_login._ensure_media_server_username"),
+        ):
+            # 既有 oauth 配置
+            mock_db.get_trakt_config.return_value = _make_config_dict(
+                auth_type="oauth", access_token="old_access"
+            )
+            await start_email_login("u1", "user@example.com")
+
+            result = await complete_email_login("u1", "123456")
+
+            assert result["success"] is True
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["auth_type"] == "bearer"
+            assert saved["access_token"] == "newaccess32characterslongenough123"
+            assert saved["refresh_token"] == "newrefresh32characterslongenough456"

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -318,6 +318,44 @@ class TestSyncUserTraktData:
             mock_auth.refresh_token.assert_awaited_once_with("user1")
 
     @pytest.mark.asyncio
+    async def test_sync_401_propagates_from_real_history_path(self):
+        """真实路径（不 mock 整段 _sync_watched_history）：拉历史中途 401 时
+        TraktAuthError 必须向上传播（不被 except Exception 吞掉），外层
+        刷新重建后重试成功。
+
+        对应评审点：_sync_watched_history 曾用 except Exception 把
+        TraktAuthError 收成普通失败结果，CI 靠 mock 整段函数保持绿色。
+        """
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch("app.services.trakt.sync_service.database_manager"),
+            patch("app.services.trakt.sync_service.notify_source_event"),
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "oauth"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            cfg.last_sync_time = None
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_auth.refresh_token = AsyncMock(return_value=True)
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            # 首次拉历史直接 401（真实走 _sync_watched_history 内部），重试后为空
+            mock_client.get_all_watched_history = AsyncMock(
+                side_effect=[TraktAuthError("401"), []]
+            )
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is True
+            assert mock_client.get_all_watched_history.await_count == 2
+            assert mock_auth.refresh_token.await_count == 1
+            assert mock_factory.create_client.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_sync_401_bearer_refresh(self):
         """bearer 模式 401：走 /oauth/token 旋转刷新（refresh_user_bearer）"""
         service = _make_service()
@@ -351,7 +389,7 @@ class TestSyncUserTraktData:
             result = await service.sync_user_trakt_data("user1")
 
             assert result.success is True
-            mock_refresh.assert_awaited_once_with("user1")
+            mock_refresh.assert_awaited_once_with("user1", force=True)
 
 
 class TestFetchDetailsBatch401:
@@ -548,6 +586,17 @@ class TestSyncWatchedHistory:
             "u", mock_client, MagicMock(), False
         )
         assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_trakt_auth_error_propagates(self):
+        """_sync_watched_history 中 401 必须向上传播（不吞成普通失败结果）"""
+        service = _make_service()
+        mock_client = AsyncMock()
+        mock_client.get_all_watched_history = AsyncMock(
+            side_effect=TraktAuthError("401")
+        )
+        with pytest.raises(TraktAuthError):
+            await service._sync_watched_history("u", mock_client, MagicMock(), False)
 
 
 class TestConvertTraktHistoryToCustomItem:

--- a/tests/services/test_trakt_sync_service.py
+++ b/tests/services/test_trakt_sync_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.services.trakt.client import TraktAuthError
 from app.services.trakt.models import (
     TraktCollectionItem,
     TraktHistoryItem,
@@ -91,7 +92,39 @@ class TestSyncUserTraktData:
             mock_auth.get_user_trakt_config.return_value = cfg
             result = await service.sync_user_trakt_data("user1")
             assert result.success is False
-            assert "未授权" in result.message
+            assert "未配置凭证" in result.message
+
+    @pytest.mark.asyncio
+    async def test_bearer_mode_uses_bearer_client(self):
+        """bearer 模式：走正常同步，client 以 auth_type=bearer 创建"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch("app.services.trakt.sync_service.database_manager"),
+            patch.object(
+                service,
+                "_sync_watched_history",
+                new_callable=AsyncMock,
+                return_value=MagicMock(
+                    synced_count=1, skipped_count=0, error_count=0, details={}
+                ),
+            ),
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "bearer"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            cfg.last_sync_time = None
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+            result = await service.sync_user_trakt_data("user1")
+            assert result.success is True
+            mock_factory.create_client.assert_awaited_once_with(
+                "tok", auth_type="bearer"
+            )
 
     @pytest.mark.asyncio
     async def test_token_expired_refresh_fail(self):
@@ -158,6 +191,181 @@ class TestSyncUserTraktData:
             result = await service.sync_user_trakt_data("user1")
             assert result.success is False
             assert "同步失败" in result.message
+
+    @pytest.mark.asyncio
+    async def test_sync_401_refresh_and_retry_success(self):
+        """同步中 401：刷新凭证 + 重建客户端后重试成功"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch("app.services.trakt.sync_service.database_manager"),
+            patch.object(
+                service, "_sync_watched_history", new_callable=AsyncMock
+            ) as mock_sync,
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "oauth"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            cfg.last_sync_time = None
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_auth.refresh_token = AsyncMock(return_value=True)
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+            mock_sync.side_effect = [
+                TraktAuthError("401"),
+                MagicMock(synced_count=1, skipped_count=0, error_count=0, details={}),
+            ]
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is True
+            assert mock_sync.await_count == 2
+            mock_auth.refresh_token.assert_awaited_once_with("user1")
+            # 首次创建 + 刷新后重建
+            assert mock_factory.create_client.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_401_refresh_fail(self):
+        """同步中 401 且刷新失败：返回明确错误"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch.object(
+                service, "_sync_watched_history", new_callable=AsyncMock
+            ) as mock_sync,
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "oauth"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_auth.refresh_token = AsyncMock(return_value=False)
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+            mock_sync.side_effect = [TraktAuthError("401")]
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is False
+            assert "刷新失败" in result.message
+            assert mock_sync.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_401_retry_still_fails(self):
+        """刷新后重试仍 401：只重试一次，返回明确错误"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch.object(
+                service, "_sync_watched_history", new_callable=AsyncMock
+            ) as mock_sync,
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "oauth"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_auth.refresh_token = AsyncMock(return_value=True)
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+            mock_sync.side_effect = [TraktAuthError("401"), TraktAuthError("401")]
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is False
+            assert "刷新后仍失败" in result.message
+            assert mock_sync.await_count == 2  # 首次 + 重试一次
+
+    @pytest.mark.asyncio
+    async def test_sync_401_on_create_client_retries(self):
+        """创建客户端时 401：同样触发刷新重建后重试"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch("app.services.trakt.sync_service.database_manager"),
+            patch.object(
+                service, "_sync_watched_history", new_callable=AsyncMock
+            ) as mock_sync,
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "oauth"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            cfg.last_sync_time = None
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_auth.refresh_token = AsyncMock(return_value=True)
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(
+                side_effect=[TraktAuthError("401"), mock_client]
+            )
+            mock_sync.return_value = MagicMock(
+                synced_count=1, skipped_count=0, error_count=0, details={}
+            )
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is True
+            assert mock_factory.create_client.await_count == 2
+            mock_auth.refresh_token.assert_awaited_once_with("user1")
+
+    @pytest.mark.asyncio
+    async def test_sync_401_bearer_refresh(self):
+        """bearer 模式 401：走 /oauth/token 旋转刷新（refresh_user_bearer）"""
+        service = _make_service()
+        with (
+            patch("app.services.trakt.sync_service.trakt_auth_service") as mock_auth,
+            patch("app.services.trakt.sync_service.TraktClientFactory") as mock_factory,
+            patch("app.services.trakt.sync_service.database_manager"),
+            patch(
+                "app.services.trakt.sync_service.refresh_user_bearer",
+                new_callable=AsyncMock,
+            ) as mock_refresh,
+            patch.object(
+                service, "_sync_watched_history", new_callable=AsyncMock
+            ) as mock_sync,
+        ):
+            cfg = MagicMock()
+            cfg.auth_type = "bearer"
+            cfg.access_token = "tok"
+            cfg.is_token_expired.return_value = False
+            cfg.last_sync_time = None
+            mock_auth.get_user_trakt_config.return_value = cfg
+            mock_refresh.return_value = "ok"
+            mock_client = AsyncMock()
+            mock_client.close = AsyncMock()
+            mock_factory.create_client = AsyncMock(return_value=mock_client)
+            mock_sync.side_effect = [
+                TraktAuthError("401"),
+                MagicMock(synced_count=1, skipped_count=0, error_count=0, details={}),
+            ]
+
+            result = await service.sync_user_trakt_data("user1")
+
+            assert result.success is True
+            mock_refresh.assert_awaited_once_with("user1")
+
+
+class TestFetchDetailsBatch401:
+    """详情批量获取中的 401 传播"""
+
+    @pytest.mark.asyncio
+    async def test_401_propagates(self):
+        service = _make_service()
+        client = AsyncMock()
+        client.get_show_info = AsyncMock(side_effect=TraktAuthError("401"))
+        with pytest.raises(TraktAuthError):
+            await service._fetch_details_batch(
+                [("1", "episode", 100)], client, True, {}, {}
+            )
 
 
 class TestSyncWatchedHistory:

--- a/tests/services/test_trakt_token_refresher.py
+++ b/tests/services/test_trakt_token_refresher.py
@@ -1,5 +1,6 @@
 """Trakt Bearer 凭证续期服务测试。"""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -60,7 +61,7 @@ class TestValidateAndSaveBearer:
             mock_db.get_trakt_config.return_value = _make_config_dict()
             mock_call.return_value = ("ok", _token_response(), None)
 
-            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+            result = await validate_and_save_bearer("u1", "ref1")
 
             assert result["success"] is True
             saved = mock_db.save_trakt_config.call_args[0][0]
@@ -81,7 +82,7 @@ class TestValidateAndSaveBearer:
         ):
             mock_call.return_value = ("invalid_grant", None, "invalid refresh token")
 
-            result = await validate_and_save_bearer("u1", "tok1", "bad")
+            result = await validate_and_save_bearer("u1", "bad")
 
             assert result["success"] is False
             assert "invalid_grant" in result["message"]
@@ -99,7 +100,7 @@ class TestValidateAndSaveBearer:
         ):
             mock_call.return_value = ("error", None, "timeout")
 
-            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+            result = await validate_and_save_bearer("u1", "ref1")
 
             assert result["success"] is False
             mock_db.save_trakt_config.assert_not_called()
@@ -117,7 +118,7 @@ class TestValidateAndSaveBearer:
             mock_db.get_trakt_config.return_value = None
             mock_call.return_value = ("ok", _token_response(), None)
 
-            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+            result = await validate_and_save_bearer("u1", "ref1")
 
             assert result["success"] is True
             saved = mock_db.save_trakt_config.call_args[0][0]
@@ -215,6 +216,96 @@ class TestRefreshUserBearer:
                 auth_type="oauth", refresh_token=None
             )
             assert (await refresh_user_bearer("u1")) == STATUS_SKIPPED
+
+    @pytest.mark.asyncio
+    async def test_force_skips_slack_check(self):
+        """force=True 时忽略 expires_at slack，剩余 >1 天也强制刷新（401 路径）"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(
+                expires_at=int(time.time()) + 6 * 86400  # 剩余 6 天
+            )
+            mock_call.return_value = ("ok", _token_response(), None)
+
+            status = await refresh_user_bearer("u1", force=True)
+
+            assert status == STATUS_OK
+            mock_call.assert_awaited_once()
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["access_token"] == "newaccess"
+
+    @pytest.mark.asyncio
+    async def test_ok_response_missing_tokens_keeps_state(self):
+        """ok 响应缺 token 字段：STATUS_FAILED 且不落库"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(expires_at=0)
+            mock_call.return_value = ("ok", {"expires_in": 604800}, None)
+
+            status = await refresh_user_bearer("u1", force=True)
+
+            assert status == STATUS_FAILED
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_refresh_serialized_by_lock(self):
+        """并发刷新被 per-user 锁串行化：第二个刷新读到第一次落库后的新 refresh。
+
+        无锁时两个协程会同时读到旧 refresh（r1），各自旋转后互相覆盖；
+        有锁 + 持锁重读时，第二次调用应以第一次的新 refresh（newrefresh）
+        发起 /oauth/token。
+        """
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            # 模拟真实存储：save 后 get 返回新值（否则并发重读永远拿到旧 config）
+            store = _make_config_dict(expires_at=0)
+
+            def _fake_get(uid):
+                return dict(store)
+
+            def _fake_save(cfg):
+                store.clear()
+                store.update(cfg)
+
+            mock_db.get_trakt_config.side_effect = _fake_get
+            mock_db.save_trakt_config.side_effect = _fake_save
+            # 每次刷新都返回同一组新 token（旋转式）；记录每次调用使用的 refresh
+            mock_call.side_effect = [
+                ("ok", _token_response(), None),
+                ("ok", _token_response(), None),
+            ]
+
+            r1, r2 = await asyncio.gather(
+                refresh_user_bearer("u1", force=True),
+                refresh_user_bearer("u1", force=True),
+            )
+
+            assert r1 == STATUS_OK
+            assert r2 == STATUS_OK
+            # 两次都真的调了 /oauth/token
+            assert mock_call.await_count == 2
+            # 第二次调用用的是第一次落库后的新 refresh（持锁重读）
+            assert mock_call.await_args_list[0][0][0] == "ref1"
+            assert mock_call.await_args_list[1][0][0] == "newrefresh"
+            # 落库两次，最终是旋转后的新 token
+            assert mock_db.save_trakt_config.call_count == 2
+            final_saved = mock_db.save_trakt_config.call_args[0][0]
+            assert final_saved["refresh_token"] == "newrefresh"
 
 
 class TestHeartbeatAllUsers:

--- a/tests/services/test_trakt_token_refresher.py
+++ b/tests/services/test_trakt_token_refresher.py
@@ -1,0 +1,263 @@
+"""Trakt Bearer 凭证续期服务测试。"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.trakt.token_refresher import (
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_OK,
+    STATUS_SKIPPED,
+    heartbeat_all_users,
+    refresh_user_bearer,
+    validate_and_save_bearer,
+)
+
+
+def _make_config_dict(**over):
+    d = {
+        "user_id": "u1",
+        "access_token": "tok1",
+        "refresh_token": "ref1",
+        "expires_at": None,
+        "enabled": 1,
+        "sync_interval": "0 */6 * * *",
+        "sync_filter_enabled": 1,
+        "last_sync_time": None,
+        "auth_type": "bearer",
+        "created_at": 1,
+        "updated_at": 1,
+    }
+    d.update(over)
+    return d
+
+
+def _token_response(access="newaccess", refresh="newrefresh", expires_in=604800):
+    return {
+        "access_token": access,
+        "expires_in": expires_in,
+        "expires_at": int(time.time()) + expires_in,
+        "token_type": "bearer",
+        "refresh_token": refresh,
+        "scope": "public openid profile email offline_access",
+        "id_token": "jwt",
+    }
+
+
+class TestValidateAndSaveBearer:
+    @pytest.mark.asyncio
+    async def test_success_rotates_and_saves(self):
+        """有效凭证：旋转式换新并落库（auth_type=bearer）"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict()
+            mock_call.return_value = ("ok", _token_response(), None)
+
+            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+
+            assert result["success"] is True
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["auth_type"] == "bearer"
+            assert saved["access_token"] == "newaccess"  # 旋转换新
+            assert saved["refresh_token"] == "newrefresh"
+            assert saved["expires_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_invalid_grant_not_saved(self):
+        """凭证无效：不落库，返回失败"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_call.return_value = ("invalid_grant", None, "invalid refresh token")
+
+            result = await validate_and_save_bearer("u1", "tok1", "bad")
+
+            assert result["success"] is False
+            assert "invalid_grant" in result["message"]
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_network_error_not_saved(self):
+        """网络错误：不落库，返回失败"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_call.return_value = ("error", None, "timeout")
+
+            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+
+            assert result["success"] is False
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_new_config_when_none(self):
+        """无既有配置：验证成功即新建配置"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = None
+            mock_call.return_value = ("ok", _token_response(), None)
+
+            result = await validate_and_save_bearer("u1", "tok1", "ref1")
+
+            assert result["success"] is True
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["user_id"] == "u1"
+            assert saved["auth_type"] == "bearer"
+
+
+class TestRefreshUserBearer:
+    @pytest.mark.asyncio
+    async def test_skipped_when_not_due(self):
+        """剩余 >1 天：跳过刷新"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(
+                expires_at=int(time.time()) + 3 * 86400
+            )
+            status = await refresh_user_bearer("u1")
+            assert status == STATUS_SKIPPED
+            mock_call.assert_not_called()
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ok_when_due(self):
+        """剩余 ≤1 天：刷新并旋转落库"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(
+                expires_at=int(time.time()) + 3600
+            )
+            mock_call.return_value = ("ok", _token_response(), None)
+
+            status = await refresh_user_bearer("u1")
+
+            assert status == STATUS_OK
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["access_token"] == "newaccess"
+            assert saved["refresh_token"] == "newrefresh"
+
+    @pytest.mark.asyncio
+    async def test_invalid_grant_marks_expired_and_notifies(self):
+        """invalid_grant：标失效（expires_at=0）+ 通知，保留配置"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+            patch(
+                "app.services.trakt.token_refresher.notify_scheduler_failure"
+            ) as mock_notify,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(expires_at=0)
+            mock_call.return_value = ("invalid_grant", None, "invalid refresh token")
+
+            status = await refresh_user_bearer("u1")
+
+            assert status == STATUS_EXPIRED
+            saved = mock_db.save_trakt_config.call_args[0][0]
+            assert saved["expires_at"] == 0
+            mock_notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_server_error_keeps_state(self):
+        """服务端错误：非失效，保留原状态"""
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher._call_oauth_token",
+                new_callable=AsyncMock,
+            ) as mock_call,
+        ):
+            mock_db.get_trakt_config.return_value = _make_config_dict(expires_at=0)
+            mock_call.return_value = ("error", None, "HTTP 500")
+
+            status = await refresh_user_bearer("u1")
+
+            assert status == STATUS_FAILED
+            mock_db.save_trakt_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skipped_wrong_mode_or_no_refresh(self):
+        """非 bearer 模式 / 无 refresh_token：跳过"""
+        with patch("app.services.trakt.token_refresher.database_manager") as mock_db:
+            mock_db.get_trakt_config.return_value = _make_config_dict(
+                auth_type="oauth", refresh_token=None
+            )
+            assert (await refresh_user_bearer("u1")) == STATUS_SKIPPED
+
+
+class TestHeartbeatAllUsers:
+    @pytest.mark.asyncio
+    async def test_only_bearer_mode_with_refresh(self):
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher.refresh_user_bearer",
+                new_callable=AsyncMock,
+            ) as mock_refresh,
+        ):
+            mock_db.get_trakt_configs_with_sync_enabled.return_value = [
+                _make_config_dict(user_id="u1", auth_type="bearer", refresh_token="r1"),
+                _make_config_dict(user_id="u2", auth_type="oauth", refresh_token=None),
+                _make_config_dict(user_id="u3", auth_type="bearer", refresh_token=None),
+            ]
+            mock_refresh.return_value = STATUS_OK
+
+            results = await heartbeat_all_users()
+
+            # 仅 u1 是 bearer 且有 refresh_token
+            assert results["checked"] == 1
+            assert results["ok"] == 1
+            mock_refresh.assert_awaited_once_with("u1")
+
+    @pytest.mark.asyncio
+    async def test_counts_expired_and_failed(self):
+        with (
+            patch("app.services.trakt.token_refresher.database_manager") as mock_db,
+            patch(
+                "app.services.trakt.token_refresher.refresh_user_bearer",
+                new_callable=AsyncMock,
+            ) as mock_refresh,
+        ):
+            mock_db.get_trakt_configs_with_sync_enabled.return_value = [
+                _make_config_dict(user_id="u1", refresh_token="r1"),
+                _make_config_dict(user_id="u2", refresh_token="r2"),
+            ]
+            mock_refresh.side_effect = [STATUS_EXPIRED, STATUS_SKIPPED]
+
+            results = await heartbeat_all_users()
+
+            assert results["checked"] == 2
+            assert results["expired"] == 1
+            assert results["skipped"] == 1

--- a/tests/trakt/test_client_http.py
+++ b/tests/trakt/test_client_http.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import respx
 
-from app.services.trakt.client import TraktClient, TraktClientFactory
+from app.services.trakt.client import TraktAuthError, TraktClient, TraktClientFactory
 
 
 @pytest.fixture
@@ -82,6 +82,50 @@ async def test_get_watched_history(mock_config):
     assert len(result) == 1
     assert result[0].show["title"] == "Test Show"
     assert mock_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_watched_history_401_propagates(mock_config):
+    """观看历史 401：传播 TraktAuthError 而非静默返回空列表"""
+    mock_route = respx.get("https://api.trakt.tv/sync/history").mock(
+        return_value=httpx.Response(
+            401,
+            headers={
+                "Content-Type": "application/json",
+                "X-RateLimit-Remaining": "999",
+                "X-RateLimit-Reset": "9999999999",
+            },
+        )
+    )
+
+    client = TraktClient(access_token="expired_token")
+    async with client:
+        with pytest.raises(TraktAuthError):
+            await client.get_watched_history()
+
+    assert mock_route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_all_watched_history_401_propagates(mock_config):
+    """分页全量历史 401：传播 TraktAuthError"""
+    respx.get("https://api.trakt.tv/sync/history").mock(
+        return_value=httpx.Response(
+            401,
+            headers={
+                "Content-Type": "application/json",
+                "X-RateLimit-Remaining": "999",
+                "X-RateLimit-Reset": "9999999999",
+            },
+        )
+    )
+
+    client = TraktClient(access_token="expired_token")
+    async with client:
+        with pytest.raises(TraktAuthError):
+            await client.get_all_watched_history()
 
 
 @pytest.mark.asyncio
@@ -260,7 +304,7 @@ async def test_test_connection(mock_config):
 @pytest.mark.asyncio
 @respx.mock
 async def test_test_connection_failure(mock_config):
-    """测试连接失败"""
+    """测试连接失败（401 = 认证失败，传播 TraktAuthError）"""
     mock_route = respx.get("https://api.trakt.tv/users/me").mock(
         return_value=httpx.Response(
             401,
@@ -275,9 +319,9 @@ async def test_test_connection_failure(mock_config):
 
     client = TraktClient(access_token="invalid_token")
     async with client:
-        result = await client.test_connection()
+        with pytest.raises(TraktAuthError):
+            await client.test_connection()
 
-    assert result is False
     assert mock_route.called
 
 

--- a/tests/trakt/test_client_http_branches.py
+++ b/tests/trakt/test_client_http_branches.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from app.services.trakt.client import TraktClient, TraktClientFactory
+from app.services.trakt.client import TraktAuthError, TraktClient, TraktClientFactory
 
 
 @pytest.fixture
@@ -35,13 +35,14 @@ async def test_make_request_200_and_204(client):
 
 @pytest.mark.asyncio
 async def test_make_request_401_raises(client):
+    """401 抛专用 TraktAuthError（不重试、不吞掉）"""
     resp = MagicMock(status_code=401)
     resp.headers = httpx.Headers({})
     client._http = MagicMock()
     client._http.request = AsyncMock(return_value=resp)
     with patch.object(client, "_check_rate_limit", new_callable=AsyncMock):
         with patch.object(client, "_update_rate_limit"):
-            with pytest.raises(ValueError, match="认证失败"):
+            with pytest.raises(TraktAuthError, match="401"):
                 await client._make_request("GET", "/x")
 
 

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -52,7 +52,7 @@ async def test_sync_user_trakt_data_no_token():
         result = await service.sync_user_trakt_data("user1")
 
         assert result.success is False
-        assert "未授权" in result.message
+        assert "未配置凭证" in result.message
 
 
 @pytest.mark.asyncio

--- a/tests/trakt/test_sync_service_comprehensive.py
+++ b/tests/trakt/test_sync_service_comprehensive.py
@@ -210,6 +210,7 @@ async def test_sync_user_trakt_data_empty_history_success():
         patch("app.services.trakt.sync_service.database_manager") as mock_db,
     ):
         cfg = MagicMock()
+        cfg.user_id = "u1"
         cfg.access_token = "tok"
         cfg.is_token_expired.return_value = False
         mock_auth.get_user_trakt_config.return_value = cfg
@@ -221,7 +222,12 @@ async def test_sync_user_trakt_data_empty_history_success():
         svc = TraktSyncService()
         r = await svc.sync_user_trakt_data("u1")
         assert r.success is True
-        mock_db.save_trakt_config.assert_called()
+        # 同步完成：只更新 last_sync_time（不触碰 token 列）
+        mock_db.update_trakt_config_fields.assert_called()
+        assert mock_db.update_trakt_config_fields.call_args[0][0] == "u1"
+        assert set(mock_db.update_trakt_config_fields.call_args[0][1].keys()) == {
+            "last_sync_time"
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_http_base.py
+++ b/tests/utils/test_http_base.py
@@ -462,6 +462,105 @@ class TestLogging:
             msg = ml.debug.call_args[0][0]
             assert "Body(Form)" in msg
 
+    def test_log_request_redacts_sensitive_headers(self):
+        """Authorization / Cookie 头值在 DEBUG 日志中脱敏"""
+        client = SyncHttpClient(label="T")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_request(
+                "GET",
+                "http://example.com",
+                headers={
+                    "Authorization": "Bearer secret-access-token",
+                    "Cookie": "__Secure-better-auth.session_token=abc123",
+                    "X-Custom": "keep-me",
+                },
+            )
+            msg = ml.debug.call_args[0][0]
+            assert "secret-access-token" not in msg
+            assert "abc123" not in msg
+            assert "keep-me" in msg
+
+    def test_log_request_redacts_sensitive_json_keys(self):
+        """JSON 请求体敏感键（refresh_token / otp / code / client_secret）脱敏"""
+        client = SyncHttpClient(label="T")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_request(
+                "POST",
+                "http://example.com",
+                json={
+                    "grant_type": "refresh_token",
+                    "refresh_token": "rotating-refresh",
+                    "client_id": "public-id",
+                },
+            )
+            msg = ml.debug.call_args[0][0]
+            assert "rotating-refresh" not in msg
+            assert "public-id" in msg
+
+    def test_log_request_redacts_sensitive_form_data(self):
+        """表单串中的 otp 脱敏、email 保留"""
+        client = SyncHttpClient(label="T")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_request(
+                "POST",
+                "http://example.com",
+                data="email=user%40example.com&otp=123456",
+            )
+            msg = ml.debug.call_args[0][0]
+            assert "123456" not in msg
+            assert "user%40example.com" in msg
+
+    def test_log_success_redacts_response_body(self):
+        """响应体 JSON 中的 access_token / refresh_token 脱敏"""
+        resp = _mock_response(
+            status_code=200,
+            text='{"access_token": "tok-1", "refresh_token": "tok-2", "expires_in": 3600}',
+            headers={"Set-Cookie": "session=xyz; Path=/"},
+        )
+        client = SyncHttpClient(label="T").prefix("🚀").success_tpl("成功")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_success(resp, "POST", "http://example.com")
+            msg = ml.debug.call_args[0][0]
+            assert "tok-1" not in msg
+            assert "tok-2" not in msg
+            assert "xyz" not in msg
+            assert "expires_in" in msg
+
+    def test_log_success_redacts_code_state_in_location_header(self):
+        """302 Location 头中的授权 code / state 脱敏（授权码/CSRF 不得进日志）"""
+        resp = _mock_response(
+            status_code=302,
+            text="",
+            headers={
+                "Location": (
+                    "https://app.trakt.tv/callback?code=AUTHCODE123&state=CSRF456"
+                )
+            },
+        )
+        client = SyncHttpClient(label="T")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_success(resp, "GET", "http://example.com")
+            msg = ml.debug.call_args[0][0]
+            assert "AUTHCODE123" not in msg
+            assert "CSRF456" not in msg
+
+    def test_log_success_redacts_code_state_in_json_url(self):
+        """JSON 回跳负载 url 字段中的 code / state 脱敏"""
+        resp = _mock_response(
+            status_code=200,
+            text=(
+                '{"redirect": true, '
+                '"url": "https://app.trakt.tv/callback?code=SECRETCODE&state=SECRETSTATE"}'
+            ),
+            headers={},
+        )
+        client = SyncHttpClient(label="T")
+        with patch("app.utils.http_base.logger") as ml:
+            client._log_success(resp, "GET", "http://example.com")
+            msg = ml.debug.call_args[0][0]
+            assert "SECRETCODE" not in msg
+            assert "SECRETSTATE" not in msg
+
     def test_log_success_debug_only(self):
         resp = _mock_response(status_code=200, text="hello", headers={"X": "1"})
         client = SyncHttpClient(label="T").prefix("🚀").success_tpl("成功")


### PR DESCRIPTION
## 背景

见 [Related #218](https://github.com/SanaeMio/Bangumi-syncer/issues/218)：Trakt 限制了免费用户，非会员无法创建 OAuth 应用且授权应用仅限一个，导致原本依赖 OAuth 的同步功能对多数用户不可用。本 PR 为 Trakt 同步新增**免建应用**的授权路径，让用户无需创建 Trakt 应用也能正常使用同步。

## 变更内容

### 新增 Bearer 凭证模式

- 新增 `auth_type: oauth/bearer` 凭证模式，复用现有 `access_token` / `refresh_token` / `expires_at` 字段，切换即覆盖
- 保存凭证时立即调用 `auth.trakt.tv/oauth/token` 验证并旋转刷新后落库（refresh_token 为旋转式，旧值作废）
- `TraktClient` 按模式分流：bearer 走官方数据域 `apiz.trakt.tv` + 静态 client_id，无需 Client ID / Secret / 回调地址
- 配置页新增 Bearer 双 token 输入，token 绝不回显、留空表示不修改
- 同步服务删掉 cookie 模式报错，bearer 模式正常走增量同步

### 邮箱一键登录自动获取凭证

- 新增 `email_login` 服务：发信 → OTP → OIDC 授权码流（PKCE S256）→ 自动落库，全程服务端流转
- 新增 `POST /api/trakt/email-login/start` 与 `/complete` 两个端点
- 前端「通过邮箱登录」按钮与两步骤弹窗（60s 重发冷却）
- 登录成功自动切换 Bearer 模式并追加 `media_server_usernames`（与 API 应用授权成功行为一致）
- 兼容 `authorize` 200 JSON 跳转（SvelteKit 协议）与 302 两种响应

### 凭证生命周期管理

- 每日心跳按 `expires_at` 智能续期（剩余 <1 天才刷新），失效通知不删除配置
- 同步中 401 抛 `TraktAuthError`，自动刷新凭证并重建客户端重试一次

### 配置页交互重构

- 凭证模式卡片置顶，「API 应用」与「Bearer 凭证」拆分为独立卡片按需显示
- 切换模式即时联动显示对应凭证卡片；「OAuth 授权」更名「API 应用」
- 更新 `docs/usage/trakt.md`

## 验证

- `ruff check` / `ruff format --check`：通过
- `pytest tests/`：**3182 passed**，新增约 700+ 行测试覆盖 email_login、token_refresher、sync 401 重试等