### PR TITLE
fix: bangumi-data 配置刷新后 TMDB 映射未重建，修复 Trakt 多季匹配失效

### DIFF
--- a/app/utils/bangumi_data/index.py
+++ b/app/utils/bangumi_data/index.py
@@ -145,6 +145,11 @@ class IndexMixin:
                         self._title_index.setdefault(zh_title, []).append(item)
         logger.info(f"标题索引构建完成，共 {len(self._title_index)} 个唯一标题")
 
+    def _ensure_tmdb_mapping(self) -> None:
+        """TMDB 映射为空时懒重建（reload_config 清空映射后首次查询触发）。"""
+        if not self._cache_tmdb_mapping:
+            self._build_tmdb_mapping()
+
     def get_title_by_tmdb_id(
         self, tmdb_id: str, season: int | None = None
     ) -> str | None:
@@ -157,6 +162,7 @@ class IndexMixin:
         Returns:
             番剧名或 None
         """
+        self._ensure_tmdb_mapping()
         if season is not None:
             title = self._cache_tmdb_mapping.get(f"{tmdb_id}/season/{season}", None)
             if title:
@@ -173,6 +179,7 @@ class IndexMixin:
         Returns:
             开始日期字符串（空字符串表示未找到）
         """
+        self._ensure_tmdb_mapping()
         if not hasattr(self, "_cache_tmdb_begin"):
             return ""
         if season is not None:

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -1929,6 +1929,37 @@ class TestTmdbMappingMultiSeason:
             assert len(sao) > 3
 
 
+class TestReloadConfigRebuildTmdbMapping:
+    """reload_config 清空映射后首次查询懒重建"""
+
+    def test_reload_config_clears_tmdb_mapping(self):
+        """配置刷新后 TMDB 标题/日期映射被清空"""
+        data = _make_data()
+        data._cache_tmdb_mapping = {"tv/old": "旧标题"}
+        data._cache_tmdb_begin = {"tv/old": "旧日期"}
+        with patch("app.utils.bangumi_data.config_manager") as mock_cm:
+            mock_cm.get.return_value = ""
+            data.reload_config()
+            assert data._cache_tmdb_mapping == {}
+            assert data._cache_tmdb_begin == {}
+
+    def test_get_title_by_tmdb_id_lazy_rebuilds_mapping(self):
+        """映射清空后首次查询懒重建标题/日期映射"""
+        data = _make_data()
+        data._cache_tmdb_mapping = {}
+        data._cache_tmdb_begin = {}
+        items = [
+            {
+                "title": "番剧A",
+                "begin": "2026-07-17T00:00:00.000Z",
+                "sites": [{"site": "tmdb", "id": "tv/12345"}],
+            }
+        ]
+        with patch.object(data, "_parse_data", return_value=items):
+            assert data.get_title_by_tmdb_id("tv/12345") == "番剧A"
+            assert data.get_begin_by_tmdb_id("tv/12345") == "2026-07-17T00:00:00.000Z"
+
+
 class TestFindBangumiCandidates:
     """find_bangumi_candidates 候选回传测试"""
 


### PR DESCRIPTION
修复trakt同步始终无法命中 bangumi-data 导致无法获取正确的季日期无法进行多季匹配
<img width="1952" height="1194" alt="image" src="https://github.com/user-attachments/assets/ec54c385-499a-4da1-b1b2-c2121d553edc" />



## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复 bangumi-data 配置刷新后 TMDB 映射丢失，导致 Trakt 同步多季匹配失效。

`reload_config`（配置变更监听触发）清空了 `_cache_tmdb_mapping` 与
`_cache_tmdb_begin`，但 `_build_tmdb_mapping()` 只在 `__init__` 调用一次，
清空后不会重建。`_parse_data()` 重新加载数据时仅重建标题索引，不重建
TMDB 映射。因此配置刷新后 TMDB 标题/日期查询全部失效。

修复：在 `get_title_by_tmdb_id` / `get_begin_by_tmdb_id` 查询时检测映射
为空则懒重建，保持配置刷新的 lazy 语义（reload 阶段不立即加载数据）。

### 相关 Issue
暂无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `ruff check .` 并修复所有问题
- [x] 已运行 `ruff format .` 格式化代码
- [ ] 无页面模板变更

### 测试
- [x] 新增 `TestReloadConfigRebuildTmdbMapping` 测试（清空 + 懒重建两个用例）
- [x] `test_config_change_listener.py` 原失败用例已恢复通过
- [x] `test_bangumi_data.py` 159 passed
- [x] bangumi_data / trakt / sync 相关 412 passed

## 🔍 额外说明

### 根因

`reload_config` 来自 commit `6338655`（feat(config): 配置变更回调统一失效进程级缓存）。
该改动统一清空进程级缓存，但遗漏了 TMDB 映射的重建：

- 标题索引 `_title_index` 清空后能自动重建 —— `_parse_data()` 懒加载时会调 `_build_title_index()`
- TMDB 映射 `_cache_tmdb_mapping` / `_cache_tmdb_begin` 清空后**不会**重建 —— `_build_tmdb_mapping()` 只在 `__init__` 调用

### 实际案例：逃げ上手の若君 S02E04

用户观看第二季时，映射已被配置刷新清空：

| 查询 | 期望 | 实际（清空后） |
|------|------|------|
| `get_title_by_tmdb_id("tv/222623", season=2)` | 逃げ上手の若君(第二期) | None（映射空）→ 降级 original_title（第一季） |
| `get_begin_by_tmdb_id("tv/222623", season=2)` | 2026-07-17 | 空 → 降级 show.year=2024 → 2024-01-01 |

错误日期导致 bgm 用 2024 年区间搜索，命中第一季 subject 424573（而非第二季 517106）。

### 修改范围（2 文件）

| 文件 | 改动 |
|------|------|
| `app/utils/bangumi_data/index.py` | 新增 `_ensure_tmdb_mapping`，查询时懒重建映射 |
| `tests/utils/test_bangumi_data.py` | 新增清空 + 懒重建两个测试 |
