### PR TITLE
fix: 修复配置备份接口路径穿越问题

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import shutil
 import time
 from datetime import datetime
@@ -30,6 +31,21 @@ router = APIRouter(prefix="/api", tags=["config"])
 # ------------------------------------------------------------------
 # 配置备份 I/O 辅助函数（同步阻塞，需通过 asyncio.to_thread 调用）
 # ------------------------------------------------------------------
+
+_BACKUP_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+\.ini$")
+
+
+def _safe_backup_path(filename: str) -> Path:
+    """校验备份文件名并返回备份目录内的安全路径"""
+    if not _BACKUP_NAME_RE.fullmatch(filename):
+        raise HTTPException(status_code=404, detail="备份文件不存在")
+    backup_dir = Path("config_backups").resolve()
+    backup_path = (Path("config_backups") / filename).resolve()
+    if backup_path == backup_dir or not backup_path.is_relative_to(backup_dir):
+        raise HTTPException(status_code=404, detail="备份文件不存在")
+    if not backup_path.is_file():
+        raise HTTPException(status_code=404, detail="备份文件不存在")
+    return backup_path
 
 
 def _list_config_backups() -> list[dict]:
@@ -59,18 +75,14 @@ def _list_config_backups() -> list[dict]:
 
 def _read_config_backup(filename: str) -> str:
     """读取指定备份文件内容，不存在则抛 HTTPException"""
-    backup_path = Path("config_backups") / filename
-    if not backup_path.exists():
-        raise HTTPException(status_code=404, detail="备份文件不存在")
+    backup_path = _safe_backup_path(filename)
     with open(backup_path, encoding="utf-8") as f:
         return f.read()
 
 
 def _delete_config_backup(filename: str) -> None:
     """删除指定备份文件，不存在则抛 HTTPException"""
-    backup_path = Path("config_backups") / filename
-    if not backup_path.exists():
-        raise HTTPException(status_code=404, detail="备份文件不存在")
+    backup_path = _safe_backup_path(filename)
     backup_path.unlink()
 
 
@@ -87,9 +99,7 @@ def _create_config_backup() -> str:
 
 def _restore_config_backup(filename: str) -> None:
     """从指定备份恢复配置，不存在则抛 HTTPException"""
-    backup_path = Path("config_backups") / filename
-    if not backup_path.exists():
-        raise HTTPException(status_code=404, detail="备份文件不存在")
+    backup_path = _safe_backup_path(filename)
     shutil.copy2(backup_path, config_manager.active_config_path)
     config_manager.reload_config()
 

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -5,7 +5,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from app.api import config, deps
@@ -411,6 +411,68 @@ async def test_update_config_password_update_reloads_auth(
             )
     assert response.status_code == 200
     mock_security_manager._init_auth_config.assert_called()
+
+
+# ========== 备份路径安全测试 ==========
+
+
+@pytest.fixture
+def backup_layout(tmp_path, monkeypatch):
+    """在隔离目录下创建 config_backups 布局"""
+    monkeypatch.chdir(tmp_path)
+    backup_dir = tmp_path / "config_backups"
+    backup_dir.mkdir()
+    return backup_dir
+
+
+def test_safe_backup_path_valid_names(backup_layout):
+    """合法备份文件名应解析到 config_backups 内"""
+    for name in ("config_backup_20260101_000000.ini", "test_backup.ini"):
+        (backup_layout / name).write_text("content", encoding="utf-8")
+        path = config._safe_backup_path(name)
+        assert path.is_file()
+        assert path.name == name
+
+
+def test_safe_backup_path_rejects_invalid_names(backup_layout):
+    """危险或非法文件名应统一返回 404"""
+    invalid_names = [
+        "..\\secret.ini",
+        "../secret.ini",
+        "C:\\Windows\\win.ini",
+        "..ini",
+        "",
+        "no_ini_suffix",
+        "bad/name.ini",
+    ]
+    for name in invalid_names:
+        with pytest.raises(HTTPException) as exc_info:
+            config._safe_backup_path(name)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "备份文件不存在"
+
+
+def test_safe_backup_path_rejects_symlink_escape(backup_layout, tmp_path):
+    """符号链接指向备份目录外时应被拒绝"""
+    secret = tmp_path / "secret.ini"
+    secret.write_text("SECRET", encoding="utf-8")
+    (backup_layout / "escape.ini").symlink_to(secret)
+    with pytest.raises(HTTPException) as exc_info:
+        config._safe_backup_path("escape.ini")
+    assert exc_info.value.status_code == 404
+    assert secret.is_file()
+
+
+def test_safe_backup_path_traversal_does_not_touch_outside_file(
+    backup_layout, tmp_path
+):
+    """穿越文件名不应读取或影响目录外文件"""
+    secret = tmp_path / "secret.ini"
+    secret.write_text("SECRET", encoding="utf-8")
+    with pytest.raises(HTTPException):
+        config._safe_backup_path("..\\secret.ini")
+    assert secret.is_file()
+    assert secret.read_text(encoding="utf-8") == "SECRET"
 
 
 # ========== 备份功能测试 ==========


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

### 变更类型
<!-- 请从以下选项中选择保留本次变更类型 -->
🐛 Bug 修复 (bug)

### 变更内容
<!-- 简要描述本次 PR 的主要变更 -->
 - 在 `app/api/config.py` 新增 `_safe_backup_path()`，对备份文件名做双层校验：白名单正则（仅允许 `A-Za-z0-9_.-` + `.ini` 后缀）与 `resolve()` + `is_relative_to()` 目录约束。`GET/DELETE /api/config/backup/{filename}` 与 `POST /api/config/restore/{filename}` 三个端点统一经该 helper 解析路径，阻断 Windows 下反斜杠穿越、绝对路径注入及符号链接逃逸。

 - 补充 4 个回归测试，覆盖合法文件名、非法/穿越 payload、符号链接越界等场景；现有备份相关 API 测试全部通过，正常备份命名（如 `config_backup_YYYYMMDD_HHMMSS.ini`）不受影响。

### 相关 Issue
<!-- 如果有相关 Issue，请在此引用，例如: Closes #123 -->
Closes #238 

## 🔍 额外说明
<!-- 其他需要审查者注意的事项 -->
