### PR TITLE
fix: 修复指定 release_date 时部分匹配扫描被过早截断

### DIFF
--- a/app/utils/bangumi_data/matching.py
+++ b/app/utils/bangumi_data/matching.py
@@ -328,8 +328,8 @@ class MatchingMixin:
                 if bangumi_id:
                     partial_matches.append((item, match_info["score"], bangumi_id))
 
-                    # 限制部分匹配的数量以提高性能
-                    if len(partial_matches) >= 10:
+                    # 限制部分匹配的数量以提高性能，但指定 release_date 时保留全部候选供日期择优，防止因截断遗漏正确季
+                    if not release_date and len(partial_matches) >= 10:
                         break
 
         return exact_matches, partial_matches, processed_count

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -2331,6 +2331,119 @@ class TestBangumiDataComprehensiveMerged:
         assert isinstance(result, (int, float))
 
 
+def _truncation_rezero_dataset():
+    """构造 Re:Zero 风格数据集：S1 完全匹配 + 10 个干扰部分匹配 + 正确季置末。"""
+    search_title = "Re:从零开始的异世界生活"
+    items = [
+        {
+            "title": search_title,
+            "titleTranslate": {"zh-Hans": [search_title]},
+            "begin": "2016-04-03",
+            "sites": [{"site": "bangumi", "id": "140001"}],
+        }
+    ]
+    decoy_begins = [
+        "2016-07-06",
+        "2018-10-09",
+        "2019-06-25",
+        "2020-01-01",
+        "2021-03-15",
+        "2022-07-20",
+        "2023-09-10",
+        "2024-04-01",
+        "2024-10-05",
+        "2025-12-12",
+    ]
+    for i, begin in enumerate(decoy_begins, start=2):
+        title = f"{search_title} 第{i}季"
+        items.append(
+            {
+                "title": title,
+                "titleTranslate": {"zh-Hans": [title]},
+                "begin": begin,
+                "sites": [{"site": "bangumi", "id": f"20000{i}"}],
+            }
+        )
+    items.append(
+        {
+            "title": f"{search_title} 第四季 夺还篇",
+            "titleTranslate": {"zh-Hans": [f"{search_title} 第四季 夺还篇"]},
+            "begin": "2026-07-20",
+            "sites": [{"site": "bangumi", "id": "633836"}],
+        }
+    )
+    return items
+
+
+def _truncation_all_partial_dataset():
+    """构造无完全匹配的数据集，用于验证无 release_date 时仍按 10 截断。"""
+    search_title = "Re:从零开始的异世界生活"
+    items = []
+    for i in range(11):
+        title = f"{search_title} 第{i + 1}季"
+        items.append(
+            {
+                "title": title,
+                "titleTranslate": {"zh-Hans": [title]},
+                "begin": "2020-01-01",
+                "sites": [{"site": "bangumi", "id": f"30000{i}"}],
+            }
+        )
+    return items
+
+
+class TestPartialMatchScanTruncation:
+    """部分匹配扫描截断修复：带 release_date 时保留全部候选供日期择优。"""
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_release_date_keeps_late_correct_season(self, mock_parse, mock_preload):
+        """带 release_date 时，排在扫描末位的正确季应进入部分匹配池（11 个）。"""
+        data = BangumiData()
+        mock_parse.return_value = _truncation_rezero_dataset()
+
+        exact, partial, _ = data._scan_candidates(
+            "Re:从零开始的异世界生活", "", "2026-08-18"
+        )
+
+        ids = [bid for _, _, bid in partial]
+        assert "633836" in ids
+        # S1 为完全匹配进入 exact，部分匹配池含 10 个干扰 + 正确季共 11 个
+        assert len(partial) == 11
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_no_release_date_still_caps_at_ten(self, mock_parse, mock_preload):
+        """无 release_date 时仍按 10 截断，避免线性扫描性能回归。"""
+        data = BangumiData()
+        mock_parse.return_value = _truncation_all_partial_dataset()
+
+        _, partial, _ = data._scan_candidates("Re:从零开始的异世界生活", "", None)
+
+        assert len(partial) == 10
+        # 第 11 个（id 300010）应被截断
+        ids = [bid for _, _, bid in partial]
+        assert "300010" not in ids
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_rezero_s04_selects_season4_recapture(self, mock_parse, mock_preload):
+        """Re:Zero S04 经日期择优应命中第四季 夺还篇（633836）而非第一季。"""
+        data = BangumiData()
+        mock_parse.return_value = _truncation_rezero_dataset()
+        with patch.object(data, "_title_index", {}):
+            result = data._find_bangumi_id_optimized(
+                title="Re:从零开始的异世界生活",
+                ori_title="",
+                release_date="2026-08-18",
+                season=1,
+            )
+
+        assert result is not None
+        assert result[0] == "633836"
+        assert result[2] is True
+
+
 class TestBangumiDataCacheHelpersMerged:
     """自 test_bangumi_data_internals.py 并入的缓存/下载边界用例。"""
 


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

本提交修复了在同步Re0第四季时日期择优未生效的问题，但并不解决 https://github.com/SanaeMio/Bangumi-syncer/issues/236

修复前：
```
[2026/08/27 14:42:39.057] [INFO] 同步开始: Re：从零开始的异世界生活 S04E13 (test)
[2026/08/27 14:42:39.058] [INFO] 接收到同步请求：media_type='episode' title='Re：从零开始的异世界生活' ori_title=None season=4 episode=13 release_date='2026-08-18' user_name='Elegy233' source='test' sync_action=None raw_payload=None
[2026/08/27 14:42:39.061] [INFO] 已加载 5 个外部通知渠道 + 1 个站内信渠道
[2026/08/27 14:42:39.062] [DEBUG] 无匹配规则，跳过 request_received 通知
[2026/08/27 14:42:40.605] [DEBUG] BangumiApi 初始化 - 代理参数: 无, SSL验证: True
[2026/08/27 14:42:40.619] [DEBUG] 标题归一化：'Re：从零开始的异世界生活' → 'Re:从零开始的异世界生活'
[2026/08/27 14:42:40.620] [DEBUG] 使用缓存的映射配置，共 1 个映射、0 条规则
[2026/08/27 14:42:40.620] [DEBUG] 正在查找番剧 ID: title='Re：从零开始的异世界生活', ori_title=None, release_date='2026-08-18', season=4, media_type='episode'
[2026/08/27 14:42:40.621] [DEBUG] 标题索引命中: key='Re：从零开始的异世界生活', 候选数=1
[2026/08/27 14:42:40.623] [DEBUG] 标题索引命中但日期差 3789 天 > 180，回退线性扫描检查部分匹配
[2026/08/27 14:42:40.624] [DEBUG] 开始尝试完全匹配...
[2026/08/27 14:42:40.625] [DEBUG] 使用内存缓存数据 (命中次数: 3)
[2026/08/27 14:42:40.871] [DEBUG] 处理了 8717 个项目，找到 1 个完全匹配，10 个部分匹配
[2026/08/27 14:42:40.872] [DEBUG] 完全匹配的最佳日期误差高达 3789 天，启动全局日期择优机制
[2026/08/27 14:42:40.873] [DEBUG] 找到匹配的番剧: Re:ゼロから始める異世界生活, 中文翻译: Re：从零开始的异世界生活, bangumi_id: 140001, 匹配方式: zh-hans
```

修复后：
```
[2026/08/28 15:05:04.745] [INFO] 同步开始: Re：从零开始的异世界生活 S04E13 (test)
[2026/08/28 15:05:04.746] [INFO] 接收到同步请求：media_type='episode' title='Re：从零开始的异世界生活' ori_title=None season=4 episode=13 release_date='2026-08-18' user_name='Elegy233' source='test' sync_action=None raw_payload=None
[2026/08/28 15:05:04.748] [DEBUG] 无匹配规则，跳过 request_received 通知
[2026/08/28 15:05:08.970] [DEBUG] BangumiApi 初始化 - 代理参数: 无, SSL验证: True
[2026/08/28 15:05:08.971] [DEBUG] 标题归一化：'Re：从零开始的异世界生活' → 'Re:从零开始的异世界生活'
[2026/08/28 15:05:08.972] [DEBUG] 使用缓存的映射配置，共 1 个映射、0 条规则
[2026/08/28 15:05:08.973] [DEBUG] 正在查找番剧 ID: title='Re：从零开始的异世界生活', ori_title=None, release_date='2026-08-18', season=4, media_type='episode'
[2026/08/28 15:05:08.973] [DEBUG] 标题索引命中: key='Re：从零开始的异世界生活', 候选数=1
[2026/08/28 15:05:08.973] [DEBUG] 标题索引命中但日期差 3789 天 > 180，回退线性扫描检查部分匹配
[2026/08/28 15:05:08.973] [DEBUG] 开始尝试完全匹配...
[2026/08/28 15:05:08.974] [DEBUG] 使用内存缓存数据 (命中次数: 4)
[2026/08/28 15:05:09.226] [DEBUG] 处理了 8821 个项目，找到 1 个完全匹配，11 个部分匹配
[2026/08/28 15:05:09.227] [DEBUG] 完全匹配的最佳日期误差高达 3789 天，启动全局日期择优机制
[2026/08/28 15:05:09.228] [DEBUG] 因完全匹配结果日期差异过大，采纳日期择优番剧: Re：从零开始的异世界生活 第四季 夺还篇 (日期差距 6 天)
```

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容

`_scan_candidates` 在部分匹配累计达到 10 个时无条件 `break`，会按扫描顺序截断排在靠后的正确季（如 Re:Zero 这类多季拆分为独立 Bangumi 条目的作品，正确季往往扫描靠后），导致后续全局日期择优机制因候选池中缺少正确季而无法命中。

- 仅当未指定 `release_date` 时仍按 10 个上限截断，保留线性扫描性能；
- 指定 `release_date` 时不再按数量截断，保留全部候选交由日期择优选择正确季。

### 相关 Issue

无直接关联 Issue。修复 Re:Zero S04E13 等「指定 `release_date` 时正确季被部分匹配截断、日期择优失效」类匹配错误。

## 🔍 额外说明

- 改动文件：`app/utils/bangumi_data/matching.py`（+2/−2）；测试并入 `tests/utils/test_bangumi_data.py` 新增 `TestPartialMatchScanTruncation`（3 例）。
- 测试覆盖：带 `release_date` 时末位正确季进入候选池（共 11 个）；无 `release_date` 时仍按 10 截断（性能不回归）；端到端 Re:Zero S04 经日期择优选中第四季 夺还篇（`633836`）。
- 已通过 `ruff check` / `ruff format --check` / `pytest`。