### PR TITLE
fix(notification): 追番总结通知类型按任务动态展示，修复订阅匹配方向

### DIFF
--- a/app/api/notification.py
+++ b/app/api/notification.py
@@ -901,7 +901,12 @@ async def get_notification_types(
 
     替代原先硬编码在 config.html 中的 13 种类型复选框。
     """
-    from ..core.notification_registry import CATEGORIES, ui_visible_types
+    from ..core.notification_registry import (
+        CATEGORIES,
+        WATCHING_SUMMARY_PREFIX,
+        get_type_meta,
+        ui_visible_types,
+    )
 
     types = [
         {
@@ -915,6 +920,23 @@ async def get_notification_types(
         }
         for t in ui_visible_types()
     ]
+    # 动态附加追番总结任务的 watching_summary_{name} 类型（每个任务一个可勾选项）
+    summary_meta = get_type_meta(WATCHING_SUMMARY_PREFIX)
+    for job in config_manager.get_summary_configs():
+        name = job.get("name")
+        if not name:
+            continue
+        types.append(
+            {
+                "id": f"{WATCHING_SUMMARY_PREFIX}_{name}",
+                "display_name": f"{summary_meta.display_name} · {name}",
+                "icon": summary_meta.icon,
+                "color": summary_meta.color,
+                "description": summary_meta.description,
+                "is_item_level": summary_meta.is_item_level,
+                "category": summary_meta.category,
+            }
+        )
     # 附加分类定义，前端动态读取，避免前后端重复维护
     categories = [{"id": k, "name": v} for k, v in CATEGORIES.items()]
     return {"status": "success", "data": types, "categories": categories}

--- a/app/core/notification_registry.py
+++ b/app/core/notification_registry.py
@@ -62,9 +62,12 @@ _WATCHING_SUMMARY_META = NotificationTypeMeta(
     display_name="追番总结",
     icon="📊",
     color="#6c8ebf",
-    description="AI 追番总结任务完成/失败",
+    description="成功时发送总结正文，失败时发送失败提示",
     is_item_level=False,
-    visible_in_ui=False,  # 动态类型不在静态列表展示
+    # 通配类型不进入静态列表；具体任务类型 watching_summary_{name}
+    # 由 /api/notification/types 端点按 summary 任务动态附加
+    visible_in_ui=False,
+    category="scheduler",
 )
 
 

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -311,10 +311,7 @@ class NotificationService:
                 types_str = str(cfg.get("types", "all")).strip()
                 # 空字符串或 "all" 表示订阅全部事件（与渠道 supports 行为一致）
                 if types_str and types_str != "all":
-                    lookup = notification_type
-                    if lookup.startswith("watching_summary"):
-                        lookup = "watching_summary"
-                    if lookup not in {
+                    if notification_type not in {
                         t.strip() for t in types_str.split(",") if t.strip()
                     }:
                         continue

--- a/app/utils/notifier/__init__.py
+++ b/app/utils/notifier/__init__.py
@@ -93,10 +93,7 @@ class Notifier(EmailHtmlMixin, WebhookMixin, EmailSenderMixin, TestHelpersMixin)
         if types == "all":
             return True
         type_list = [t.strip() for t in types.split(",")]
-        lookup = notification_type
-        if lookup.startswith("watching_summary"):
-            lookup = "watching_summary"
-        return lookup in type_list
+        return notification_type in type_list
 
     def _get_webhook_configs(self) -> list:
         config = self.config_manager.get_config_parser()

--- a/app/utils/notifier/channels.py
+++ b/app/utils/notifier/channels.py
@@ -52,15 +52,13 @@ class NotificationChannel(abc.ABC):
         """判断该渠道是否订阅了指定通知类型
 
         约定：配置中的 ``types`` 字段为逗号分隔的类型列表，``"all"`` 表示全订阅。
+        订阅按类型 id 精确匹配：追番总结的 watching_summary_{name} 各自独立，
+        由前端按任务动态展示，用户可对单个任务单独开关。
         """
         types = str(self.config.get("types", "all")).strip()
         if not types or types == "all":
             return True
-        # watching_summary_* 归一化到 watching_summary
-        lookup = notification_type
-        if lookup.startswith("watching_summary"):
-            lookup = "watching_summary"
-        return lookup in {t.strip() for t in types.split(",") if t.strip()}
+        return notification_type in {t.strip() for t in types.split(",") if t.strip()}
 
     @abc.abstractmethod
     def send(

--- a/templates/config.html
+++ b/templates/config.html
@@ -416,8 +416,6 @@
   async function loadNotificationTypes(containerId, prefix) {
     const container = document.getElementById(containerId)
     if (!container) return
-    // 已填充则跳过（避免重复加载）
-    if (container.children.length > 0) return
     try {
       const json = await apiFetch('/api/notification/types')
       const types = json.data || []
@@ -463,6 +461,8 @@
           frag.appendChild(div)
         })
       })
+      // 清空旧内容后重新填充，确保动态类型（如 summary 任务）变化后能刷新
+      container.innerHTML = ''
       container.appendChild(frag)
     } catch (e) {
       console.error('加载通知类型失败:', e)

--- a/tests/api/test_notification.py
+++ b/tests/api/test_notification.py
@@ -74,6 +74,46 @@ async def test_get_emails(app_with_auth):
         assert response.status_code in [200, 404, 500]
 
 
+@pytest.mark.asyncio
+async def test_get_notification_types_includes_summary_jobs(
+    app_with_auth, mock_config_manager
+):
+    """/api/notification/types 动态附加 summary 任务的 watching_summary_{name}"""
+    mock_config_manager.get_summary_configs.return_value = [
+        {"name": "每日总结"},
+        {"name": "每周总结"},
+    ]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/notification/types")
+    assert response.status_code == 200
+    result = response.json()
+    assert result["status"] == "success"
+    type_ids = [t["id"] for t in result["data"]]
+    assert "watching_summary_每日总结" in type_ids
+    assert "watching_summary_每周总结" in type_ids
+    daily = next(t for t in result["data"] if t["id"] == "watching_summary_每日总结")
+    assert daily["display_name"] == "追番总结 · 每日总结"
+    assert daily["category"] == "scheduler"
+
+
+@pytest.mark.asyncio
+async def test_get_notification_types_without_summary_jobs(
+    app_with_auth, mock_config_manager
+):
+    """无 summary 任务时，不附加 watching_summary_{name} 类型"""
+    mock_config_manager.get_summary_configs.return_value = []
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_auth), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/notification/types")
+    assert response.status_code == 200
+    result = response.json()
+    type_ids = [t["id"] for t in result["data"]]
+    assert not any(t.startswith("watching_summary_") for t in type_ids)
+
+
 # ========== 通知规则测试 ==========
 
 

--- a/tests/services/test_notification_rule_e2e.py
+++ b/tests/services/test_notification_rule_e2e.py
@@ -146,6 +146,35 @@ def test_rule_skips_non_matching_type():
     assert len(channel.send_calls) == 0
 
 
+def test_rule_watching_summary_exact_match():
+    """watching_summary_{name} 规则按具体任务名精确匹配，不归一化到通配。"""
+    channel = _FakeChannel("notify-webhook-1")
+    service = NotificationService(channel_registry=ChannelRegistry())
+    service.channel_registry.register(channel)
+    service.cooldown.cooldown_seconds = 0
+
+    rules = [
+        {
+            "enabled": True,
+            "types": "watching_summary_dad",
+            "channels": "notify-webhook-1",
+        }
+    ]
+    cfg_mgr = _make_config_manager(rules)
+
+    with (
+        patch("app.core.config.config_manager", cfg_mgr),
+        patch(
+            "app.services.notification_service.NotificationService._lazy_load_channels"
+        ),
+    ):
+        service.notify("watching_summary_dad", source="summary")
+        service.notify("watching_summary_other", source="summary")
+
+    assert len(channel.send_calls) == 1
+    assert channel.send_calls[0][0] == "watching_summary_dad"
+
+
 def test_rule_all_types_matches_everything():
     """types='all' 应匹配所有通知类型"""
     channel = _FakeChannel("notify-webhook-1")

--- a/tests/utils/test_notifier.py
+++ b/tests/utils/test_notifier.py
@@ -1016,6 +1016,20 @@ class TestTypeMatches:
         assert Notifier._type_matches("mark_success", "mark_success") is True
         assert Notifier._type_matches("mark_failed", "mark_success") is False
 
+    def test_watching_summary_exact_match(self):
+        """watching_summary_{name} 按具体任务名精确匹配，不归一化到通配。"""
+        assert (
+            Notifier._type_matches("watching_summary_dad", "watching_summary_dad")
+            is True
+        )
+        assert (
+            Notifier._type_matches("watching_summary_dad", "watching_summary_other")
+            is False
+        )
+        assert (
+            Notifier._type_matches("watching_summary_dad", "watching_summary") is False
+        )
+
 
 class TestNotifierMergedExtended:
     """test_notifier_extended.py 并入的独有用例。"""


### PR DESCRIPTION
## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复追番总结（watching_summary）通知类型无法在前端通知配置中勾选的问题。

`watching_summary_{name}` 是动态类型，每个 summary 任务对应一个，但存在两个问题：

1. `_WATCHING_SUMMARY_META.visible_in_ui=False`，且没有「按任务动态附加类型」的逻辑，
   前端 `/api/notification/types` 返回的可见类型里看不到「追番总结」可勾选项。
2. `supports()` / `_get_enabled_rules()` / `_type_matches()` 把收到的
   `watching_summary_{name}` 归一化到通配 `watching_summary` 再查配置，
   导致配置存具体任务名时永远匹配不上。

修复：
- `/api/notification/types` 按 summary 任务动态附加 `watching_summary_{name}` 类型
  （display_name 带任务名，归「调度任务」分类）
- 订阅匹配改为按类型 id 精确匹配，保留 `rename_notification_type` 的任务改名联动
- 前端通知类型列表每次打开重新加载，任务创建/改名后能刷新

### 相关 Issue
暂无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `ruff check .` 并修复所有问题
- [x] 已运行 `ruff format .` 格式化代码
- [x] 已运行 `djlint templates/` 检查模板

### 测试
- [x] 新增动态附加测试（`test_notification.py` +2）
- [x] 新增规则精确匹配测试（`test_notification_rule_e2e.py` +1）
- [x] 新增 `_type_matches` 精确匹配测试（`test_notifier.py` +1）
- [x] 通知相关全量 216 passed
- [x] `test_config_change_listener.py` 11 passed

## 🔍 额外说明

### 根因：两个设计相互矛盾

`rename_notification_type`（summary_jobs.py 任务改名时调用）与
`tests/core/test_config_summary.py` 都假设配置存**具体** `watching_summary_{name}`
（每个任务一个类型，用户可单独开关）。但 `supports()` 等匹配逻辑把收到的具体类型
归一化到通配 `watching_summary` 再查配置，方向写反了，导致具体任务名永远失配。

### 实际案例

用户配置 LLM + 创建 summary 任务后，在「通知配置」→ Webhook/邮件规则里找不到
「追番总结」可勾选项；即使手动在配置里写入具体任务名，也收不到通知。

| 场景 | 修复前 | 修复后 |
|------|------|------|
| 前端勾选列表 | 无「追番总结」类型 | 每个任务动态出现「📊 追番总结 · {任务名}」 |
| 配置存具体任务名 + 收到同名通知 | 归一化失配，不发送 | 精确匹配，正常发送 |

### 修改范围（9 文件）

| 文件 | 改动 |
|------|------|
| `app/api/notification.py` | `/api/notification/types` 动态附加 summary 任务类型 |
| `app/core/notification_registry.py` | `_WATCHING_SUMMARY_META` 补 category、修正 description |
| `app/services/notification_service.py` | `_get_enabled_rules` 按类型 id 精确匹配 |
| `app/utils/notifier/channels.py` | `supports` 按类型 id 精确匹配 |
| `app/utils/notifier/__init__.py` | `_type_matches` 按类型 id 精确匹配 |
| `templates/config.html` | 通知类型列表每次打开重载 |
| `tests/api/test_notification.py` | 动态附加测试 |
| `tests/services/test_notification_rule_e2e.py` | 规则精确匹配测试 |
| `tests/utils/test_notifier.py` | `_type_matches` 精确匹配测试 |
