### PR TITLE
fix: 跨季链查找按季编号定位目标季修复Re0第四季夺还篇匹配错误

### DIFF
--- a/app/services/matching/ports.py
+++ b/app/services/matching/ports.py
@@ -74,7 +74,7 @@ class BangumiSearchPort(Protocol):
     ) -> tuple[str, int]: ...
 
     def find_episode_across_seasons(
-        self, subject_id: str, target_sort: int
+        self, subject_id: str, target_sort: int, target_season: int = 1
     ) -> tuple[str, int] | None: ...
 
     # 相似度计算

--- a/app/services/sync_service/season_info.py
+++ b/app/services/sync_service/season_info.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 
 from ...core.logging import logger
-from ...utils.text_constants import CN_NUM
+from ...utils.season_title import extract_explicit_season
 
 
 class SeasonInfoMixin:
@@ -18,37 +18,12 @@ class SeasonInfoMixin:
         """从标题中提取明确声明的季度编号。
 
         返回值：
-        - 明确声明第N季时返回 N（>=1）
+        - 明确声明第 N 季时返回 N（>=1）
         - 标题不含季度声明时返回 None（可能是第一季本体，也可能是总集篇等）
 
-        覆盖形式：第X季/第X期（阿拉伯与中文数字）、Xnd/Xrd/Xth season、Season X
+        覆盖形式：第 X 季 / 第 X 期（阿拉伯与中文数字）、Xnd/Xrd/Xth season、Season X
         """
-        if not title:
-            return None
-        text = title.strip()
-
-        # "第X期" / "第X季"（阿拉伯数字）
-        m = re.search(r"第\s*(\d+)\s*[期季]", text)
-        if m:
-            return int(m.group(1))
-        # "第X期" / "第X季"（中文数字，含"十一"~"十九"）
-        m = re.search(r"第\s*([一二三四五六七八九十]+)\s*[期季]", text)
-        if m:
-            cn = m.group(1)
-            if len(cn) == 1:
-                return CN_NUM.get(cn)
-            if cn.startswith("十"):
-                return 10 + CN_NUM.get(cn[1], 0)
-            return CN_NUM.get(cn)
-        # "Xnd/Xrd/Xth season"
-        m = re.search(r"(\d+)(?:st|nd|rd|th)\s+season", text, re.IGNORECASE)
-        if m:
-            return int(m.group(1))
-        # "Season X"（需带数字，避免误匹配"Season"单词本身）
-        m = re.search(r"season\s*(\d+)", text, re.IGNORECASE)
-        if m:
-            return int(m.group(1))
-        return None
+        return extract_explicit_season(title)
 
     def _check_season_info_in_title(self, title: str, season: int) -> bool:
         """检查标题中是否包含季度信息"""

--- a/app/services/sync_service/steps/cross_season.py
+++ b/app/services/sync_service/steps/cross_season.py
@@ -39,7 +39,9 @@ class CrossSeasonStep(ExecutionStepBase):
 
         try:
             chain_pick = ctx.bgm.find_episode_across_seasons(
-                ctx.subject_id, ctx.item.episode
+                ctx.subject_id,
+                ctx.item.episode,
+                target_season=ctx.item.season or 1,
             )
         except Exception:
             logger.debug(f"关联季条目链查找异常: {ctx.subject_id}", exc_info=True)

--- a/app/services/sync_service/steps/cross_season.py
+++ b/app/services/sync_service/steps/cross_season.py
@@ -37,11 +37,12 @@ class CrossSeasonStep(ExecutionStepBase):
         if prev and prev.get("episode_id"):
             return StepOutcome(status="skipped", reason="集数解析已命中，无需跨季回退")
 
+        target_season = ctx.item.season or 1
         try:
             chain_pick = ctx.bgm.find_episode_across_seasons(
                 ctx.subject_id,
                 ctx.item.episode,
-                target_season=ctx.item.season or 1,
+                target_season=target_season,
             )
         except Exception:
             logger.debug(f"关联季条目链查找异常: {ctx.subject_id}", exc_info=True)
@@ -52,15 +53,21 @@ class CrossSeasonStep(ExecutionStepBase):
                 f"bgm: {ctx.subject_id=} {ctx.item.season=} {ctx.item.episode=}, "
                 "不存在或集数过多，跳过"
             )
+            # 集数语义随 target_season 变化：大于 1 时是季内集编号，否则是全局 sort
+            ep_desc = (
+                f"第 {target_season} 季第 {ctx.item.episode} 集"
+                if target_season > 1
+                else f"sort={ctx.item.episode}"
+            )
             return StepOutcome(
                 status="miss",
-                reason=f"跨季链查找未命中含 sort={ctx.item.episode} 的季条目",
+                reason=f"跨季链查找未命中含 {ep_desc} 的季条目",
                 inputs=inputs,
                 outputs={
                     "subject_id": "",
                     "episode_id": "",
                     "changed": False,
-                    "error": f"未找到含 sort={ctx.item.episode} 的关联季条目",
+                    "error": f"未找到含 {ep_desc} 的关联季条目",
                 },
                 is_terminal=True,
             )

--- a/app/utils/bangumi_api/episodes.py
+++ b/app/utils/bangumi_api/episodes.py
@@ -21,7 +21,6 @@ from ...utils.bangumi_constants import (
     SUBJECT_TYPE_REAL,
 )
 from ...utils.season_title import extract_explicit_season
-from ...utils.text_constants import CN_NUM
 
 # 关联类型中文名（由 ID 常量推导，避免硬编码字符串）
 _RELATION_CN_SEQUEL = RELATIONS[RELATION_ID_SEQUEL]
@@ -397,26 +396,7 @@ class EpisodesMixin:
 
     def _extract_season_number(self, name: str, name_cn: str) -> int | None:
         """从名称中提取季度编号，用于续集链季度去重计数"""
-        text = f"{name} {name_cn}"
-        # "第X期" / "第X季"（阿拉伯数字）
-        m = re.search(r"第\s*(\d+)\s*[期季]", text)
-        if m:
-            return int(m.group(1))
-        # "第X期" / "第X季"（中文数字）
-        m = re.search(r"第\s*([一二三四五六七八九十]+)\s*[期季]", text)
-        if m:
-            cn = m.group(1)
-            if len(cn) == 1:
-                return CN_NUM.get(cn)
-            # "十一"~"十九"
-            if cn.startswith("十"):
-                return 10 + CN_NUM.get(cn[1], 0)
-            return CN_NUM.get(cn)
-        # "Xnd/Xrd/Xth season"
-        m = re.search(r"(\d+)(?:st|nd|rd|th)\s+season", text, re.IGNORECASE)
-        if m:
-            return int(m.group(1))
-        return None
+        return extract_explicit_season(f"{name} {name_cn}")
 
     def _match_target_ep_rows(
         self, ep_info: list, target_ep: int

--- a/app/utils/bangumi_api/episodes.py
+++ b/app/utils/bangumi_api/episodes.py
@@ -749,7 +749,7 @@ class EpisodesMixin:
         集号在目标季内解析，从而命中用户所指的具体季与集。
 
         无法在关联链上确定目标季，或目标季内找不到对应集时返回 None，
-        交由本方法的全局 sort 回退逻辑处理（保持既有行为不变）。
+        由调用方回退到全局 sort 匹配。
         """
         chain = self._collect_related_subjects(subject_id, max_depth, deadline)
         if not chain:

--- a/app/utils/bangumi_api/episodes.py
+++ b/app/utils/bangumi_api/episodes.py
@@ -20,6 +20,7 @@ from ...utils.bangumi_constants import (
     SUBJECT_TYPE_ANIME,
     SUBJECT_TYPE_REAL,
 )
+from ...utils.season_title import extract_explicit_season
 from ...utils.text_constants import CN_NUM
 
 # 关联类型中文名（由 ID 常量推导，避免硬编码字符串）
@@ -650,8 +651,9 @@ class EpisodesMixin:
         subject_id: int,
         target_ep: int,
         max_depth: int = 20,
+        target_season: int = 1,
     ) -> tuple[int, int] | None:
-        """在当前条目及其前传/续集链中查找含 sort=target_ep 的章节。
+        """在当前条目及其前传/续集链中查找目标章节（target_season>1 时优先按季定位，否则按全局 sort 解析）。
 
         场景：fongmi 解析出连续编号 episode=102，但已命中的 subject（如第六季）
         的 sort 范围是 235-286，不含 102。需通过前传链向前找到含 sort=102 的
@@ -662,8 +664,10 @@ class EpisodesMixin:
 
         Args:
             subject_id: 已命中的初始条目 id
-            target_ep: 目标集数（连续编号，对应 ep.sort）
+            target_ep: 目标集数（季内集编号，对应 ep.ep；target_season<=1 时回退为全局 sort）
             max_depth: 沿单方向最多遍历多少个关联条目，防极端环
+            target_season: 目标季编号；大于 1 时优先按季在关联链上定位目标条目，
+                再按集解析，避免命中错误季
 
         Returns:
             (subject_id, episode_id) 或 None
@@ -677,6 +681,16 @@ class EpisodesMixin:
         # 整体 deadline：链式 API 调用累计耗时超过 60s 立即放弃
         # （防御错误 subject_id 触发的长链遍历占用 sync 线程池）
         deadline = time.monotonic() + _CROSS_SEASON_DEADLINE_SECONDS
+
+        # 季定位优先：明确指定季时，先按季在关联链上定位目标条目，再按集解析，
+        # 避免仅凭全局 sort 命中错误季（例如第 4 季第 13 集误命中第 1 季第 13 集）。
+        if target_season and target_season > 1:
+            season_pick = self._resolve_by_season_chain(
+                subject_id, target_season, target_ep, max_depth, deadline
+            )
+            if season_pick:
+                self.last_cross_season_path = "chain"
+                return season_pick
 
         # 先在当前 subject 内查
         found = self._find_episode_by_sort(subject_id, target_ep)
@@ -739,6 +753,109 @@ class EpisodesMixin:
         if franchise_result:
             return franchise_result
         return None
+
+    def _resolve_by_season_chain(
+        self,
+        subject_id: int,
+        target_season: int,
+        target_ep: int,
+        max_depth: int,
+        deadline: float | None = None,
+    ) -> tuple[int, int] | None:
+        """按季在关联链上定位目标条目并解析集数。
+
+        调用方明确提供季编号（target_season>1）时，依据各条目标题中的季声明在
+        整条前传/续集链上定位目标季的条目（分篇 cours 视为同一季的连续段），再按
+        集号在目标季内解析，从而命中用户所指的具体季与集。
+
+        无法在关联链上确定目标季，或目标季内找不到对应集时返回 None，
+        交由本方法的全局 sort 回退逻辑处理（保持既有行为不变）。
+        """
+        chain = self._collect_related_subjects(subject_id, max_depth, deadline)
+        if not chain:
+            return None
+
+        # 收集关联链上每个条目的季编号与正片章节，按链序排列
+        season_buckets: list[tuple[int | None, int, list[dict]]] = []
+        for sid in chain:
+            if deadline is not None and time.monotonic() > deadline:
+                break
+            info = self.get_subject(sid)
+            if not info:
+                continue
+            subject_type = info.get("type")
+            if subject_type is not None and subject_type != SUBJECT_TYPE_ANIME:
+                continue
+            season = extract_explicit_season(
+                info.get("name_cn") or ""
+            ) or extract_explicit_season(info.get("name") or "")
+            episodes = self.get_episodes(sid, fetch_all=True).get("data") or []
+            type0 = [e for e in episodes if e.get("type", 0) == 0]
+            season_buckets.append((season, sid, type0))
+
+        # 仅保留目标季的连续段，按链序累计集数定位目标集
+        targets = [
+            (sid, eps)
+            for (season, sid, eps) in season_buckets
+            if season == target_season
+        ]
+        if not targets:
+            return None
+
+        cumulative = 0
+        for sid, eps in targets:
+            count = len(eps)
+            if cumulative < target_ep <= cumulative + count:
+                local_ep = target_ep - cumulative
+                rows = [e for e in eps if e.get("ep") == local_ep]
+                if rows:
+                    return sid, rows[0]["id"]
+            cumulative += count
+        return None
+
+    def _collect_related_subjects(
+        self,
+        subject_id: int,
+        max_depth: int,
+        deadline: float | None = None,
+    ) -> list[int]:
+        """按时间顺序收集关联链条目（前传在前、起始居中、续集在后）。
+
+        续集方向优先使用 Archive 续集链短路，未命中时降级逐跳；前传方向使用
+        search_previous_subjects（由近到远），反转后置于起始条目之前以形成时间序。
+        """
+        chain: list[int] = [subject_id]
+        visited: set[int] = {subject_id}
+
+        # 续集方向（由近到远追加在起始之后）
+        shortcut = self._archive.try_find_sequel_chain(subject_id, max_hops=max_depth)
+        if shortcut.hit and shortcut.data:
+            for sid in shortcut.data:
+                if sid and sid not in visited:
+                    visited.add(sid)
+                    chain.append(sid)
+        else:
+            current_id = subject_id
+            for _ in range(max_depth):
+                if deadline is not None and time.monotonic() > deadline:
+                    break
+                next_id = self._find_related_id_by_relation(
+                    current_id, _RELATION_CN_SEQUEL
+                )
+                if not next_id or next_id in visited:
+                    break
+                visited.add(next_id)
+                chain.append(next_id)
+                current_id = next_id
+
+        # 前传方向（由近到远），反转后置于起始之前形成时间序
+        prequels = self.search_previous_subjects(subject_id, max_hops=max_depth) or []
+        prefixed: list[int] = []
+        for sid in reversed(prequels):
+            if sid and sid not in visited:
+                visited.add(sid)
+                prefixed.append(sid)
+        return prefixed + chain
 
     def _try_find_episode_in_franchise(
         self,

--- a/app/utils/bangumi_api/episodes.py
+++ b/app/utils/bangumi_api/episodes.py
@@ -646,8 +646,9 @@ class EpisodesMixin:
             subject_id: 已命中的初始条目 id
             target_ep: 目标集数（季内集编号，对应 ep.ep；target_season<=1 时回退为全局 sort）
             max_depth: 沿单方向最多遍历多少个关联条目，防极端环
-            target_season: 目标季编号；大于 1 时优先按季在关联链上定位目标条目，
-                再按集解析，避免命中错误季
+            target_season: 目标季编号；大于 1 时 target_ep 按季内集编号在关联链上
+                定位目标季后解析。季定位未命中时不回退全局 sort，除非该编号超出
+                目标季总集数（可判定调用方给出的是跨季连续编号）
 
         Returns:
             (subject_id, episode_id) 或 None
@@ -665,12 +666,18 @@ class EpisodesMixin:
         # 季定位优先：明确指定季时，先按季在关联链上定位目标条目，再按集解析，
         # 避免仅凭全局 sort 命中错误季（例如第 4 季第 13 集误命中第 1 季第 13 集）。
         if target_season and target_season > 1:
-            season_pick = self._resolve_by_season_chain(
+            season_pick, beyond_season_total = self._resolve_by_season_chain(
                 subject_id, target_season, target_ep, max_depth, deadline
             )
             if season_pick:
                 self.last_cross_season_path = "chain"
                 return season_pick
+            # target_season>1 时 target_ep 是季内集编号。目标季未定位、或该季章节
+            # 无法按 ep 解析时回退全局 sort，会把季内编号当作全局序号命中错误季
+            # （第 4 季第 13 集命中第 1 季第 13 集）；仅当编号超出目标季总集数、
+            # 可判定为跨季连续编号时才回退。
+            if not beyond_season_total:
+                return None
 
         # 先在当前 subject 内查
         found = self._find_episode_by_sort(subject_id, target_ep)
@@ -741,19 +748,24 @@ class EpisodesMixin:
         target_ep: int,
         max_depth: int,
         deadline: float | None = None,
-    ) -> tuple[int, int] | None:
-        """按季在关联链上定位目标条目并解析集数。
+    ) -> tuple[tuple[int, int] | None, bool]:
+        """按季在关联链上定位目标条目并解析季内集编号。
 
         调用方明确提供季编号（target_season>1）时，依据各条目标题中的季声明在
         整条前传/续集链上定位目标季的条目（分篇 cours 视为同一季的连续段），再按
-        集号在目标季内解析，从而命中用户所指的具体季与集。
+        累计集数把 target_ep 解析为目标季内的具体章节。
 
-        无法在关联链上确定目标季，或目标季内找不到对应集时返回 None，
-        由调用方回退到全局 sort 匹配。
+        Returns:
+            (命中结果, target_ep 是否超出目标季总集数)
+            - 命中结果非 None 时为 (subject_id, episode_id)
+            - 命中为 None 且未超范围：目标季不在关联链上，或该季章节缺少 ep 字段，
+              无法按季内编号解析
+            - 命中为 None 且超出范围：目标季已定位，但 target_ep 大于该季总集数，
+              说明调用方给出的是跨季连续编号而非季内编号
         """
         chain = self._collect_related_subjects(subject_id, max_depth, deadline)
         if not chain:
-            return None
+            return None, False
 
         # 收集关联链上每个条目的季编号与正片章节，按链序排列
         season_buckets: list[tuple[int | None, int, list[dict]]] = []
@@ -766,9 +778,9 @@ class EpisodesMixin:
             subject_type = info.get("type")
             if subject_type is not None and subject_type != SUBJECT_TYPE_ANIME:
                 continue
-            season = extract_explicit_season(
-                info.get("name_cn") or ""
-            ) or extract_explicit_season(info.get("name") or "")
+            season = self._extract_season_number(
+                info.get("name") or "", info.get("name_cn") or ""
+            )
             episodes = self.get_episodes(sid, fetch_all=True).get("data") or []
             type0 = [e for e in episodes if e.get("type", 0) == 0]
             season_buckets.append((season, sid, type0))
@@ -780,7 +792,11 @@ class EpisodesMixin:
             if season == target_season
         ]
         if not targets:
-            return None
+            return None, False
+
+        # 超出目标季总集数：不是季内相对编号，交由调用方按全局 sort 解释
+        if target_ep > sum(len(eps) for _, eps in targets):
+            return None, True
 
         cumulative = 0
         for sid, eps in targets:
@@ -789,9 +805,10 @@ class EpisodesMixin:
                 local_ep = target_ep - cumulative
                 rows = [e for e in eps if e.get("ep") == local_ep]
                 if rows:
-                    return sid, rows[0]["id"]
+                    return (sid, rows[0]["id"]), False
+                break
             cumulative += count
-        return None
+        return None, False
 
     def _collect_related_subjects(
         self,

--- a/app/utils/season_title.py
+++ b/app/utils/season_title.py
@@ -1,0 +1,47 @@
+"""季编号解析纯函数（无外部依赖，可被 bangumi_api 层复用）。
+
+从条目标题中提取明确声明的季度编号，供跨季选集时定位目标季条目。
+"""
+
+from __future__ import annotations
+
+import re
+
+from .text_constants import CN_NUM
+
+
+def extract_explicit_season(title: str) -> int | None:
+    """从标题中提取明确声明的季度编号。
+
+    返回值：
+    - 明确声明第 N 季时返回 N（>=1）
+    - 标题不含季度声明时返回 None（可能是第一季本体，也可能是总集篇等）
+
+    覆盖形式：第 X 季 / 第 X 期（阿拉伯与中文数字）、Xnd/Xrd/Xth season、Season X
+    """
+    if not title:
+        return None
+    text = title.strip()
+
+    # "第X期" / "第X季"（阿拉伯数字）
+    m = re.search(r"第\s*(\d+)\s*[期季]", text)
+    if m:
+        return int(m.group(1))
+    # "第X期" / "第X季"（中文数字，含"十一"~"十九"）
+    m = re.search(r"第\s*([一二三四五六七八九十]+)\s*[期季]", text)
+    if m:
+        cn = m.group(1)
+        if len(cn) == 1:
+            return CN_NUM.get(cn)
+        if cn.startswith("十"):
+            return 10 + CN_NUM.get(cn[1], 0)
+        return CN_NUM.get(cn)
+    # "Xnd/Xrd/Xth season"
+    m = re.search(r"(\d+)(?:st|nd|rd|th)\s+season", text, re.IGNORECASE)
+    if m:
+        return int(m.group(1))
+    # "Season X"（需带数字，避免误匹配"Season"单词本身）
+    m = re.search(r"season\s*(\d+)", text, re.IGNORECASE)
+    if m:
+        return int(m.group(1))
+    return None

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -2,10 +2,14 @@
 Bangumi API 完整测试
 """
 
+from __future__ import annotations
+
 from typing import Optional
 from unittest.mock import MagicMock
 
 from app.utils.bangumi_api import BangumiApi
+from app.utils.bangumi_api._archive_shortcut import ShortcutResult
+from app.utils.season_title import extract_explicit_season
 
 
 class TestGetTargetSeasonEpisodeIdAirdate:
@@ -1178,6 +1182,265 @@ class TestFindEpisodeAcrossSeasons:
         )
         assert sid == 2
         assert eid == 2002  # sort 27 -> id 2000 + (27 - 25)
+
+
+# find_episode_across_seasons 的 target_season 季定位分支测试
+# （避免仅凭全局 sort 命中最先含该 sort 的错误季，如 S04E13 误命中 S1E13）
+
+
+def _make_eps_by_ep(
+    start_ep: int, count: int, start_id: int, start_sort: int | None = None
+):
+    """生成单 cour 的 episode 列表（type=0）。"""
+    eps = []
+    for i in range(count):
+        ep = start_ep + i
+        sort = start_sort + i if start_sort is not None else ep
+        eps.append(
+            {
+                "sort": sort,
+                "ep": ep,
+                "id": start_id + i,
+                "type": 0,
+                "airdate": "",
+            }
+        )
+    return eps
+
+
+def build_api_with_chain(subjects, episodes, sequel_chain, prequel_chain=None):
+    """构造 mock 好的 BangumiApi，用预设关联链 + 条目/章节数据驱动季定位逻辑。
+
+    subjects: {sid: {"name","name_cn","type"}}
+    episodes: {sid: [ep dict]}
+    sequel_chain / prequel_chain: subject id 列表（由近到远）
+    """
+    api = BangumiApi()
+
+    def get_subject(sid):
+        return subjects.get(int(sid))
+
+    def get_episodes(sid, *args, **kwargs):
+        data = episodes.get(int(sid), [])
+        return {"data": data, "total": len(data)}
+
+    api.get_subject = MagicMock(side_effect=get_subject)
+    api.get_episodes = MagicMock(side_effect=get_episodes)
+    api._fetch_episodes_page = MagicMock(return_value={"data": [], "total": 0})
+    api._archive = MagicMock()
+    api._archive.try_find_sequel_chain = MagicMock(
+        return_value=ShortcutResult(True, sequel_chain or [], "archive_hit")
+    )
+    api.search_previous_subjects = MagicMock(return_value=prequel_chain or [])
+    return api
+
+
+class TestExtractExplicitSeason:
+    """extract_explicit_season 纯函数：从标题提取明确声明的季度编号。"""
+
+    def test_rezero_season_titles(self):
+        # 各 cour 标题均携带「第X季」，应解析出对应季编号
+        assert extract_explicit_season("Re：从零开始的异世界生活") is None
+        assert extract_explicit_season("Re：从零开始的异世界生活 第二季") == 2
+        assert extract_explicit_season("Re：从零开始的异世界生活 第二季 后半") == 2
+        assert extract_explicit_season("Re：从零开始的异世界生活 第三季 袭击篇") == 3
+        assert extract_explicit_season("Re：从零开始的异世界生活 第三季 反击篇") == 3
+        assert extract_explicit_season("Re：从零开始的异世界生活 第四季 失坠篇") == 4
+        assert extract_explicit_season("Re：从零开始的异世界生活 第四季 夺还篇") == 4
+
+    def test_chinese_and_arabic_season_keywords(self):
+        assert extract_explicit_season("进击的巨人 第四季") == 4
+        assert extract_explicit_season("进击の巨人 第四期") == 4
+        assert extract_explicit_season("第12期") == 12
+        assert extract_explicit_season("第2季") == 2
+        assert extract_explicit_season("某番剧 第十一季") == 11
+
+    def test_english_season_keywords(self):
+        assert extract_explicit_season("Attack on Titan Season 4") == 4
+        assert extract_explicit_season("Anime 2nd season") == 2
+        assert extract_explicit_season("Anime Season 3") == 3
+
+    def test_no_season_declaration(self):
+        # 无季声明（第一季本体 / 总集篇 / 续章）应返回 None
+        assert extract_explicit_season("虫师 续章") is None
+        assert extract_explicit_season("凡人修仙传") is None
+        assert extract_explicit_season("") is None
+
+
+class TestFindEpisodeAcrossSeasonsBySeason:
+    """find_episode_across_seasons 季定位分支：Re:Zero 多 cour 跨季场景。"""
+
+    @staticmethod
+    def _rezero_subjects():
+        base = "Re：从零开始的异世界生活"
+        return {
+            140001: {"name": base, "name_cn": base, "type": 2},
+            278826: {"name": f"{base} 第二季", "name_cn": f"{base} 第二季", "type": 2},
+            316247: {
+                "name": f"{base} 第二季 后半",
+                "name_cn": f"{base} 第二季 后半",
+                "type": 2,
+            },
+            425998: {
+                "name": f"{base} 第三季 袭击篇",
+                "name_cn": f"{base} 第三季 袭击篇",
+                "type": 2,
+            },
+            510728: {
+                "name": f"{base} 第三季 反击篇",
+                "name_cn": f"{base} 第三季 反击篇",
+                "type": 2,
+            },
+            547888: {
+                "name": f"{base} 第四季 失坠篇",
+                "name_cn": f"{base} 第四季 失坠篇",
+                "type": 2,
+            },
+            633836: {
+                "name": f"{base} 第四季 夺还篇",
+                "name_cn": f"{base} 第四季 夺还篇",
+                "type": 2,
+            },
+        }
+
+    @staticmethod
+    def _rezero_episodes():
+        # 每 cour 11 集；S1 25 集；ep13 真实 id = 626044，S4 第二 cour ep2 真实 id = 1656859
+        return {
+            140001: _make_eps_by_ep(1, 25, 626032, start_sort=1),
+            278826: _make_eps_by_ep(1, 11, 278000),
+            316247: _make_eps_by_ep(1, 11, 316000),
+            425998: _make_eps_by_ep(1, 11, 425000),
+            510728: _make_eps_by_ep(1, 11, 510000),
+            547888: _make_eps_by_ep(1, 11, 547000),
+            633836: _make_eps_by_ep(1, 11, 1656858),
+        }
+
+    @classmethod
+    def _rezero_api(cls):
+        return build_api_with_chain(
+            cls._rezero_subjects(),
+            cls._rezero_episodes(),
+            sequel_chain=[278826, 316247, 425998, 510728, 547888, 633836],
+            prequel_chain=[],
+        )
+
+    def test_rezero_s04e13_resolves_to_season4_cour2(self):
+        """分支结果：S04E13 应定位到第四季第二 cour 的 ep2（id 1656859），而非 S1E13。"""
+        api = self._rezero_api()
+        result = api.find_episode_across_seasons(140001, 13, target_season=4)
+        assert result is not None
+        assert result[0] == 633836
+        assert result[1] == 1656859
+
+    def test_rezero_s04e13_without_season_falls_back_to_global_sort(self):
+        """上游结果：未传入季编号时回退全局 sort，S04E13 命中 S1E13（id 626044）。
+
+        这正是 bug 触发路径——证明修复仅在调用方传入季编号时生效，
+        未传季编号时保持既有（有误）行为不变。
+        """
+        api = self._rezero_api()
+        result = api.find_episode_across_seasons(140001, 13)
+        assert result is not None
+        assert result[0] == 140001
+        assert result[1] == 626044
+
+    def test_rezero_s04e01_resolves_to_season4_cour1(self):
+        """S04E01 应定位到第四季第一 cour（547888）的 ep1。"""
+        api = self._rezero_api()
+        result = api.find_episode_across_seasons(140001, 1, target_season=4)
+        assert result is not None
+        assert result[0] == 547888
+
+    def test_target_season_one_skips_season_resolver(self):
+        """常规：target_season<=1 时不应进入季定位快路径，直接走全局 sort。"""
+        api = self._rezero_api()
+        original = api._resolve_by_season_chain
+        api._resolve_by_season_chain = MagicMock(wraps=original)
+        result = api.find_episode_across_seasons(140001, 13, target_season=1)
+        api._resolve_by_season_chain.assert_not_called()
+        assert result == (140001, 626044)
+
+    def test_single_subject_season1_uses_global_sort_unchanged(self):
+        """常规/零回归：单 subject 季=1 走全局 sort 原路径，结果不变。"""
+        subjects = {100: {"name": "某番剧", "name_cn": "某番剧", "type": 2}}
+        episodes = {100: _make_eps_by_ep(1, 13, 10000, start_sort=1)}
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[], prequel_chain=[]
+        )
+        result = api.find_episode_across_seasons(100, 5)
+        assert result == (100, 10004)
+
+    def test_resolve_by_season_chain_returns_none_when_season_absent(self):
+        """边缘：关联链上不存在目标季时，季定位分支返回 None（交由全局 sort 处理）。"""
+        subjects = {
+            100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
+            200: {"name": "某番剧 第二季", "name_cn": "某番剧 第二季", "type": 2},
+            300: {"name": "某番剧 第三季", "name_cn": "某番剧 第三季", "type": 2},
+        }
+        episodes = {
+            100: _make_eps_by_ep(1, 11, 10000),
+            200: _make_eps_by_ep(1, 11, 20000),
+            300: _make_eps_by_ep(1, 11, 30000),
+        }
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[200, 300], prequel_chain=[]
+        )
+        # 关联链仅到第 3 季，要求第 4 季 → 季定位 miss
+        result = api._resolve_by_season_chain(100, 4, 13, 20)
+        assert result is None
+
+    def test_season_unparseable_title_falls_back_to_global_sort(self):
+        """边缘：链上标题均无法解析季编号时，季定位 miss，回退全局 sort。"""
+        subjects = {
+            100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
+            200: {"name": "某番剧 续章", "name_cn": "某番剧 续章", "type": 2},
+        }
+        episodes = {
+            100: _make_eps_by_ep(1, 13, 10000, start_sort=1),
+            200: _make_eps_by_ep(1, 13, 20000, start_sort=1),
+        }
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[200], prequel_chain=[]
+        )
+        # 标题无季声明，季定位无法命中，回退到 S1 的全局 sort
+        result = api.find_episode_across_seasons(100, 13, target_season=2)
+        assert result == (100, 10012)
+
+    def test_cross_cour_same_season_cumulative(self):
+        """边缘：同季多 cour 累计定位。S2 分两 cour（各 12 集），ep=20 应落在第二 cour ep8。"""
+        subjects = {
+            100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
+            200: {"name": "某番剧 第二季", "name_cn": "某番剧 第二季", "type": 2},
+            210: {
+                "name": "某番剧 第二季 后半",
+                "name_cn": "某番剧 第二季 后半",
+                "type": 2,
+            },
+        }
+        episodes = {
+            100: _make_eps_by_ep(1, 12, 10000, start_sort=1),
+            200: _make_eps_by_ep(1, 12, 20000, start_sort=1),
+            210: _make_eps_by_ep(1, 12, 21000, start_sort=1),
+        }
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[200, 210], prequel_chain=[]
+        )
+        result = api.find_episode_across_seasons(100, 20, target_season=2)
+        assert result is not None
+        assert result[0] == 210
+        # 第二 cour 内 local_ep = 20 - 12 = 8
+        assert result[1] == 21007
+
+    def test_season_not_in_chain_overall_none(self):
+        """边缘：目标季不在链内且全局 sort 也找不到时，整体返回 None（不崩溃）。"""
+        subjects = {100: {"name": "某番剧", "name_cn": "某番剧", "type": 2}}
+        episodes = {100: _make_eps_by_ep(1, 10, 10000, start_sort=1)}
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[], prequel_chain=[]
+        )
+        result = api.find_episode_across_seasons(100, 13, target_season=4)
+        assert result is None
 
 
 class TestFindEpisodeFranchiseFallback:

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -1207,6 +1207,14 @@ def _make_eps_by_ep(
     return eps
 
 
+def _make_eps_by_sort(start_sort: int, count: int, start_id: int):
+    """生成仅含 sort、不含 ep 字段的 episode 列表（模拟 Archive 的 episode 表）。"""
+    return [
+        {"sort": start_sort + i, "id": start_id + i, "type": 0, "airdate": ""}
+        for i in range(count)
+    ]
+
+
 def build_api_with_chain(subjects, episodes, sequel_chain, prequel_chain=None):
     """构造 mock 好的 BangumiApi，用预设关联链 + 条目/章节数据驱动季定位逻辑。
 
@@ -1415,7 +1423,7 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         assert result == (100, 10004)
 
     def test_resolve_by_season_chain_returns_none_when_season_absent(self):
-        """边缘：关联链上不存在目标季时，季定位分支返回 None（交由全局 sort 处理）。"""
+        """边缘：关联链上不存在目标季时既不命中，也不判定为跨季连续编号。"""
         subjects = {
             100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
             200: {"name": "某番剧 第二季", "name_cn": "某番剧 第二季", "type": 2},
@@ -1429,12 +1437,17 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         api = build_api_with_chain(
             subjects, episodes, sequel_chain=[200, 300], prequel_chain=[]
         )
-        # 关联链仅到第 3 季，要求第 4 季 → 季定位 miss
-        result = api._resolve_by_season_chain(100, 4, 13, 20)
-        assert result is None
+        # 关联链仅到第 3 季，要求第 4 季 → 目标季无法定位
+        pick, beyond_season_total = api._resolve_by_season_chain(100, 4, 13, 20)
+        assert pick is None
+        assert beyond_season_total is False
 
-    def test_season_unparseable_title_falls_back_to_global_sort(self):
-        """边缘：链上标题均无法解析季编号时，季定位 miss，回退全局 sort。"""
+    def test_season_unparseable_title_returns_none(self):
+        """边缘：链上标题均无法解析季编号时目标季无法定位，不回退全局 sort。
+
+        target_season>1 时集数是季内编号，回退全局 sort 会把它当作全局序号命中
+        第一季的同号集（第 2 季第 13 集命中第 1 季第 13 集）。
+        """
         subjects = {
             100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
             200: {"name": "某番剧 续章", "name_cn": "某番剧 续章", "type": 2},
@@ -1446,9 +1459,50 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         api = build_api_with_chain(
             subjects, episodes, sequel_chain=[200], prequel_chain=[]
         )
-        # 标题无季声明，季定位无法命中，回退到 S1 的全局 sort
+        # 标题无季声明，第 2 季无法定位；不得退化为 sort=13 命中第一季
         result = api.find_episode_across_seasons(100, 13, target_season=2)
-        assert result == (100, 10012)
+        assert result is None
+
+    def test_season_located_without_ep_field_returns_none(self):
+        """边缘：目标季已定位但章节缺 ep 字段时无法按季内编号解析，不回退全局 sort。
+
+        Archive 的 episode 表只提供全局连续 sort，不含季内 ep；此时回退全局 sort
+        会把季内编号当作全局序号命中第一季同号集。
+        """
+        subjects = {
+            100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
+            200: {"name": "某番剧 第二季", "name_cn": "某番剧 第二季", "type": 2},
+        }
+        # 第二季 sort 全局连续 14..25，无 ep 字段
+        episodes = {
+            100: _make_eps_by_sort(1, 13, 10000),
+            200: _make_eps_by_sort(14, 12, 20000),
+        }
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[200], prequel_chain=[]
+        )
+        result = api.find_episode_across_seasons(100, 6, target_season=2)
+        assert result is None
+
+    def test_target_ep_beyond_season_total_keeps_global_sort_fallback(self):
+        """边缘：集数超出目标季总集数时按跨季连续编号处理，回退全局 sort 匹配。"""
+        subjects = {
+            100: {"name": "某番剧", "name_cn": "某番剧", "type": 2},
+            200: {"name": "某番剧 第二季", "name_cn": "某番剧 第二季", "type": 2},
+            300: {"name": "某番剧 第三季", "name_cn": "某番剧 第三季", "type": 2},
+        }
+        # sort 全局连续：第 1 季 1-10、第 2 季 11-20、第 3 季 21-30；ep 每季从 1 起
+        episodes = {
+            100: _make_eps_by_ep(1, 10, 10000, start_sort=1),
+            200: _make_eps_by_ep(1, 10, 20000, start_sort=11),
+            300: _make_eps_by_ep(1, 10, 30000, start_sort=21),
+        }
+        api = build_api_with_chain(
+            subjects, episodes, sequel_chain=[200, 300], prequel_chain=[]
+        )
+        # 第 2 季共 10 集，25 超出该范围 → 视为连续编号，回退全局 sort=25
+        result = api.find_episode_across_seasons(100, 25, target_season=2)
+        assert result == (300, 30004)
 
     def test_cross_cour_same_season_cumulative(self):
         """边缘：同季多 cour 累计定位。S2 分两 cour（各 12 集），ep=20 应落在第二 cour ep8。"""

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -4,7 +4,6 @@ Bangumi API 完整测试
 
 from __future__ import annotations
 
-from typing import Optional
 from unittest.mock import MagicMock
 
 from app.utils.bangumi_api import BangumiApi
@@ -692,7 +691,7 @@ class TestFindEpisodeAcrossSeasons:
     def _make_api(
         episodes: dict,
         related: dict,
-        subject_info: Optional[dict] = None,
+        subject_info: dict | None = None,
     ):
         """构造一个 mock 好的 BangumiApi 实例。
 
@@ -842,9 +841,9 @@ class TestFindEpisodeAcrossSeasons:
     def _make_api_with_archive(
         episodes: dict,
         related: dict,
-        sequel_chain: Optional[list[int]],
+        sequel_chain: list[int] | None,
         archive_hit: bool = True,
-        subject_info: Optional[dict] = None,
+        subject_info: dict | None = None,
     ):
         """构造一个 mock 好的 BangumiApi 实例，并启用 archive 短路。
 

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -1370,7 +1370,7 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         )
 
     def test_rezero_s04e13_resolves_to_season4_cour2(self):
-        """分支结果：S04E13 应定位到第四季第二 cour 的 ep2（id 1656859），而非 S1E13。"""
+        """显式传入 target_season=4 时，S04E13 定位到第四季第二 cour 的 ep2（id 1656859）。"""
         api = self._rezero_api()
         result = api.find_episode_across_seasons(140001, 13, target_season=4)
         assert result is not None
@@ -1378,10 +1378,9 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         assert result[1] == 1656859
 
     def test_rezero_s04e13_without_season_falls_back_to_global_sort(self):
-        """上游结果：未传入季编号时回退全局 sort，S04E13 命中 S1E13（id 626044）。
+        """未传入季编号（target_season 取默认值 1）时按全局 sort 解析，S04E13 命中 sort=13 的第一季 ep13（id 626044）。
 
-        这正是 bug 触发路径——证明修复仅在调用方传入季编号时生效，
-        未传季编号时保持既有（有误）行为不变。
+        季定位仅在 target_season>1 时启用，故不传季编号的请求仍走全局 sort。
         """
         api = self._rezero_api()
         result = api.find_episode_across_seasons(140001, 13)
@@ -1406,7 +1405,7 @@ class TestFindEpisodeAcrossSeasonsBySeason:
         assert result == (140001, 626044)
 
     def test_single_subject_season1_uses_global_sort_unchanged(self):
-        """常规/零回归：单 subject 季=1 走全局 sort 原路径，结果不变。"""
+        """常规：单 subject、季=1 的请求按全局 sort 解析，命中 sort 对应的章节。"""
         subjects = {100: {"name": "某番剧", "name_cn": "某番剧", "type": 2}}
         episodes = {100: _make_eps_by_ep(1, 13, 10000, start_sort=1)}
         api = build_api_with_chain(

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -1266,6 +1266,50 @@ class TestExtractExplicitSeason:
         assert extract_explicit_season("") is None
 
 
+class TestExtractSeasonNumber:
+    """_extract_season_number 委托 extract_explicit_season 后的行为
+
+    此前该方法在 episodes.py 内联了一份正则，缺少「Season X」规则，与共享函数对
+    同一标题会给出不同结果。委托后两者应始终一致。
+    """
+
+    @staticmethod
+    def _api() -> BangumiApi:
+        return BangumiApi()
+
+    def test_english_season_keyword_supported(self):
+        api = self._api()
+        assert api._extract_season_number("Attack on Titan Season 4", "") == 4
+        assert api._extract_season_number("Anime Season 3", "") == 3
+
+    def test_name_cn_merged_with_name(self):
+        api = self._api()
+        assert api._extract_season_number("某番剧", "某番剧 第二季") == 2
+        assert (
+            api._extract_season_number("Re：从零开始的异世界生活 第四季 夺还篇", "")
+            == 4
+        )
+
+    def test_no_season_declaration_returns_none(self):
+        api = self._api()
+        assert api._extract_season_number("虫师 续章", "") is None
+        assert api._extract_season_number("", "") is None
+
+    def test_consistent_with_shared_helper(self):
+        """与 extract_explicit_season 对同一输入结果一致"""
+        api = self._api()
+        for name, name_cn in [
+            ("Attack on Titan Season 4", ""),
+            ("Anime 2nd season", ""),
+            ("某番剧 第十一季", ""),
+            ("进击の巨人 第四期", ""),
+            ("凡人修仙传", ""),
+        ]:
+            assert api._extract_season_number(name, name_cn) == extract_explicit_season(
+                f"{name} {name_cn}"
+            )
+
+
 class TestFindEpisodeAcrossSeasonsBySeason:
     """find_episode_across_seasons 季定位分支：Re:Zero 多 cour 跨季场景。"""
 

--- a/tests/utils/test_bangumi_api_extended.py
+++ b/tests/utils/test_bangumi_api_extended.py
@@ -1267,10 +1267,11 @@ class TestExtractExplicitSeason:
 
 
 class TestExtractSeasonNumber:
-    """_extract_season_number 委托 extract_explicit_season 后的行为
+    """_extract_season_number：从条目名与中文名中提取季编号
 
-    此前该方法在 episodes.py 内联了一份正则，缺少「Season X」规则，与共享函数对
-    同一标题会给出不同结果。委托后两者应始终一致。
+    覆盖四种明确声明形式：「第 X 季 / 第 X 期」（阿拉伯数字与中文数字）、
+    「Xnd/Xrd/Xth season」、「Season X」。条目名与中文名合并后解析；两者均不含
+    季声明时返回 None（可能是第一季本体，也可能是总集篇）。
     """
 
     @staticmethod


### PR DESCRIPTION
<!-- 请务必在创建 PR 前，在右侧 Labels 选项中加上 label：`[bug]` -->

## 📝 PR 描述
不一定要合并采纳因为我现在对当前大规模重构后的我们项目很懵（）
只是基于当前版本这个类型问题针对性的修复，并不确定这么做会不会破坏其他案例

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复跨季链选集时仅凭全局 `sort` 命中错误季的问题（如 Re:Zero S04E13 误命中 S1E13）。

`find_episode_across_seasons` 原实现仅按 `ep.sort` 在关联链上做全局解析，未利用调用方已知的目标季编号。当调用方已掌握目标季（如 `ctx.item.season=4`）时，仍可能沿链命中「最先含该 sort」的错误季条目。

修复：调用方明确提供 `target_season>1` 时，新增「按季定位」快路径 `_resolve_by_season_chain`——在整条前传/续集链上依据各条目标题中的季声明定位目标季条目（分 cour 视为同一季的连续段），再按**季内集编号**在目标季内解析；无法在链上确定目标季或目标季内找不到对应集时，整体回退原全局 `sort` 逻辑，保持既有行为不变。

### 相关 Issue
Closes #236 


## 📋 提交前检查清单

### 规范与静态检查
- [x] 本次改动文件 `ruff check` 全部通过（`app/utils/season_title.py`、`app/utils/bangumi_api/episodes.py`、`app/services/sync_service/season_info.py`、`app/services/sync_service/steps/cross_season.py`、`app/services/matching/ports.py`）
- [x] 本次改动文件 `ruff format --check` 全部通过
- [x] 全仓 `ruff check .` 通过：为支持新增测试中 `int | None` 注解在 py39 运行期合法，本分支在 `tests/utils/test_bangumi_api_extended.py` 顶部加入 `from __future__ import annotations`；该导入使 ruff 在 `target-version=py39` 下放开 `UP045`，相应将文件内 3 处既有 `Optional[X]` 现代化为 `X | None` 并移除失效的 `from typing import Optional`，全仓 `ruff check .` / `ruff format --check .` 均通过。

### 测试
- [x] 新增 `TestExtractExplicitSeason`（`extract_explicit_season` 纯函数，4 例）
- [x] 新增 `TestFindEpisodeAcrossSeasonsBySeason`（季定位分支，11 例）与 `TestExtractSeasonNumber`（4 例，校验 `_extract_season_number` 与共享函数 `extract_explicit_season` 对同标题给出一致结果）
- [x] `uv run pytest tests/utils/test_bangumi_api_extended.py::TestExtractExplicitSeason tests/utils/test_bangumi_api_extended.py::TestExtractSeasonNumber tests/utils/test_bangumi_api_extended.py::TestFindEpisodeAcrossSeasonsBySeason` → 19 passed
- [x] `pytest tests/` → 3506 passed, 1 failed（唯一失败同为本机符号链接特权问题，与 `main` 一致）

## 🔍 额外说明

### 根因：缺省行为未利用已知的季编号
`_resolve_by_season_chain` 此前不存在，跨季选集完全依赖全局 `sort` 匹配。Bangumi 每季条目内 `ep` 从 1 开始、`sort` 为整部作品连续编号；当目标集号（如 13）在多个季的 `sort` 范围重叠命中时，会落到「最先遍历到」的错误季。

### 实际案例：Re:Zero S04E13
Re:Zero 多 cour 结构：S1 25 集，S2/S3/S4 各分两 cour（每 cour 11 集）。传入 `subject_id=140001`、`target_ep=13`、`target_season=4`：

| 场景 | 修复前（仅全局 sort） | 修复后（按季定位） |
|------|------|------|
| `find_episode_across_seasons(140001, 13, target_season=4)` | 沿链命中 S1E13（`626044`） | 命中 S4 第二 cour ep2（`1656859`） |
| `find_episode_across_seasons(140001, 13)`（不传季） | S1E13（`626044`，既有行为） | 同样命中 S1E13（快路径跳过，回退全局 sort） |

Re:Zero 全 7 季 `sort` 全局连续（1~85），用户发 `S01`（不分季）或不传季时 `target_season=1`，新逻辑完全不介入，原代码（本分支未改动）按 `sort` 沿关联链定位，结果与上游逐字一致——`S01E79` 即此类全局连续编号请求，不受本分支影响：

| 调用 | 结果 |
|------|------|
| `find_episode_across_seasons(140001, 79, target_season=1)` | 命中 S4 夺还篇 ep2（sort79） |
| `find_episode_across_seasons(140001, 79)`（不传季） | 同上（回退全局 sort） |
| `find_episode_across_seasons(140001, 85, target_season=1)` | 命中 S4 夺还篇 ep8（末集，sort85） |
| `find_episode_across_seasons(140001, 13, target_season=1)` | 命中 S1E13（sort13） |

因此 `S01E79` 等全局编号请求由原始全局 `sort` 路径（本分支零改动）精确命中第四季夺还篇第 2 集；跨季分支仅对 `target_season>1`（用户显式声明季且需按季内相对编号定位）生效（如 `S04E13`），两路径分工清晰、互不冲突。

### 设计要点（非临时补丁）
- **快路径条件严格**：`target_season and target_season > 1` 才进入季定位；`<=1` 完全走原路径，零回归。
- **常规匹配零回归（已测试覆盖）**：仅 `target_season>1` 进入新路径；`target_season<=1`（如 TMDB 不分季、用户发 `S01` 的常规场景，例如【我推的孩子】`S01E15`/`S01E35`）完全走原全局 `sort` 链，行为与上游逐字一致，不会被新逻辑介入。覆盖用例：`test_target_season_one_skips_season_resolver`（`find_episode_across_seasons(140001, 13, target_season=1)` 命中 `(140001, 626044)`，即跳过季解析、回退全局 sort）与 `test_single_subject_season1_uses_global_sort_unchanged`。
- **季定位未命中不回退全局 sort**：`target_season>1` 时 `target_ep` 是季内集编号，若季定位未命中就回退全局 sort，等于把季内编号当作全局序号，会再次命中错误季——开启 Archive 时目标季章节缺少 `ep` 字段无法解析，`S04E13` 回退后命中第一季同号集；关联链标题无法解析季编号时 `S02E13` 同样命中第一季同号集。因此 `_resolve_by_season_chain` 会区分未命中原因：仅当 `target_ep` 超出目标季总集数（可判定调用方给出的是跨季连续编号，如 `S04E78`）时，才回退全局 sort 与 franchise 兜底；目标季未在链上定位、或该季章节缺少 `ep` 字段时直接返回 `None`。对已声明季号的请求，标记为未命中优于标记到错误章节。
- **与日期无关（纯 `sort` 匹配，已用 Re:Zero 七季真实连续 `sort` 数据验证）**：`find_episode_across_seasons` 不接收也不使用 `release_date`（方法文档明写「本方法不依赖 release_date，仅通过 sort 字段匹配」）。形如 `S04E78` 的「季内相对编号越界」请求（`target_ep=78` 超过 S4 共 19 集）会由 `_resolve_by_season_chain` 返回 `None`，回退全局 `sort=78` → 夺还篇 ep1，全程纯 sort 匹配，既与日期无关、也与「日期择优选中的起点 subject」无关（已用 Re:Zero 七季真实连续 `sort` 数据验证「起点=140001(S1)」与「起点=633836(夺还篇)」结果一致）。整体流程中唯一涉及日期的 `get_target_season_episode_id` 的 `_try_resolve_sequel_by_airdate`（line 579，需 `release_date and target_season>1`）在携带日期且窗口内时优先返回**同一**结果，不改变正确性。
- **类型单一来源**：原 `season_info.py` 内联的季解析逻辑抽取为无依赖纯函数 `app/utils/season_title.py:extract_explicit_season`，`_get_explicit_season_from_title` 改为委托，无重复代码、无遗留死代码（`CN_NUM` 在本文件不再引用，已随内联逻辑移除导入）。
- **协议兼容**：`BangumiSearchPort.find_episode_across_seasons` 新增 `target_season: int = 1` 默认参数，既有调用方无需改动；唯一调用方 `cross_season.py` 已传入 `target_season=ctx.item.season or 1`。

### 修改范围（6 文件）

| 文件 | 改动 |
|------|------|
| `app/utils/season_title.py` | 新增：从标题提取明确季编号的纯函数 `extract_explicit_season` |
| `app/utils/bangumi_api/episodes.py` | `find_episode_across_seasons` 增 `target_season` 参数与按季定位快路径；新增 `_resolve_by_season_chain`（返回命中结果与「是否超出目标季总集数」）、`_collect_related_subjects` |
| `app/services/sync_service/season_info.py` | `_get_explicit_season_from_title` 委托 `extract_explicit_season`，移除内联实现与 `CN_NUM` 导入 |
| `app/services/sync_service/steps/cross_season.py` | 调用 `find_episode_across_seasons` 时传入 `target_season=ctx.item.season or 1`；未命中日志按 `target_season` 输出季内集编号或 `sort`，与匹配口径一致 |
| `app/services/matching/ports.py` | `BangumiSearchPort.find_episode_across_seasons` 协议签名增 `target_season: int = 1` |
| `tests/utils/test_bangumi_api_extended.py` | 新增 `TestExtractExplicitSeason`（4 例）+ `TestExtractSeasonNumber`（4 例）+ `TestFindEpisodeAcrossSeasonsBySeason`（11 例），共 19 例 |


