### PR TITLE
fix(archive): 在数据边界补全 Archive episode 季内话数 ep 字段修复逃跑殿下第二季匹配错误

### DIFF
--- a/app/utils/bangumi_archive/_store.py
+++ b/app/utils/bangumi_archive/_store.py
@@ -215,7 +215,9 @@ class ArchiveStore:
                 params.append(episode_type)
             sql += " ORDER BY sort"
             rows = conn.execute(sql, params).fetchall()
-            return [self._adapt_episode_row(dict(r)) for r in rows]
+            episodes = [dict(r) for r in rows]
+            self._synthesize_ep_field(episodes)
+            return [self._adapt_episode_row(e) for e in episodes]
         except sqlite3.Error as e:
             logger.warning(f"bangumi_archive get_episodes 失败: {e}")
             return []
@@ -627,6 +629,21 @@ class ArchiveStore:
         Archive 的字段名与 API 一致，仅 airdate 对应 API 的 airdate。
         """
         return row
+
+    @staticmethod
+    def _synthesize_ep_field(episodes: list[dict[str, Any]]) -> None:
+        """为 Archive episode 补全季内话数 ep 字段
+
+        Archive 按全局连续 sort 存储，不提供 API 中的季内集编号 ep。
+        下游匹配层（episodes.py）以 ep 作为季内话数，需在数据边界处补全：
+        取 type=0 的常规话，按 sort 升序给出 1-based 季内位置作为 ep。
+        """
+        type0_sorted = sorted(
+            (e for e in episodes if e.get("type", 0) == 0),
+            key=lambda e: e.get("sort", 0),
+        )
+        for i, e in enumerate(type0_sorted, start=1):
+            e["ep"] = i
 
     @staticmethod
     def _adapt_relation_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/app/utils/bangumi_archive/_store.py
+++ b/app/utils/bangumi_archive/_store.py
@@ -640,7 +640,7 @@ class ArchiveStore:
         """
         type0_sorted = sorted(
             (e for e in episodes if e.get("type", 0) == 0),
-            key=lambda e: e.get("sort", 0),
+            key=lambda e: e.get("sort") or 0,
         )
         for i, e in enumerate(type0_sorted, start=1):
             e["ep"] = i

--- a/app/utils/bangumi_archive/_store.py
+++ b/app/utils/bangumi_archive/_store.py
@@ -639,7 +639,8 @@ class ArchiveStore:
         取 type=0 的常规话，按 sort 升序给出 1-based 季内位置作为 ep。
 
         同一 subject 内 sort 每季重置为 1 时（多季合并到同一条目），季边界无法由
-        sort 推得，此时不补全，交由下游既有的 sort 重置检测定位季边界。
+        sort 推得，此时不补全，交由下游 episodes.py 依据 sort 重置（大于 1 跳回 1
+        判定新季起点）定位季边界。
         """
         type0 = [e for e in episodes if e.get("type", 0) == 0]
 

--- a/app/utils/bangumi_archive/_store.py
+++ b/app/utils/bangumi_archive/_store.py
@@ -637,12 +637,21 @@ class ArchiveStore:
         Archive 按全局连续 sort 存储，不提供 API 中的季内集编号 ep。
         下游匹配层（episodes.py）以 ep 作为季内话数，需在数据边界处补全：
         取 type=0 的常规话，按 sort 升序给出 1-based 季内位置作为 ep。
+
+        同一 subject 内 sort 每季重置为 1 时（多季合并到同一条目），季边界无法由
+        sort 推得，此时不补全，交由下游既有的 sort 重置检测定位季边界。
         """
-        type0_sorted = sorted(
-            (e for e in episodes if e.get("type", 0) == 0),
-            key=lambda e: e.get("sort") or 0,
-        )
-        for i, e in enumerate(type0_sorted, start=1):
+        type0 = [e for e in episodes if e.get("type", 0) == 0]
+
+        # 按 id 升序遍历（反映章节录入顺序），sort 由大于 1 跳回 1 即为新季起点
+        prev_sort = None
+        for e in sorted(type0, key=lambda e: e.get("id") or 0):
+            sort_num = e.get("sort") or 0
+            if prev_sort is not None and sort_num == 1 and prev_sort > 1:
+                return
+            prev_sort = sort_num
+
+        for i, e in enumerate(sorted(type0, key=lambda e: e.get("sort") or 0), start=1):
             e["ep"] = i
 
     @staticmethod

--- a/tests/utils/test_bangumi_api.py
+++ b/tests/utils/test_bangumi_api.py
@@ -1054,6 +1054,38 @@ class TestGetTargetSeasonEpisodeId:
         conn.close()
         return db_path
 
+    @pytest.fixture
+    def archive_sort_reset_db(self, tmp_path):
+        """构建 subject 900002 的 Archive 库：多季合并条目，sort 每季重置为 1"""
+        db_path = tmp_path / "archive_sort_reset.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE episode ("
+            "id INTEGER, name TEXT, name_cn TEXT, description TEXT, "
+            "airdate TEXT, disc INTEGER, duration INTEGER, "
+            "subject_id INTEGER, sort INTEGER, type INTEGER)"
+        )
+        rows = [
+            (301, "EP1", "", "", "2025-01-01", 0, 0, 900002, 1, 0),
+            (302, "EP2", "", "", "2025-01-08", 0, 0, 900002, 2, 0),
+            (303, "EP3", "", "", "2025-01-15", 0, 0, 900002, 3, 0),
+            (304, "EP4", "", "", "2025-01-22", 0, 0, 900002, 4, 0),
+            (305, "EP5", "", "", "2025-01-29", 0, 0, 900002, 5, 0),
+            (306, "EP1", "", "", "2025-02-05", 0, 0, 900002, 1, 0),
+            (307, "EP2", "", "", "2025-02-12", 0, 0, 900002, 2, 0),
+            (308, "EP3", "", "", "2025-02-19", 0, 0, 900002, 3, 0),
+            (309, "EP4", "", "", "2025-02-26", 0, 0, 900002, 4, 0),
+            (310, "EP5", "", "", "2025-03-05", 0, 0, 900002, 5, 0),
+        ]
+        conn.executemany(
+            "INSERT INTO episode (id,name,name_cn,description,airdate,disc,"
+            "duration,subject_id,sort,type) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
     def _enable_archive_with_db(self, api, db_path):
         from app.utils.bangumi_archive import _archive as _arch_mod
 
@@ -1127,6 +1159,28 @@ class TestGetTargetSeasonEpisodeId:
                 )
             assert subject_id == "517106"
             assert episode_id == 13
+        finally:
+            self._restore_archive(api, orig)
+
+    def test_sort_reset_subject_uses_sort_jump_detection(self, archive_sort_reset_db):
+        """多季合并条目（sort 每季重置为 1）不补全 ep，季边界仍由 sort 重置检测定位
+
+        Archive 缺 ep 时上游依赖 sort 由高值跳回 1 判定新季。补全 ep 不得使该检测
+        失效，否则同一条目内的第 2 季将无法定位。
+        """
+        api = BangumiApi()
+        orig = self._enable_archive_with_db(api, archive_sort_reset_db)
+        try:
+            with (
+                patch.object(
+                    api,
+                    "get_subject",
+                    return_value={"id": 900002, "type": 2, "name": "多季合并条目"},
+                ),
+                patch.object(api, "get_related_subjects", return_value=[]),
+            ):
+                result = api._try_resolve_continuous_season_episode(900002, 2, 3)
+            assert result == (900002, 308)
         finally:
             self._restore_archive(api, orig)
 

--- a/tests/utils/test_bangumi_api.py
+++ b/tests/utils/test_bangumi_api.py
@@ -2,6 +2,7 @@
 Bangumi API 工具测试
 """
 
+import sqlite3
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -1017,6 +1018,117 @@ class TestGetTargetSeasonEpisodeId:
             result = api.get_target_season_episode_id("123", 1, 0)
         # P0-3 修复: 返回 tuple (subject_id, None) 保持解包契约
         assert result == ("123", None)
+
+    @pytest.fixture
+    def archive_517106_db(self, tmp_path):
+        """构建 subject 517106（第二期）原始 Archive 库：全局连续 sort 13..24，无 ep 字段"""
+        db_path = tmp_path / "archive_517106.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE episode ("
+            "id INTEGER, name TEXT, name_cn TEXT, description TEXT, "
+            "airdate TEXT, disc INTEGER, duration INTEGER, "
+            "subject_id INTEGER, sort INTEGER, type INTEGER)"
+        )
+        rows = [
+            (13, "EP1", "", "", "2025-01-01", 0, 0, 517106, 13, 0),
+            (14, "EP2", "", "", "2025-01-08", 0, 0, 517106, 14, 0),
+            (15, "EP3", "", "", "2025-01-15", 0, 0, 517106, 15, 0),
+            (16, "EP4", "", "", "2025-01-22", 0, 0, 517106, 16, 0),
+            (17, "EP5", "", "", "2025-01-29", 0, 0, 517106, 17, 0),
+            (18, "EP6", "", "", "2025-02-05", 0, 0, 517106, 18, 0),
+            (19, "EP7", "", "", "2025-02-12", 0, 0, 517106, 19, 0),
+            (20, "EP8", "", "", "2025-02-19", 0, 0, 517106, 20, 0),
+            (21, "EP9", "", "", "2025-02-26", 0, 0, 517106, 21, 0),
+            (22, "EP10", "", "", "2025-03-05", 0, 0, 517106, 22, 0),
+            (23, "EP11", "", "", "2025-03-12", 0, 0, 517106, 23, 0),
+            (24, "EP12", "", "", "2025-03-19", 0, 0, 517106, 24, 0),
+            (25, "SP", "", "", "2025-03-26", 0, 0, 517106, 25, 3),
+        ]
+        conn.executemany(
+            "INSERT INTO episode (id,name,name_cn,description,airdate,disc,"
+            "duration,subject_id,sort,type) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def _enable_archive_with_db(self, api, db_path):
+        from app.utils.bangumi_archive import _archive as _arch_mod
+
+        orig = (
+            _arch_mod.bangumi_archive.db_a_path,
+            _arch_mod.bangumi_archive._meta.active,
+            api._archive._enabled,
+        )
+        _arch_mod.bangumi_archive.db_a_path = db_path
+        _arch_mod.bangumi_archive._meta.active = "a"
+        api._archive._enabled = True
+        return orig
+
+    def _restore_archive(self, api, orig):
+        from app.utils.bangumi_archive import _archive as _arch_mod
+
+        _arch_mod.bangumi_archive.db_a_path = orig[0]
+        _arch_mod.bangumi_archive._meta.active = orig[1]
+        api._archive._enabled = orig[2]
+
+    def test_archive_synthesized_ep_resolves_season_local(self, archive_517106_db):
+        """Archive 补全 ep 后，is_season_subject_id 按季内话数定位章节
+
+        subject 517106 是第二期（全局连续 sort 13..24，无 sort=6），Archive 原始 dump
+        不含 ep，依赖 get_episodes 边界补全 ep=1..12，下游 _match_target_ep_rows 才能
+        按 ep 回退匹配到 sort=18（id=18）。本测试走真实 try_get_episodes → get_episodes
+        路径，是补全逻辑端到端回归测试。
+        """
+        api = BangumiApi()
+        orig = self._enable_archive_with_db(api, archive_517106_db)
+        try:
+            with (
+                patch.object(
+                    api,
+                    "get_subject",
+                    return_value={
+                        "id": 517106,
+                        "type": 2,
+                        "name": "逃げ上手の若君 第二期",
+                    },
+                ),
+                patch.object(api, "get_related_subjects", return_value=[]),
+            ):
+                subject_id, episode_id = api.get_target_season_episode_id(
+                    "517106", 2, 6, is_season_subject_id=True
+                )
+            assert subject_id == "517106"
+            assert episode_id == 18
+        finally:
+            self._restore_archive(api, orig)
+
+    def test_archive_synthesized_ep_first_maps_to_sort13(self, archive_517106_db):
+        """季内第 1 话应映射到全局 sort=13（id=13）"""
+        api = BangumiApi()
+        orig = self._enable_archive_with_db(api, archive_517106_db)
+        try:
+            with (
+                patch.object(
+                    api,
+                    "get_subject",
+                    return_value={
+                        "id": 517106,
+                        "type": 2,
+                        "name": "逃げ上手の若君 第二期",
+                    },
+                ),
+                patch.object(api, "get_related_subjects", return_value=[]),
+            ):
+                subject_id, episode_id = api.get_target_season_episode_id(
+                    "517106", 2, 1, is_season_subject_id=True
+                )
+            assert subject_id == "517106"
+            assert episode_id == 13
+        finally:
+            self._restore_archive(api, orig)
 
 
 class TestTitleDiffRatio:

--- a/tests/utils/test_bangumi_archive.py
+++ b/tests/utils/test_bangumi_archive.py
@@ -1026,6 +1026,20 @@ class TestArchiveEpisodeEpField:
     def store_with_sort_reset(self, tmp_path: Path) -> ArchiveStore:
         yield from _archive_store(tmp_path, _SORT_RESET_ROWS, "sort_reset.db")
 
+    @pytest.fixture
+    def store_empty(self, tmp_path: Path) -> ArchiveStore:
+        yield from _archive_store(tmp_path, [], "empty.db")
+
+    @pytest.fixture
+    def store_only_sp(self, tmp_path: Path) -> ArchiveStore:
+        rows = [(501, "SP", "", "", "2025-01-01", 0, 0, 900003, 1, 3)]
+        yield from _archive_store(tmp_path, rows, "only_sp.db")
+
+    @pytest.fixture
+    def store_single_episode(self, tmp_path: Path) -> ArchiveStore:
+        rows = [(601, "EP1", "", "", "2025-01-01", 0, 0, 900004, 7, 0)]
+        yield from _archive_store(tmp_path, rows, "single.db")
+
     def test_ep_field_synthesized_in_sort_order(self, store_with_episodes):
         """type=0 常规话按 sort 升序补全 1-based 季内 ep（13..24 → 1..12）"""
         eps = store_with_episodes.get_episodes(517106)
@@ -1058,3 +1072,19 @@ class TestArchiveEpisodeEpField:
         eps = store_with_sort_reset.get_episodes(900002)
         assert len(eps) == 10
         assert all("ep" not in e for e in eps)
+
+    def test_ep_field_empty_subject_no_error(self, store_empty):
+        """无章节的条目返回空列表，不补全也不报错"""
+        assert store_empty.get_episodes(900003) == []
+
+    def test_ep_field_only_non_type0_no_ep(self, store_only_sp):
+        """条目内只有非本篇章节时不补全 ep"""
+        eps = store_only_sp.get_episodes(900003)
+        assert len(eps) == 1
+        assert "ep" not in eps[0]
+
+    def test_ep_field_single_episode_is_one(self, store_single_episode):
+        """单集条目的季内话数为 1"""
+        eps = store_single_episode.get_episodes(900004)
+        assert len(eps) == 1
+        assert eps[0]["ep"] == 1

--- a/tests/utils/test_bangumi_archive.py
+++ b/tests/utils/test_bangumi_archive.py
@@ -955,6 +955,20 @@ _NULL_SORT_ROWS = [
     (703, "EP3", "", "", "2025-01-15", 0, 0, 900001, 6, 0),
 ]
 
+# subject 900002：多季合并到同一条目，sort 每季重置为 1（S1 ids 301-305，S2 ids 306-310）
+_SORT_RESET_ROWS = [
+    (301, "EP1", "", "", "2025-01-01", 0, 0, 900002, 1, 0),
+    (302, "EP2", "", "", "2025-01-08", 0, 0, 900002, 2, 0),
+    (303, "EP3", "", "", "2025-01-15", 0, 0, 900002, 3, 0),
+    (304, "EP4", "", "", "2025-01-22", 0, 0, 900002, 4, 0),
+    (305, "EP5", "", "", "2025-01-29", 0, 0, 900002, 5, 0),
+    (306, "EP1", "", "", "2025-02-05", 0, 0, 900002, 1, 0),
+    (307, "EP2", "", "", "2025-02-12", 0, 0, 900002, 2, 0),
+    (308, "EP3", "", "", "2025-02-19", 0, 0, 900002, 3, 0),
+    (309, "EP4", "", "", "2025-02-26", 0, 0, 900002, 4, 0),
+    (310, "EP5", "", "", "2025-03-05", 0, 0, 900002, 5, 0),
+]
+
 
 def _archive_store(tmp_path: Path, rows: list[tuple], db_name: str):
     """用给定 episode 行建立临时 Archive 库，挂到全局单例并提供就绪的 ArchiveStore
@@ -1008,6 +1022,10 @@ class TestArchiveEpisodeEpField:
     def store_with_null_sort(self, tmp_path: Path) -> ArchiveStore:
         yield from _archive_store(tmp_path, _NULL_SORT_ROWS, "null_sort.db")
 
+    @pytest.fixture
+    def store_with_sort_reset(self, tmp_path: Path) -> ArchiveStore:
+        yield from _archive_store(tmp_path, _SORT_RESET_ROWS, "sort_reset.db")
+
     def test_ep_field_synthesized_in_sort_order(self, store_with_episodes):
         """type=0 常规话按 sort 升序补全 1-based 季内 ep（13..24 → 1..12）"""
         eps = store_with_episodes.get_episodes(517106)
@@ -1034,3 +1052,9 @@ class TestArchiveEpisodeEpField:
         eps = store_with_null_sort.get_episodes(900001)
         assert len(eps) == 3
         assert [e["ep"] for e in eps] == [1, 2, 3]
+
+    def test_ep_field_absent_when_sort_resets(self, store_with_sort_reset):
+        """多季合并条目（sort 每季重置为 1）不补全 ep，季边界交由下游 sort 重置检测"""
+        eps = store_with_sort_reset.get_episodes(900002)
+        assert len(eps) == 10
+        assert all("ep" not in e for e in eps)

--- a/tests/utils/test_bangumi_archive.py
+++ b/tests/utils/test_bangumi_archive.py
@@ -929,3 +929,81 @@ class TestBackgroundIndexBuildOnStartup:
         # reload_config 后再次触发（build_in_background 内部有就绪检查，不会重复构建）
         archive.reload_config()
         assert mock_build.call_count == 2
+
+
+class TestArchiveEpisodeEpField:
+    """ArchiveStore.get_episodes 应在数据边界补全季内话数 ep 字段
+
+    Archive 按全局连续 sort 存储（如第二期 sort 13..24），不提供 API 中的季内集编号 ep。
+    下游匹配层（episodes.py 的 _match_target_ep_rows / 连续编号季边界检测）依赖 ep 作为
+    季内话数，因此必须在 get_episodes 返回前补全。
+    """
+
+    @pytest.fixture
+    def store_with_episodes(self, tmp_path: Path) -> ArchiveStore:
+        # subject 517106 = 逃げ上手の若君 第二期，全局连续 sort 13..24（type=0），外传 SP sort=25（type=3）
+        db_path = tmp_path / "ep_synth.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE episode ("
+            "id INTEGER, name TEXT, name_cn TEXT, description TEXT, "
+            "airdate TEXT, disc INTEGER, duration INTEGER, "
+            "subject_id INTEGER, sort INTEGER, type INTEGER)"
+        )
+        rows = [
+            (13, "EP1", "", "", "2025-01-01", 0, 0, 517106, 13, 0),
+            (14, "EP2", "", "", "2025-01-08", 0, 0, 517106, 14, 0),
+            (15, "EP3", "", "", "2025-01-15", 0, 0, 517106, 15, 0),
+            (16, "EP4", "", "", "2025-01-22", 0, 0, 517106, 16, 0),
+            (17, "EP5", "", "", "2025-01-29", 0, 0, 517106, 17, 0),
+            (18, "EP6", "", "", "2025-02-05", 0, 0, 517106, 18, 0),
+            (19, "EP7", "", "", "2025-02-12", 0, 0, 517106, 19, 0),
+            (20, "EP8", "", "", "2025-02-19", 0, 0, 517106, 20, 0),
+            (21, "EP9", "", "", "2025-02-26", 0, 0, 517106, 21, 0),
+            (22, "EP10", "", "", "2025-03-05", 0, 0, 517106, 22, 0),
+            (23, "EP11", "", "", "2025-03-12", 0, 0, 517106, 23, 0),
+            (24, "EP12", "", "", "2025-03-19", 0, 0, 517106, 24, 0),
+            (25, "SP", "", "", "2025-03-26", 0, 0, 517106, 25, 3),
+        ]
+        conn.executemany(
+            "INSERT INTO episode (id,name,name_cn,description,airdate,disc,"
+            "duration,subject_id,sort,type) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+
+        from app.utils.bangumi_archive import _archive
+
+        orig_db_a = _archive.bangumi_archive.db_a_path
+        orig_active = _archive.bangumi_archive._meta.active
+        _archive.bangumi_archive.db_a_path = db_path
+        _archive.bangumi_archive._meta.active = "a"
+
+        store = ArchiveStore()
+        yield store
+
+        store.close()
+        _archive.bangumi_archive.db_a_path = orig_db_a
+        _archive.bangumi_archive._meta.active = orig_active
+
+    def test_ep_field_synthesized_in_sort_order(self, store_with_episodes):
+        """type=0 常规话按 sort 升序补全 1-based 季内 ep（13..24 → 1..12）"""
+        eps = store_with_episodes.get_episodes(517106)
+        type0 = [e for e in eps if e["type"] == 0]
+        assert [e["sort"] for e in type0] == list(range(13, 25))
+        assert [e["ep"] for e in type0] == list(range(1, 13))
+
+    def test_ep_field_absent_for_non_type0(self, store_with_episodes):
+        """非 type=0（如外传 SP）不补全 ep 字段"""
+        eps = store_with_episodes.get_episodes(517106)
+        sp = [e for e in eps if e["type"] == 3]
+        assert len(sp) == 1
+        assert "ep" not in sp[0]
+
+    def test_ep_field_with_type_filter(self, store_with_episodes):
+        """episode_type=0 过滤时同样补全 ep"""
+        eps = store_with_episodes.get_episodes(517106, episode_type=0)
+        assert len(eps) == 12
+        assert all(e.get("ep") for e in eps)
+        assert [e["ep"] for e in eps] == list(range(1, 13))

--- a/tests/utils/test_bangumi_archive.py
+++ b/tests/utils/test_bangumi_archive.py
@@ -931,6 +931,67 @@ class TestBackgroundIndexBuildOnStartup:
         assert mock_build.call_count == 2
 
 
+# subject 517106 = 逃げ上手の若君 第二期：全局连续 sort 13..24（type=0），外传 SP sort=25（type=3）
+_SEASON2_ROWS = [
+    (13, "EP1", "", "", "2025-01-01", 0, 0, 517106, 13, 0),
+    (14, "EP2", "", "", "2025-01-08", 0, 0, 517106, 14, 0),
+    (15, "EP3", "", "", "2025-01-15", 0, 0, 517106, 15, 0),
+    (16, "EP4", "", "", "2025-01-22", 0, 0, 517106, 16, 0),
+    (17, "EP5", "", "", "2025-01-29", 0, 0, 517106, 17, 0),
+    (18, "EP6", "", "", "2025-02-05", 0, 0, 517106, 18, 0),
+    (19, "EP7", "", "", "2025-02-12", 0, 0, 517106, 19, 0),
+    (20, "EP8", "", "", "2025-02-19", 0, 0, 517106, 20, 0),
+    (21, "EP9", "", "", "2025-02-26", 0, 0, 517106, 21, 0),
+    (22, "EP10", "", "", "2025-03-05", 0, 0, 517106, 22, 0),
+    (23, "EP11", "", "", "2025-03-12", 0, 0, 517106, 23, 0),
+    (24, "EP12", "", "", "2025-03-19", 0, 0, 517106, 24, 0),
+    (25, "SP", "", "", "2025-03-26", 0, 0, 517106, 25, 3),
+]
+
+# subject 900001：首话 sort 为 NULL，用于覆盖排序键取到 None 的场景
+_NULL_SORT_ROWS = [
+    (701, "EP1", "", "", "2025-01-01", 0, 0, 900001, None, 0),
+    (702, "EP2", "", "", "2025-01-08", 0, 0, 900001, 5, 0),
+    (703, "EP3", "", "", "2025-01-15", 0, 0, 900001, 6, 0),
+]
+
+
+def _archive_store(tmp_path: Path, rows: list[tuple], db_name: str):
+    """用给定 episode 行建立临时 Archive 库，挂到全局单例并提供就绪的 ArchiveStore
+
+    表结构与 Archive dump 一致（不含 ep 列）。teardown 时关闭连接并恢复全局单例状态。
+    """
+    db_path = tmp_path / db_name
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE episode ("
+        "id INTEGER, name TEXT, name_cn TEXT, description TEXT, "
+        "airdate TEXT, disc INTEGER, duration INTEGER, "
+        "subject_id INTEGER, sort INTEGER, type INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO episode (id,name,name_cn,description,airdate,disc,"
+        "duration,subject_id,sort,type) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+    from app.utils.bangumi_archive import _archive
+
+    orig_db_a = _archive.bangumi_archive.db_a_path
+    orig_active = _archive.bangumi_archive._meta.active
+    _archive.bangumi_archive.db_a_path = db_path
+    _archive.bangumi_archive._meta.active = "a"
+
+    store = ArchiveStore()
+    yield store
+
+    store.close()
+    _archive.bangumi_archive.db_a_path = orig_db_a
+    _archive.bangumi_archive._meta.active = orig_active
+
+
 class TestArchiveEpisodeEpField:
     """ArchiveStore.get_episodes 应在数据边界补全季内话数 ep 字段
 
@@ -941,51 +1002,11 @@ class TestArchiveEpisodeEpField:
 
     @pytest.fixture
     def store_with_episodes(self, tmp_path: Path) -> ArchiveStore:
-        # subject 517106 = 逃げ上手の若君 第二期，全局连续 sort 13..24（type=0），外传 SP sort=25（type=3）
-        db_path = tmp_path / "ep_synth.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "CREATE TABLE episode ("
-            "id INTEGER, name TEXT, name_cn TEXT, description TEXT, "
-            "airdate TEXT, disc INTEGER, duration INTEGER, "
-            "subject_id INTEGER, sort INTEGER, type INTEGER)"
-        )
-        rows = [
-            (13, "EP1", "", "", "2025-01-01", 0, 0, 517106, 13, 0),
-            (14, "EP2", "", "", "2025-01-08", 0, 0, 517106, 14, 0),
-            (15, "EP3", "", "", "2025-01-15", 0, 0, 517106, 15, 0),
-            (16, "EP4", "", "", "2025-01-22", 0, 0, 517106, 16, 0),
-            (17, "EP5", "", "", "2025-01-29", 0, 0, 517106, 17, 0),
-            (18, "EP6", "", "", "2025-02-05", 0, 0, 517106, 18, 0),
-            (19, "EP7", "", "", "2025-02-12", 0, 0, 517106, 19, 0),
-            (20, "EP8", "", "", "2025-02-19", 0, 0, 517106, 20, 0),
-            (21, "EP9", "", "", "2025-02-26", 0, 0, 517106, 21, 0),
-            (22, "EP10", "", "", "2025-03-05", 0, 0, 517106, 22, 0),
-            (23, "EP11", "", "", "2025-03-12", 0, 0, 517106, 23, 0),
-            (24, "EP12", "", "", "2025-03-19", 0, 0, 517106, 24, 0),
-            (25, "SP", "", "", "2025-03-26", 0, 0, 517106, 25, 3),
-        ]
-        conn.executemany(
-            "INSERT INTO episode (id,name,name_cn,description,airdate,disc,"
-            "duration,subject_id,sort,type) VALUES (?,?,?,?,?,?,?,?,?,?)",
-            rows,
-        )
-        conn.commit()
-        conn.close()
+        yield from _archive_store(tmp_path, _SEASON2_ROWS, "ep_synth.db")
 
-        from app.utils.bangumi_archive import _archive
-
-        orig_db_a = _archive.bangumi_archive.db_a_path
-        orig_active = _archive.bangumi_archive._meta.active
-        _archive.bangumi_archive.db_a_path = db_path
-        _archive.bangumi_archive._meta.active = "a"
-
-        store = ArchiveStore()
-        yield store
-
-        store.close()
-        _archive.bangumi_archive.db_a_path = orig_db_a
-        _archive.bangumi_archive._meta.active = orig_active
+    @pytest.fixture
+    def store_with_null_sort(self, tmp_path: Path) -> ArchiveStore:
+        yield from _archive_store(tmp_path, _NULL_SORT_ROWS, "null_sort.db")
 
     def test_ep_field_synthesized_in_sort_order(self, store_with_episodes):
         """type=0 常规话按 sort 升序补全 1-based 季内 ep（13..24 → 1..12）"""
@@ -1007,3 +1028,9 @@ class TestArchiveEpisodeEpField:
         assert len(eps) == 12
         assert all(e.get("ep") for e in eps)
         assert [e["ep"] for e in eps] == list(range(1, 13))
+
+    def test_ep_field_synthesized_when_sort_is_null(self, store_with_null_sort):
+        """sort 为 NULL 的章节不得使补全抛异常，常规话照常补全 ep"""
+        eps = store_with_null_sort.get_episodes(900001)
+        assert len(eps) == 3
+        assert [e["ep"] for e in eps] == [1, 2, 3]


### PR DESCRIPTION
<!-- 请务必在创建 PR 前，在右侧 Labels 选项中加上 label：`[bug]` -->

## 📝 PR 描述

@musnow 佬有时间可以审一下方法对不对，好像仅仅是因为 Archive 缺少 ep 字段

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容
修复开启 Bangumi Archive 后，跨季作品按季内话数定位章节失败、进而误命中错误季的问题（如擅长逃跑的殿下 第二期 `S02E06` 被匹配到第一季）。

Archive 的 `episode` 表按**全局连续 `sort`** 存储，不提供在线 API 中的**季内集编号 `ep`**——两者语义不同：`ep` 是季内从 1 开始的话数，`sort` 是整部作品连续递增的序号，且第二季不会重置为 1。而下游匹配层（`episodes.py`）以 `ep` 作为季内话数，因此开启 Archive 后，对第二期这类 `sort` 全局连续（13..24）的条目，按季内话数匹配无从定位季边界。

修复：在 Archive 数据边界处补全该字段——`ArchiveStore.get_episodes` 返回结果前调用新增的 `_synthesize_ep_field`，取 `type=0` 的常规话按 `sort` 升序给出 1-based 季内位置写入 `ep`，使 Archive 与在线 API 的 episode schema 保持一致。下游匹配层零改动。

### 相关 Issue
Closes #237

## 📋 提交前检查清单

### 规范与静态检查
- [x] 全仓 `ruff check .` 通过
- [x] 全仓 `ruff format --check .` 通过（375 files already formatted）
- [x] 未改动 Jinja 模板，无需执行 `djlint`

### 测试
- [x] 新增 `TestArchiveEpisodeEpField`（`ArchiveStore.get_episodes` 的补全行为，9 例：覆盖 ep 补全、sort 为 NULL、sort 每季重置、空表、仅含非 `type=0` 条目、单集条目等场景）
- [x] `tests/utils/test_bangumi_api.py` 既有 `TestGetTargetSeasonEpisodeId` 内新增 3 例端到端回归用例（含 sort 重置季边界检测），走真实 `try_get_episodes` → `get_episodes` 路径，不 mock 定位逻辑
- [x] `pytest tests/` → 3498 passed, 1 failed
  - 唯一失败 `tests/api/test_config.py::test_safe_backup_path_rejects_symlink_escape` 为**本机环境既存失败**：`OSError: [WinError 1314] 客户端没有所需的特权`（Windows 创建符号链接需管理员或开发者模式）。已在未打补丁的 `main`（`62fe207`）上复现，与本分支无关。


## 🔍 额外说明

### 根因：Archive 缺少季内集编号字段，`ep` 被当成 `sort` 使用

本仓库 `ArchiveStore.get_episodes` 的 SELECT 列即为 `id, name, name_cn, description, airdate, disc, duration, subject_id, sort, type`，**不含 `ep`**；上游 [bangumi/Archive](https://github.com/bangumi/Archive) 的 `episode` 表同样不提供该字段（此前已核对，非字段名不同）。

Issue 中的日志直接暴露了两处失效：

```
[DEBUG] 直接尝试从指定季度ID匹配集数: 517106, 目标季度: 2, 目标集数: 6
[DEBUG] archive 命中但未找到 sort=6 subject_id=517106，降级 API
[DEBUG] 连续编号: 检测到 1 季，无法定位第 2 季 (subject_id=517106, use_ep_field=False)
[DEBUG] archive 短路命中 sort=6 subject_id=424573
[DEBUG] 通过 archive 续集链找到目标集: subject_id=424573, sort=6, ep_id=1353814
```

1. 季内话数 `6` 被直接当作全局 `sort` 查询，而第二期 `sort` 从 `13` 起，自然查不到，于是降级；
2. `use_ep_field=False` 是关键——季边界检测依赖 `ep` 从 1 重置来判定新季，Archive 无 `ep` 字段时该判定不可用，只检测到 1 季、无法定位第 2 季，最终回退到全局 `sort` 沿续集链匹配，命中第一季 `424573` 的 `sort=6`（`ep_id=1353814`）。

### 实际案例：擅长逃跑的殿下（逃げ上手の若君）第二期

subject `517106`（第二期）在 Archive 中 `sort` 为全局连续 13..24，季内第 1 话对应 `sort=13`。以该条目作为独立季条目（`is_season_subject_id=True`）时：

| 观测点 | 修复前（`main` `62fe207`） | 修复后 |
|------|------|------|
| `get_target_season_episode_id("517106", 2, 6, is_season_subject_id=True)` | `(None, None)`，匹配失败 | `('517106', 18)`，即季内第 6 话 → `sort=18` |
| `get_target_season_episode_id("517106", 2, 1, is_season_subject_id=True)` | `(None, None)`，匹配失败 | `('517106', 13)`，即季内第 1 话 → `sort=13` |
| `try_get_episodes(517106)` 首行 | `{'id': 13, 'sort': 13, 'type': 0}`，无 `ep` 键 | `{'id': 13, 'sort': 13, 'type': 0, 'ep': 1}` |

上表前后两列均在纯净 `main`（`62fe207`）与打补丁后的同一探针脚本下实测取得，非推断。

其中季内第 6 话 → `sort=18` 的映射由回归用例断言；落到真实 Archive 数据时该话即 Issue 期望的 `ep_id=1716840`（测试 fixture 为最小合成库，其 `id` 列取 `sort` 值，故断言为 `18` 而非真实 ep id）。

### 设计要点（非临时补丁）

- **补全位置在数据边界**：`ep` 的合成只发生在 `ArchiveStore.get_episodes`（Archive 数据出口）一处，下游 `episodes.py` 匹配逻辑零改动，在线 API 路径完全不受影响。这是选择数据层归一化而非匹配层回退的原因——缺字段是数据源差异，适配它属于数据源自身的职责。
- **仅常规话参与季内编号**：只取 `type=0` 的常规话按 `sort` 升序编号；非 `type=0` 的 SP/OP/ED 等条目不写入 `ep`，它们不属于季内连续话数。
- **`episode_type` 过滤下行为一致**：`get_episodes` 带 `episode_type` 参数时 SQL 已在数据库侧过滤，补全逻辑对过滤后的结果集按 `sort` 升序编号，季内位置保持不变（由 `test_ep_field_with_type_filter` 覆盖）。
- **无新增依赖、无死代码**：新增方法为 `@staticmethod`，仅被 `get_episodes` 调用；未引入新的配置项或外部依赖。












### 修改范围（3 文件）

| 文件 | 改动 |
|------|------|
| `app/utils/bangumi_archive/_store.py` | `get_episodes` 返回前调用新增的 `_synthesize_ep_field`，为 `type=0` 常规话按 `sort` 升序补全 1-based 季内 `ep` |
| `tests/utils/test_bangumi_archive.py` | 新增 `TestArchiveEpisodeEpField`（9 例：按 `sort` 补全、非 `type=0` 不补全、`episode_type` 过滤下仍补全、sort 为 NULL、sort 每季重置、空表、仅含非 `type=0`、单集条目） |
| `tests/utils/test_bangumi_api.py` | 既有 `TestGetTargetSeasonEpisodeId` 内新增 3 例端到端回归用例（含 sort 重置季边界检测），附 Archive 库 fixture 与启用/还原辅助方法 |


