### PR TITLE
fix: 修复升级时迁移配置的一些问题

### DIFF
--- a/app/core/accounts.py
+++ b/app/core/accounts.py
@@ -11,10 +11,17 @@ Bangumi 账号统一访问层（全列表化重构的核心）。
 
 from typing import Any, Optional
 
-from .config import config_manager
+from .config import config_manager, parse_media_server_username_value
 from .database import database_manager
 
 _BANGUMI_SECTION = "bangumi"
+
+
+def _to_str(value) -> str:
+    """规范化配置值为字符串（兼容 get() 将纯数字转为 int）。"""
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
 def _to_int(value):
@@ -48,13 +55,15 @@ def _collect_ini_accounts() -> list[dict]:
     # 单用户段 [bangumi]（仅当真实存在且有 username + access_token 时，
     # 与多用户段 get_bangumi_configs 的过滤条件对齐，避免迁入"半配置"幽灵账号）
     if config_manager.get_config_parser().has_section(_BANGUMI_SECTION):
-        username = config_manager.get(_BANGUMI_SECTION, "username", fallback="") or ""
-        access_token = (
-            config_manager.get(_BANGUMI_SECTION, "access_token", fallback="") or ""
+        username = _to_str(
+            config_manager.get(_BANGUMI_SECTION, "username", fallback="")
+        )
+        access_token = _to_str(
+            config_manager.get(_BANGUMI_SECTION, "access_token", fallback="")
         )
         if (
-            username.strip()
-            and access_token.strip()
+            username
+            and access_token
             and _BANGUMI_SECTION not in {a["section_name"] for a in accounts}
         ):
             raw = {
@@ -91,19 +100,28 @@ def _collect_ini_accounts() -> list[dict]:
     return accounts
 
 
+def _normalize_media_server_usernames(raw) -> list[str]:
+    """规范化 media_server_username（兼容 get() 将纯数字转为 int）。"""
+    if isinstance(raw, (list, tuple)):
+        return list(raw)
+    return parse_media_server_username_value(raw)
+
+
 def _cfg_to_account(section_name: str, cfg: dict) -> dict:
     return {
         "section_name": section_name,
-        "username": (cfg.get("username") or "").strip(),
-        "media_server_usernames": cfg.get("media_server_username") or [],
-        "auth_method": cfg.get("auth_method") or "manual",
-        "access_token": cfg.get("access_token") or "",
-        "refresh_token": cfg.get("refresh_token") or "",
-        "token_type": cfg.get("token_type") or "Bearer",
+        "username": _to_str(cfg.get("username")),
+        "media_server_usernames": _normalize_media_server_usernames(
+            cfg.get("media_server_username")
+        ),
+        "auth_method": _to_str(cfg.get("auth_method")) or "manual",
+        "access_token": _to_str(cfg.get("access_token")),
+        "refresh_token": _to_str(cfg.get("refresh_token")),
+        "token_type": _to_str(cfg.get("token_type")) or "Bearer",
         "expires_at": _to_int(cfg.get("expires_at")),
-        "bangumi_user_id": cfg.get("bangumi_user_id") or "",
-        "nickname": cfg.get("nickname") or "",
-        "avatar": cfg.get("avatar") or "",
+        "bangumi_user_id": _to_str(cfg.get("bangumi_user_id")),
+        "nickname": _to_str(cfg.get("nickname")),
+        "avatar": _to_str(cfg.get("avatar")),
         "private": _to_bool(cfg.get("private")),
         "is_active": False,
     }

--- a/app/core/database/accounts.py
+++ b/app/core/database/accounts.py
@@ -56,6 +56,8 @@ def _to_json_list(value) -> str:
         return json.dumps([value]) if value.strip() else "[]"
     if isinstance(value, (list, tuple)):
         return json.dumps(list(value))
+    if isinstance(value, (int, float)):
+        return json.dumps([str(value)])
     return "[]"
 
 

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -169,6 +169,7 @@ class Logger:
         # 不在 __init__ 中打开日志文件：模块执行 logger = Logger() 时，若此处导入
         # config，而 config 初始化链又 import logger，会触发 partially initialized 循环依赖。
         self._log_file_lazy_initialized = False
+        self._log_file_import_warned = False
         # 日志监听器列表（用于实时捕获日志，如重试 SSE 推送）
         self._listeners: list[Callable[[str, str], None]] = []
         # 是否已注册配置变更监听（幂等，避免重复注册）
@@ -221,21 +222,27 @@ class Logger:
         """首次写日志前再绑定文件与 config（避免与 config 模块循环导入）。"""
         if self._log_file_lazy_initialized:
             return
-        self._log_file_lazy_initialized = True
-        self._setup_log_file()
+        if self._setup_log_file():
+            self._log_file_lazy_initialized = True
 
-    def _setup_log_file(self) -> None:
-        """设置日志文件（成功/跳过/失败均向 stderr 输出一行，便于排查）"""
+    def _setup_log_file(self) -> bool:
+        """设置日志文件（成功/跳过/失败均向 stderr 输出一行，便于排查）。
+
+        返回 True 表示已尝试绑定 config（含显式禁用文件日志）；False 表示
+        config 尚未可导入，调用方应稍后重试。
+        """
         self._close_log_file_handle()
 
         try:
             from .config import config_manager
         except ImportError as e:
-            print(
-                f"文件日志未启用: 无法导入 config（{e!r}），仅输出到控制台",
-                file=sys.stderr,
-            )
-            return
+            if not self._log_file_import_warned:
+                print(
+                    f"文件日志未启用: 无法导入 config（{e!r}），仅输出到控制台",
+                    file=sys.stderr,
+                )
+                self._log_file_import_warned = True
+            return False
 
         raw = effective_dev_log_file_raw(config_manager)
         if raw is None:
@@ -243,7 +250,7 @@ class Logger:
                 "文件日志已禁用: [dev] log_file 为空（留空则禁用）",
                 file=sys.stderr,
             )
-            return
+            return True
 
         log_path = resolve_dev_log_file_path(raw)
         try:
@@ -263,6 +270,7 @@ class Logger:
                 f"文件日志打开失败: {e!r} 路径={log_path}",
                 file=sys.stderr,
             )
+        return True
 
     def _rotate_log_file(self, log_path: Path) -> None:
         """日志文件超出大小上限时轮转，保留最近的 MAX_LOG_BACKUPS 份备份。"""
@@ -336,9 +344,8 @@ class Logger:
             try:
                 from .config import config_manager
             except ImportError:
-                raw = "INFO"
-            else:
-                raw = config_manager.get("dev", "log_level", fallback="INFO")
+                return "INFO"
+            raw = config_manager.get("dev", "log_level", fallback="INFO")
             self._log_level = normalize_log_level(raw)
             self._ensure_config_change_listener()
         return self._log_level

--- a/tests/core/test_accounts_migration.py
+++ b/tests/core/test_accounts_migration.py
@@ -147,3 +147,36 @@ def test_migrate_skips_when_db_already_has_section(
     # 仅 bangumi 被迁移，bangumi-foo 已存在故跳过
     assert n == 1
     assert db.get_bangumi_account("bangumi-foo")["username"] == "prefilled"
+
+
+def test_migrate_numeric_username_from_ini(temp_dir, reset_singletons, monkeypatch):
+    """纯数字 username（get() 会转为 int）应能正常迁移。"""
+    ini = temp_dir / "config.ini"
+    ini.write_text(
+        "[bangumi-321246]\n"
+        "username = 321246\n"
+        "access_token = AT_NUM\n"
+        "media_server_username = 999\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CONFIG_FILE", str(ini))
+    from app.core.config import ConfigManager
+
+    cm = ConfigManager()
+    import app.core.accounts as accounts_mod
+    from app.core.database import DatabaseManager
+
+    db = DatabaseManager(str(temp_dir / "acc.db"))
+    monkeypatch.setattr(accounts_mod, "database_manager", db)
+    monkeypatch.setattr(accounts_mod, "config_manager", cm)
+
+    with patch("app.core.database.logger"):
+        n = accounts_mod.migrate_ini_accounts_to_db()
+
+    assert n == 1
+    acc = db.get_bangumi_account("bangumi-321246")
+    assert acc is not None
+    assert acc["username"] == "321246"
+    assert isinstance(acc["username"], str)
+    assert acc["access_token"] == "AT_NUM"
+    assert acc["media_server_usernames"] == ["999"]

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -147,8 +147,8 @@ class TestLoggerFileOperations:
         logger._close_log_file_handle()
         # 不应抛出异常
 
-    def test_setup_log_file_import_error(self):
-        """导入 config 失败时跳过文件日志"""
+    def test_setup_log_file_import_error(self, capsys):
+        """导入 config 失败时跳过文件日志且可稍后重试"""
         logger = _make_logger()
         import sys
 
@@ -156,12 +156,30 @@ class TestLoggerFileOperations:
         saved = sys.modules.pop("app.core.config", None)
         sys.modules["app.core.config"] = None  # type: ignore[assignment]
         try:
-            logger._setup_log_file()
+            assert logger._setup_log_file() is False
+            assert logger._log_file_import_warned is True
+            err = capsys.readouterr()
+            assert "文件日志未启用" in err.err
+            # 第二次失败不再重复警告
+            assert logger._setup_log_file() is False
+            assert capsys.readouterr().err == ""
         finally:
             if saved is not None:
                 sys.modules["app.core.config"] = saved
             else:
                 sys.modules.pop("app.core.config", None)
+
+    def test_lazy_init_retries_after_config_import_failure(self):
+        """config 尚未就绪时保持未初始化，成功后再标记完成"""
+        logger = _make_logger()
+        with patch.object(
+            logger, "_setup_log_file", side_effect=[False, True]
+        ) as mock_setup:
+            logger._lazy_init_log_file_once()
+            assert not logger._log_file_lazy_initialized
+            logger._lazy_init_log_file_once()
+            assert logger._log_file_lazy_initialized
+            assert mock_setup.call_count == 2
 
     def test_setup_log_file_raw_none(self):
         """log_file 配置为空时禁用文件日志"""
@@ -240,6 +258,22 @@ class TestLoggerLogLevel:
         logger._debug_mode = False
         logger._log_level = "WARNING"
         assert logger.log_level == "WARNING"
+
+    def test_log_level_not_cached_on_import_error(self):
+        """config 尚未可导入时不缓存 log_level，便于后续重试读取配置"""
+        logger = _make_logger()
+        import sys
+
+        saved = sys.modules.pop("app.core.config", None)
+        sys.modules["app.core.config"] = None  # type: ignore[assignment]
+        try:
+            assert logger.log_level == "INFO"
+            assert logger._log_level is None
+        finally:
+            if saved is not None:
+                sys.modules["app.core.config"] = saved
+            else:
+                sys.modules.pop("app.core.config", None)
 
     def test_log_level_debug_override(self, capsys):
         """debug 开关开启时始终按 DEBUG 输出"""


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
修复低版本升级启动时的两类问题：

1. **Bangumi 账号 INI → DB 迁移失败**  
   旧配置中纯数字 `username`（如 `321246`）会被 `ConfigManager.get()` 转成 `int`，迁移时对 `.strip()` 调用报错，导致账号无法写入数据库。在账号迁移边界统一用 `_to_str()` 规范化字符串字段，并兼容纯数字 `media_server_username`。

2. **文件日志在启动阶段被永久禁用**  
   `ConfigManager` 初始化期间打日志会触发与 `config` 的循环导入，且 Logger 在失败后仍标记为已初始化，后续不再重试。改为仅在成功绑定 config 后才标记完成，ImportError 时可重试；`log_level` 在 config 未就绪时不缓存。

补充对应回归测试（纯数字用户名迁移、日志重试与 `log_level` 不缓存）。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->


## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
