### PR TITLE
 fix: 放送日历测试改用调度器时区，修复跨时区 flaky

### DIFF
--- a/tests/api/test_airing_calendar.py
+++ b/tests/api/test_airing_calendar.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from app.api import airing_calendar, deps
+from app.core.config import config_manager
 
 
 @pytest.fixture
@@ -134,9 +135,9 @@ class TestAiringCalendarEndpoint:
         self, app_with_auth, mock_archive_enabled, mock_bangumi_config_with_watching
     ):
         """正常查询返回按日期分组的结果（有 Bangumi 配置 + 在看列表）"""
-        from datetime import date, timedelta
+        from datetime import timedelta
 
-        today = date.today()
+        today = config_manager.today_in_scheduler_tz()
         today_str = today.isoformat()
         tomorrow_str = (today + timedelta(days=1)).isoformat()
 
@@ -343,9 +344,7 @@ class TestAiringCalendarEndpoint:
         self, app_with_auth, mock_archive_enabled, mock_bangumi_config_with_watching
     ):
         """空日期格子也应有正确的 weekday"""
-        from datetime import date
-
-        today = date.today()
+        today = config_manager.today_in_scheduler_tz()
         with patch.object(
             airing_calendar.archive_store,
             "get_episodes_by_airdate",


### PR DESCRIPTION
<!-- 请务必在创建 PR 前，在右侧 Labels 选项中加上 label：`[bug]` -->

## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复放送日历测试的跨时区 flaky，导致 CI 在特定时间窗口必然失败。

端点 `airing_calendar.py` 的「今日」用 `config_manager.today_in_scheduler_tz()`
（调度器配置时区，默认 Asia/Shanghai），但测试仍用 `date.today()`（系统时区，
Docker 默认 UTC）。UTC 16:00~24:00 窗口内两者「今日」差一天，导致
`test_normal_query`（`assert data["today"] == today_str`）与
`test_empty_days_have_correct_weekday`（`assert weekday`）断言失败。

测试改为同样使用 `today_in_scheduler_tz()`，与端点共用同一时区基准。

### 相关 Issue
暂无

## 📋 提交前检查清单

### 规范与静态检查
- [x] 已运行 `ruff check .`（All checks passed）
- [x] 已运行 `ruff format --check .`（332 files already formatted）

### 测试
- [x] `test_airing_calendar.py` 19 passed（本地中国时区）
- [x] `TZ=UTC` 模拟 CI 环境 19 passed

## 🔍 额外说明

### 根因：端点切调度器时区时漏改测试

`8a5a72c`（fix(airing): 今日日期改用调度器配置时区避免跨时区错位）把端点从
`date.today()` 改成 `today_in_scheduler_tz()`，但未同步更新测试文件。测试停留在
系统时区的旧语义，与端点产生时区错位。

### 修复前后对比

| 时刻（UTC） | 测试 `date.today()` | 端点 `today_in_scheduler_tz()` | 修复前 | 修复后 |
|------|------|------|:---:|:---:|
| 02:55 | 08-15 | 08-15 | 通过 | 通过 |
| 17:11 | 08-15 | 08-16 | 失败 ❌ | 通过 ✅（两者同用调度器时区） |

### 修改范围（1 文件）

| 文件 | 改动 |
|------|------|
| `tests/api/test_airing_calendar.py` | `test_normal_query` / `test_empty_days_have_correct_weekday` 改用 `today_in_scheduler_tz()` 对齐端点时区 |
