### PR TITLE
feat: summary memory

### DIFF
--- a/app/core/database/__init__.py
+++ b/app/core/database/__init__.py
@@ -479,6 +479,7 @@ class DatabaseManager:
         limit: int = 200,
         user_name: Optional[str] = None,
         source: Optional[str] = None,
+        include_consumed: bool = False,
     ) -> list[dict[str, Any]]:
         """获取指定日期范围内的同步记录"""
         return self._sync.get_records_in_date_range(
@@ -487,6 +488,7 @@ class DatabaseManager:
             limit=limit,
             user_name=user_name,
             source=source,
+            include_consumed=include_consumed,
         )
 
     def cleanup_old_records(self, retention_days: int) -> int:

--- a/app/core/database/__init__.py
+++ b/app/core/database/__init__.py
@@ -19,6 +19,7 @@ from typing import Any, Optional
 
 from ..logging import logger as logger
 from .accounts import BangumiAccountRepository, OAuthStateRepository
+from .agent_memory import AgentMemoryRepository
 from .connection import (
     FEINIU_MIN_UPDATE_WATERMARK_META_KEY as FEINIU_MIN_UPDATE_WATERMARK_META_KEY,
     INBOX_ERROR_BACKFILL_META_KEY as INBOX_ERROR_BACKFILL_META_KEY,
@@ -57,8 +58,11 @@ class DatabaseManager:
         self._bangumi_accounts = BangumiAccountRepository(self._connection)
         self._oauth_state = OAuthStateRepository(self._connection)
         self.llm_usage = LLMUsageRepository(self._connection)
+        self.memory = AgentMemoryRepository(self._connection)
         self._pending = PendingCandidatesRepository(self._connection)
         self._pending_sync = PendingSyncQueueRepository(self._connection)
+        # 公开别名（消费标记写/清归 memory 域，业务层经此只读访问同步记录）
+        self.sync_records = self._sync
         # 原 ``_init_database`` 末尾的 backfill 调用移到此处：
         # 需要先创建 inbox_repository（及其 feiniu 依赖）才能执行回填
         self._inbox.backfill_historical_error_notifications()

--- a/app/core/database/agent_memory.py
+++ b/app/core/database/agent_memory.py
@@ -6,7 +6,7 @@ prune 降级到归档表（冷记忆，search_archive 用 LIKE 检索）。
 
 from __future__ import annotations
 
-from app.services.memory.models import MemoryEntry
+from app.models.memory import MemoryEntry
 
 from .base_repository import BaseRepository
 

--- a/app/core/database/agent_memory.py
+++ b/app/core/database/agent_memory.py
@@ -1,0 +1,352 @@
+"""Agent 工作记忆仓库（定时任务执行摘要）。
+
+主表（带 FTS）= 热记忆：写入（store_and_mark）、检索（get_recent/search_fts）、
+prune 降级到归档表（冷记忆，search_archive 用 LIKE 检索）。
+"""
+
+from __future__ import annotations
+
+from app.services.memory.models import MemoryEntry
+
+from .base_repository import BaseRepository
+
+_MAIN_COLS = "id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at"
+
+
+class AgentMemoryRepository(BaseRepository):
+    """记忆仓库：store_and_mark / prune / get_recent / search_fts / search_archive。"""
+
+    # ------------------------------------------------------------------
+    # 写入
+    # ------------------------------------------------------------------
+
+    def store_and_mark(self, entry: MemoryEntry, record_ids: list[int]) -> int:
+        """同一事务：INSERT 记忆（entry）+ 关联表写入消费标记
+        （sync_records_consumed：每条记录一行 (sync_record_id, run_id)）。
+
+        run 的原子单元——"记忆记录 + 记录消费"要么全成功要么全回滚，
+        消除"记忆已写但标记未写"的中间态。消费标记是记忆域数据，故在同一
+        事务内直连关联表执行。多对多：一条记录可被多个任务的 run 消费，
+        互不覆盖（INSERT OR IGNORE 幂等，同 run 不重复记）。
+        """
+
+        def _write(conn):
+            cur = conn.execute(
+                """
+                INSERT INTO agent_working_memory
+                (task_type, task_id, run_id, summary, full_text, outcome, tokens_used)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.task_type,
+                    entry.task_id,
+                    entry.run_id,
+                    entry.summary,
+                    entry.full_text,
+                    entry.outcome,
+                    entry.tokens_used,
+                ),
+            )
+            n1 = cur.rowcount
+            n2 = 0
+            if record_ids:
+                # 多对多：INSERT OR IGNORE——记录已存在 (record, run) 时不重复
+                cur = conn.executemany(
+                    "INSERT OR IGNORE INTO sync_records_consumed "
+                    "(sync_record_id, run_id) VALUES (?, ?)",
+                    [(rid, entry.run_id) for rid in record_ids],
+                )
+                n2 = cur.rowcount
+            return n1 + n2
+
+        return self._run_write(_write, error_msg="写入任务记忆失败", reraise=True)
+
+    def prune(self, task_type: str, task_id: str, keep: int = 1000) -> int:
+        """独立 best-effort 事务：超出 keep 的旧记录先 INSERT INTO archive，
+        再 DELETE 主表（触发器同步删 FTS 索引）。默认 1000 条/任务。
+
+        与 store_and_mark 不同事务：prune 是维护性操作，失败只导致表不清理
+        （下次 run 重试），不应回滚一次已成功且已消耗 LLM token 的总结 run。
+        """
+
+        def _write(conn):
+            cursor = conn.execute(
+                """
+                SELECT id FROM agent_working_memory
+                WHERE task_type = ? AND task_id = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT -1 OFFSET ?
+                """,
+                (task_type, task_id, keep),
+            )
+            old_ids = [row[0] for row in cursor.fetchall()]
+            if not old_ids:
+                return 0
+            placeholders = ",".join("?" * len(old_ids))
+            params = [task_type, task_id, *old_ids]
+            cur = conn.execute(
+                f"""
+                INSERT INTO agent_working_memory_archive
+                (task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at)
+                SELECT task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at
+                FROM agent_working_memory
+                WHERE task_type = ? AND task_id = ? AND id IN ({placeholders})
+                """,
+                params,
+            )
+            n_archived = cur.rowcount
+            cur = conn.execute(
+                f"""
+                DELETE FROM agent_working_memory
+                WHERE task_type = ? AND task_id = ? AND id IN ({placeholders})
+                """,
+                params,
+            )
+            return n_archived + cur.rowcount
+
+        return self._run_write(_write, error_msg="清理任务记忆失败", default=0)
+
+    # ------------------------------------------------------------------
+    # 清理与重置（Phase 2.0.3）
+    # ------------------------------------------------------------------
+
+    def rename_task(self, task_type: str, old_task_id: str, new_task_id: str) -> int:
+        """改名迁移：同一事务 UPDATE 主表 + 归档表的 task_id（记忆跟随任务）。
+
+        消费标记无需迁移（关联表只关联 sync_record_id + run_id，不依赖 task_id）。
+        """
+
+        def _write(conn):
+            n1 = conn.execute(
+                "UPDATE agent_working_memory SET task_id = ? "
+                "WHERE task_type = ? AND task_id = ?",
+                (new_task_id, task_type, old_task_id),
+            ).rowcount
+            n2 = conn.execute(
+                "UPDATE agent_working_memory_archive SET task_id = ? "
+                "WHERE task_type = ? AND task_id = ?",
+                (new_task_id, task_type, old_task_id),
+            ).rowcount
+            return n1 + n2
+
+        return self._run_write(_write, error_msg="迁移任务记忆失败", default=0)
+
+    def clear_task(self, task_type: str, task_id: str) -> int:
+        """同一事务清空该 task 的记忆 + 消费标记。
+
+        顺序敏感：① 先收集 run_id（主表 + 归档表 UNION）——必须在删表前取，
+        否则 run_id→task_id 映射丢失；② 删主表；③ 删归档表；
+        ④ 清关联表中 run_id ∈ 本任务 run_ids 的消费标记（DELETE 关联表行，
+        天然只影响本任务——其他任务消费同一记录的标记保留，跨任务隔离）。
+        不筛 outcome，全部删除（想保留偏好重新开始的场景用"复制新 job"）。
+        """
+
+        def _write(conn):
+            main_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT run_id FROM agent_working_memory "
+                    "WHERE task_type = ? AND task_id = ?",
+                    (task_type, task_id),
+                )
+            ]
+            arch_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT run_id FROM agent_working_memory_archive "
+                    "WHERE task_type = ? AND task_id = ?",
+                    (task_type, task_id),
+                )
+            ]
+            run_ids = set(main_ids) | set(arch_ids)
+
+            n1 = conn.execute(
+                "DELETE FROM agent_working_memory WHERE task_type = ? AND task_id = ?",
+                (task_type, task_id),
+            ).rowcount
+            n2 = conn.execute(
+                "DELETE FROM agent_working_memory_archive "
+                "WHERE task_type = ? AND task_id = ?",
+                (task_type, task_id),
+            ).rowcount
+
+            n3 = 0
+            if run_ids:
+                placeholders = ",".join("?" * len(run_ids))
+                n3 = conn.execute(
+                    "DELETE FROM sync_records_consumed "
+                    f"WHERE run_id IN ({placeholders})",
+                    tuple(run_ids),
+                ).rowcount
+            return n1 + n2 + n3
+
+        return self._run_write(_write, error_msg="清空任务记忆失败", default=0)
+
+    # ------------------------------------------------------------------
+    # 读取
+    # ------------------------------------------------------------------
+
+    def get_recent(
+        self, task_type: str, task_id: str, limit: int = 5
+    ) -> list[MemoryEntry]:
+        """按 task 取最近 N 条记忆（created_at DESC, id DESC 保证同秒内稳定排序）。"""
+
+        def _read(conn):
+            cursor = conn.execute(
+                f"""
+                SELECT {_MAIN_COLS} FROM agent_working_memory
+                WHERE task_type = ? AND task_id = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (task_type, task_id, limit),
+            )
+            return [MemoryEntry.from_row(row) for row in cursor.fetchall()]
+
+        return self._run_read(_read, error_msg="获取最近任务记忆失败", default=[])
+
+    def get_task_run_ids(self, task_type: str, task_id: str) -> set[str]:
+        """按任务取本任务全部 run_id 集合（主表 + 归档 UNION）。
+
+        供消费排除按任务隔离：判断记录在关联表中的 consumed_run_ids 是否属于
+        「当前任务」——有交集则剔除（同任务去重），无交集则保留（跨任务互斥解除，
+        如每日总结消费后年度总结仍可消费）。prune 下沉归档后 run_id 仍归属
+        本任务（消费标记不随归档失效），故必须 UNION 归档表。
+        """
+
+        def _read(conn):
+            rows = conn.execute(
+                """
+                SELECT run_id FROM agent_working_memory
+                WHERE task_type = ? AND task_id = ?
+                UNION
+                SELECT run_id FROM agent_working_memory_archive
+                WHERE task_type = ? AND task_id = ?
+                """,
+                (task_type, task_id, task_type, task_id),
+            ).fetchall()
+            return {row[0] for row in rows}
+
+        return self._run_read(
+            _read, error_msg="获取任务 run_id 集合失败", default=set()
+        )
+
+    def get_related_titles(
+        self,
+        task_type: str,
+        task_id: str,
+        titles: list[str],
+        limit: int = 5,
+    ) -> list[MemoryEntry]:
+        """同剧关联：按今日记录的剧名反查历史总结（日期倒序最近 N 条）。
+
+        机制：sync_records_consumed 关联表是"该记录被哪次总结消费过"的显式
+        关联——以今日 bgm_title 集合为键，经关联表 JOIN 主表 + 归档表 UNION，
+        即"同类剧目的历史总结"（含已归档冷层）。比 FTS 子串猜测更精确，
+        且自然覆盖冷层（消费标记不随 prune 清理）。
+
+        边界：titles 为空/全空 → 短路返回 []；同剧多集被同一次总结消费 →
+        GROUP BY m.id 去重；主表/归档表同 run_id 不可能共存（run_id UNIQUE，
+        prune 搬家）→ UNION 天然去重；排序 = get_recent 同款稳定序；
+        性能：bgm_title 暂无索引，全表扫 JOIN（10 万行内毫秒级），
+        超量预案见 closeout §3 性能注记。
+        """
+        clean = [t for t in titles if t and t.strip()]
+        if not clean:
+            return []
+        placeholders = ",".join("?" * len(clean))
+
+        def _read(conn):
+            cursor = conn.execute(
+                f"""
+                SELECT m.id, m.task_type, m.task_id, m.run_id, m.summary,
+                       m.full_text, m.outcome, m.tokens_used, m.created_at
+                FROM agent_working_memory m
+                JOIN sync_records_consumed c ON c.run_id = m.run_id
+                JOIN sync_records s ON s.id = c.sync_record_id
+                WHERE s.bgm_title IN ({placeholders})
+                  AND m.task_type = ? AND m.task_id = ?
+                GROUP BY m.id
+                UNION
+                SELECT m.id, m.task_type, m.task_id, m.run_id, m.summary,
+                       m.full_text, m.outcome, m.tokens_used, m.created_at
+                FROM agent_working_memory_archive m
+                JOIN sync_records_consumed c ON c.run_id = m.run_id
+                JOIN sync_records s ON s.id = c.sync_record_id
+                WHERE s.bgm_title IN ({placeholders})
+                  AND m.task_type = ? AND m.task_id = ?
+                GROUP BY m.id
+                -- UNION 结果集列名取自首个 SELECT，排序用序号避免列名歧义
+                ORDER BY 9 DESC, 1 DESC
+                LIMIT ?
+                """,
+                (*clean, task_type, task_id, *clean, task_type, task_id, limit),
+            )
+            return [MemoryEntry.from_row(row) for row in cursor.fetchall()]
+
+        return self._run_read(_read, error_msg="获取同剧关联记忆失败", default=[])
+
+    def search_fts(
+        self, terms: list[str], task_type: str, limit: int = 5
+    ) -> list[MemoryEntry]:
+        """[deprecated] FTS5 全文检索（热记忆），按 task_type 过滤。
+
+        **已停用**：相关回忆由 get_related_titles（联表反查）承担——FTS 搜索的
+        输入（标题词）与联表相同，而联表经关联表（sync_records_consumed）显式关联更精确、
+        且覆盖归档冷层。物理结构（虚表/触发器/索引）保留，供 Phase 5
+        混合检索（FTS5 + 向量，RRF 融合）复用；无业务调用方。
+
+        多关键词 OR 连接（任一命中即相关——关键词是今日明细标题，目的
+        是捞回与任一标题相关的历史记忆）；**每个关键词作为一个整体短语**
+        （保留多词标题如 "Spy x Family" 的完整匹配，不再按空白二次切分）；
+        中文子串匹配依赖 trigram tokenizer（SQLite >= 3.34）；查询词短语
+        引号包裹避免特殊字符破坏 MATCH 语法；短词（<3 字符，trigram
+        无法命中）过滤。
+        """
+
+        def _read(conn):
+            phrases = [
+                '"' + t.strip().replace('"', '""') + '"'
+                for t in terms
+                if len(t.strip()) >= 3
+            ]
+            if not phrases:
+                return []
+            match = " OR ".join(phrases)
+            cursor = conn.execute(
+                """
+                SELECT m.id, m.task_type, m.task_id, m.run_id, m.summary,
+                       m.full_text, m.outcome, m.tokens_used, m.created_at
+                FROM agent_memory_fts f
+                JOIN agent_working_memory m ON m.id = f.rowid
+                WHERE agent_memory_fts MATCH ? AND m.task_type = ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (match, task_type, limit),
+            )
+            return [MemoryEntry.from_row(row) for row in cursor.fetchall()]
+
+        return self._run_read(_read, error_msg="检索任务记忆失败", default=[])
+
+    def search_archive(
+        self, task_type: str | None, keywords: str, limit: int = 50
+    ) -> list[MemoryEntry]:
+        """冷记忆检索（LIKE，无 FTS）——Phase 3 失败定位等查全量历史用。"""
+
+        def _read(conn):
+            like = f"%{keywords}%"
+            type_clause = "AND task_type = ?" if task_type else ""
+            args = [like, like] + ([task_type] if task_type else []) + [limit]
+            cursor = conn.execute(
+                f"""
+                SELECT {_MAIN_COLS} FROM agent_working_memory_archive
+                WHERE (summary LIKE ? OR full_text LIKE ?) {type_clause}
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                args,
+            )
+            return [MemoryEntry.from_row(row) for row in cursor.fetchall()]
+
+        return self._run_read(_read, error_msg="检索归档记忆失败", default=[])

--- a/app/core/database/connection.py
+++ b/app/core/database/connection.py
@@ -42,12 +42,6 @@ class DatabaseConnection:
 
         self._lock = threading.Lock()
         self._conn: Optional[sqlite3.Connection] = None
-        self._media_type_migrated = False
-        self._bgm_title_migrated = False
-        self._trakt_filter_migrated = False
-        self._match_fields_migrated = False
-        self._pending_sync_sync_record_id_migrated = False
-        self._pending_candidates_sync_record_id_migrated = False
         self._agent_memory_migrated = False
         # 已确认存在（或已补上）的列集合，避免每次读写前的 ensure_schema
         # 回调重复执行 PRAGMA table_info

--- a/app/core/database/connection.py
+++ b/app/core/database/connection.py
@@ -42,6 +42,13 @@ class DatabaseConnection:
 
         self._lock = threading.Lock()
         self._conn: Optional[sqlite3.Connection] = None
+        self._media_type_migrated = False
+        self._bgm_title_migrated = False
+        self._trakt_filter_migrated = False
+        self._match_fields_migrated = False
+        self._pending_sync_sync_record_id_migrated = False
+        self._pending_candidates_sync_record_id_migrated = False
+        self._agent_memory_migrated = False
         # 已确认存在（或已补上）的列集合，避免每次读写前的 ensure_schema
         # 回调重复执行 PRAGMA table_info
         self._migrated_columns: set[tuple[str, str]] = set()
@@ -318,6 +325,118 @@ class DatabaseConnection:
         except Exception as e:
             logger.warning(f"token 加密迁移失败（将在下次启动重试）: {e}")
 
+    def _ensure_sync_records_consumed(self, cursor) -> None:
+        """消费标记关联表 schema：多对多（sync_record_id, run_id）。
+
+        一条记录可被多个任务的多个 run 消费，互不覆盖（INSERT OR IGNORE）。
+        开发阶段直接建新表，无旧库迁移；SQL 幂等（IF NOT EXISTS），
+        重复执行安全。
+        """
+        # ① 关联表（多对多消费标记）
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sync_records_consumed (
+                sync_record_id INTEGER NOT NULL,
+                run_id         TEXT NOT NULL,
+                PRIMARY KEY (sync_record_id, run_id)
+            )
+            """
+        )
+        # ② run_id 反查索引（clear_task 按 run_id 删、get_related_titles JOIN）
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sync_records_consumed_run_id "
+            "ON sync_records_consumed(run_id)"
+        )
+
+    def _ensure_agent_memory(self, cursor) -> None:
+        """Agent 工作记忆 schema：主表 + 归档表 + 索引 + FTS5 + 同步触发器。
+
+        FTS5 是 external content 表，触发器必须存在（否则 INSERT 后 FTS 不更新）。
+        tokenizer 优先 trigram（中文子串匹配）；老 SQLite（< 3.34）不支持时降级
+        默认 unicode61（整段 CJK 为一个 token，仅精确标题可命中）。
+        """
+        if self._agent_memory_migrated:
+            return
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS agent_working_memory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_type TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                run_id TEXT NOT NULL UNIQUE,
+                summary TEXT NOT NULL,
+                full_text TEXT,
+                outcome TEXT NOT NULL,
+                tokens_used INTEGER,
+                created_at TEXT DEFAULT (datetime('now'))
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS agent_working_memory_archive (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_type TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                run_id TEXT NOT NULL UNIQUE,
+                summary TEXT NOT NULL,
+                full_text TEXT,
+                outcome TEXT NOT NULL,
+                tokens_used INTEGER,
+                created_at TEXT,
+                archived_at TEXT DEFAULT (datetime('now'))
+            )
+        """)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memory_task "
+            "ON agent_working_memory(task_type, task_id)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memory_created "
+            "ON agent_working_memory(created_at)"
+        )
+        try:
+            cursor.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS agent_memory_fts USING fts5("
+                "task_type, summary, outcome, "
+                "content='agent_working_memory', content_rowid='id', "
+                "tokenize='trigram')"
+            )
+        except sqlite3.OperationalError:
+            # SQLite < 3.34：trigram 不可用，降级默认分词器（中文子串匹配失效，
+            # search_fts 关键词检索能力受限）——显式告警便于排查检索质量问题
+            logger.warning(
+                "当前 SQLite %s 不支持 trigram 分词器，agent_memory_fts 已降级为"
+                "默认分词器：中文关键词检索能力受限（建议 SQLite >= 3.34）",
+                sqlite3.sqlite_version,
+            )
+            cursor.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS agent_memory_fts USING fts5("
+                "task_type, summary, outcome, "
+                "content='agent_working_memory', content_rowid='id')"
+            )
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS agent_memory_ai
+            AFTER INSERT ON agent_working_memory BEGIN
+                INSERT INTO agent_memory_fts(rowid, task_type, summary, outcome)
+                VALUES (new.id, new.task_type, new.summary, new.outcome);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS agent_memory_ad
+            AFTER DELETE ON agent_working_memory BEGIN
+                INSERT INTO agent_memory_fts(agent_memory_fts, rowid, task_type, summary, outcome)
+                VALUES ('delete', old.id, old.task_type, old.summary, old.outcome);
+            END
+        """)
+        cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS agent_memory_au
+            AFTER UPDATE ON agent_working_memory BEGIN
+                INSERT INTO agent_memory_fts(agent_memory_fts, rowid, task_type, summary, outcome)
+                VALUES ('delete', old.id, old.task_type, old.summary, old.outcome);
+                INSERT INTO agent_memory_fts(rowid, task_type, summary, outcome)
+                VALUES (new.id, new.task_type, new.summary, new.outcome);
+            END
+        """)
+        self._agent_memory_migrated = True
+
     def _init_database(self) -> None:
         """初始化数据库"""
         conn = self._get_connection()
@@ -352,6 +471,7 @@ class DatabaseConnection:
         self._ensure_sync_records_media_type(cursor)
         self._ensure_sync_records_bgm_title(cursor)
         self._ensure_sync_records_match_fields(cursor)
+        self._ensure_sync_records_consumed(cursor)
         self._ensure_sync_records_link_fields(cursor)
 
         # 创建 Trakt 配置表
@@ -538,6 +658,8 @@ class DatabaseConnection:
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_sync_records_status ON sync_records(status)"
         )
+        # 消费标记关联表索引已在 _ensure_sync_records_consumed 创建
+        # （idx_sync_records_consumed_run_id → sync_records_consumed(run_id)）
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_trakt_sync_history_user_id ON trakt_sync_history(user_id)"
         )
@@ -573,6 +695,9 @@ class DatabaseConnection:
             "CREATE INDEX IF NOT EXISTS idx_pending_candidates_sync_record_id "
             "ON pending_candidates(sync_record_id)"
         )
+
+        # Agent 工作记忆（热表 + 归档冷表 + FTS5 + 同步触发器）
+        self._ensure_agent_memory(cursor)
 
         # 一次性数据迁移：加密历史明文 token（仓储层已改为写入即加密）
         self._ensure_tokens_encrypted(cursor)

--- a/app/core/database/sync_records.py
+++ b/app/core/database/sync_records.py
@@ -548,12 +548,16 @@ class SyncRecordsRepository(BaseRepository):
             where = " WHERE " + " AND ".join(conditions)
             limit_clause = "LIMIT ?" if limit > 0 else ""
             query = f"""
-                SELECT id, timestamp, user_name, title, ori_title, season, episode,
-                       subject_id, episode_id, status, message, source, media_type, bgm_title,
-                       run_id, batch_id
-                FROM sync_records
+                SELECT s.id, s.timestamp, s.user_name, s.title, s.ori_title,
+                       s.season, s.episode, s.subject_id, s.episode_id, s.status,
+                       s.message, s.source, s.media_type, s.bgm_title,
+                       s.run_id, s.batch_id,
+                       GROUP_CONCAT(c.run_id) AS consumed_run_ids
+                FROM sync_records s
+                LEFT JOIN sync_records_consumed c ON c.sync_record_id = s.id
                 {where}
-                ORDER BY timestamp DESC
+                GROUP BY s.id
+                ORDER BY s.timestamp DESC
                 {limit_clause}
             """
             if limit > 0:
@@ -577,6 +581,10 @@ class SyncRecordsRepository(BaseRepository):
                     "bgm_title": row[13] or "",
                     "run_id": row[14] or "",
                     "batch_id": row[15] or "",
+                    # 消费标记多对多（关联表）：逗号分隔 → 去空集合
+                    "consumed_run_ids": (
+                        {x for x in row[16].split(",") if x} if row[16] else set()
+                    ),
                 }
                 for row in cursor.fetchall()
             ]
@@ -619,7 +627,10 @@ class SyncRecordsRepository(BaseRepository):
         """清理超过保留天数的同步记录，返回删除行数。
 
         retention_days <= 0 时不清理（永不清理语义）。
+        关联表 sync_records_consumed 中指向被删记录的孤儿行一并清理
+        （避免表体积膨胀；消费标记随记录删除而失去意义）。
         """
+
         if retention_days <= 0:
             return 0
 
@@ -628,7 +639,13 @@ class SyncRecordsRepository(BaseRepository):
                 "DELETE FROM sync_records WHERE timestamp < datetime('now', ?)",
                 (f"-{retention_days} days",),
             )
-            return cursor.rowcount
+            n1 = cursor.rowcount
+            # 级联清理关联表孤儿行（被删 sync_records 的消费标记）
+            n2 = conn.execute(
+                "DELETE FROM sync_records_consumed "
+                "WHERE sync_record_id NOT IN (SELECT id FROM sync_records)"
+            ).rowcount
+            return n1 + n2
 
         try:
             deleted = self._run_write(_write, error_msg="清理旧同步记录失败")

--- a/app/core/database/sync_records.py
+++ b/app/core/database/sync_records.py
@@ -518,6 +518,7 @@ class SyncRecordsRepository(BaseRepository):
         limit: int = 200,
         user_name: Optional[str] = None,
         source: Optional[str] = None,
+        include_consumed: bool = False,
     ) -> list[dict[str, Any]]:
         """获取指定日期范围内的同步记录。
 
@@ -528,6 +529,9 @@ class SyncRecordsRepository(BaseRepository):
             limit:     最大返回条数，默认 200。
             user_name: 可选，按用户名过滤。
             source:    可选，按来源过滤。
+            include_consumed: 默认 ``False``（轻量查询——无 LEFT JOIN / GROUP BY，
+                ``consumed_run_ids`` 直接返回空集合）；``True`` 时 JOIN 关联表并
+                GROUP_CONCAT 聚合消费标记（记忆开启时消费排除所需）。
 
         Returns:
             按 ``timestamp DESC`` 排序的记录列表，每条为包含全部列的 dict。
@@ -547,19 +551,32 @@ class SyncRecordsRepository(BaseRepository):
 
             where = " WHERE " + " AND ".join(conditions)
             limit_clause = "LIMIT ?" if limit > 0 else ""
-            query = f"""
-                SELECT s.id, s.timestamp, s.user_name, s.title, s.ori_title,
-                       s.season, s.episode, s.subject_id, s.episode_id, s.status,
-                       s.message, s.source, s.media_type, s.bgm_title,
-                       s.run_id, s.batch_id,
-                       GROUP_CONCAT(c.run_id) AS consumed_run_ids
-                FROM sync_records s
-                LEFT JOIN sync_records_consumed c ON c.sync_record_id = s.id
-                {where}
-                GROUP BY s.id
-                ORDER BY s.timestamp DESC
-                {limit_clause}
-            """
+
+            if include_consumed:
+                query = f"""
+                    SELECT s.id, s.timestamp, s.user_name, s.title, s.ori_title,
+                           s.season, s.episode, s.subject_id, s.episode_id, s.status,
+                           s.message, s.source, s.media_type, s.bgm_title,
+                           s.run_id, s.batch_id,
+                           GROUP_CONCAT(c.run_id) AS consumed_run_ids
+                    FROM sync_records s
+                    LEFT JOIN sync_records_consumed c ON c.sync_record_id = s.id
+                    {where}
+                    GROUP BY s.id
+                    ORDER BY s.timestamp DESC
+                    {limit_clause}
+                """
+            else:
+                query = f"""
+                    SELECT id, timestamp, user_name, title, ori_title,
+                           season, episode, subject_id, episode_id, status,
+                           message, source, media_type, bgm_title,
+                           run_id, batch_id
+                    FROM sync_records
+                    {where}
+                    ORDER BY timestamp DESC
+                    {limit_clause}
+                """
             if limit > 0:
                 params.append(limit)
             cursor.execute(query, params)
@@ -581,9 +598,12 @@ class SyncRecordsRepository(BaseRepository):
                     "bgm_title": row[13] or "",
                     "run_id": row[14] or "",
                     "batch_id": row[15] or "",
-                    # 消费标记多对多（关联表）：逗号分隔 → 去空集合
+                    # 消费标记多对多（关联表）：include_consumed 时逗号分隔 → 去空集合；
+                    # 轻量路径该列不存在，直接给空集合（保持返回 dict 结构不变）。
                     "consumed_run_ids": (
-                        {x for x in row[16].split(",") if x} if row[16] else set()
+                        {x for x in row[16].split(",") if x}
+                        if include_consumed and row[16]
+                        else set()
                     ),
                 }
                 for row in cursor.fetchall()

--- a/app/models/memory.py
+++ b/app/models/memory.py
@@ -1,0 +1,37 @@
+"""记忆数据模型（共享层）。
+
+从 ``app/services/memory/models`` 迁出，供 core/database 与 services 共同引用，
+消除 core → services 的倒置依赖。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MemoryEntry:
+    id: int | None = None
+    task_type: str = ""
+    task_id: str = ""
+    run_id: str = ""
+    summary: str = ""  # 一行摘要（注入粒度）
+    full_text: str = ""  # 本次总结全文（回溯/诊断用，随 prune/归档同生命周期）
+    outcome: str = "success"  # 取值：success | partial（用户反馈类取值由 phase3.x 反馈通道引入，见 specs/agent-phase3-summary-enhanced.md）
+    tokens_used: int = 0  # 总结调用的 token（response.usage.total_tokens）
+    created_at: str = ""
+
+    @classmethod
+    def from_row(cls, row) -> MemoryEntry:
+        """从 DB row 构造（列序：id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at）。"""
+        return cls(
+            id=row[0],
+            task_type=row[1],
+            task_id=row[2],
+            run_id=row[3],
+            summary=row[4],
+            full_text=row[5],
+            outcome=row[6],
+            tokens_used=row[7] or 0,
+            created_at=row[8],
+        )

--- a/app/services/memory/__init__.py
+++ b/app/services/memory/__init__.py
@@ -1,0 +1,1 @@
+"""记忆模块：定时任务执行摘要的写入（extractor）、读取（retriever）与清理（service）。"""

--- a/app/services/memory/extractor.py
+++ b/app/services/memory/extractor.py
@@ -1,0 +1,84 @@
+"""记忆提取器：总结执行成功后提炼一行摘要并写入记忆（含消费标记）。"""
+
+from __future__ import annotations
+
+from app.core.database.agent_memory import AgentMemoryRepository
+from app.core.logging import logger
+from app.services.llm import Message, get_llm_client
+from app.services.llm.models import ChatResponse
+
+from .models import MemoryEntry
+
+_SUMMARY_PROMPT = (
+    "请用一句话总结以下追番总结的内容（50–100 字为宜，根据内容量自然把握），"
+    "保留关键信息：看了哪些番剧、进度、异常情况。只输出摘要本身。"
+)
+
+
+class MemoryExtractor:
+    def __init__(self, repo: AgentMemoryRepository, llm_client=None):
+        self._repo = repo
+        # 测试可注入；None 时 _summarize 内现取全局单例（LLM 配置保存会
+        # reset_llm_client()，缓存实例会滞留旧 api_base/key）
+        self._llm = llm_client
+
+    async def extract_and_store(
+        self,
+        task_type: str,
+        task_id: str,
+        run_id: str,
+        messages: list[Message],  # 总结调用的完整对话上下文（缓存前缀 + 摘要来源）
+        response: ChatResponse,  # 总结响应（含全文 content）
+        outcome: str,
+        tokens_used: int,
+        record_ids: list[int],  # 今日明细记录 id（store_and_mark 标记消费用）
+        job_name: str | None = None,  # 摘要调用用量归属 llm_usage 用
+    ) -> None:
+        summary = await self._summarize(messages, response, job_name=job_name)
+        if not summary:
+            return  # 空响应（LLM 重试耗尽）不写记忆，避免无效条目
+        # 原子单元：INSERT 记忆 + 标记消费（同一事务，见 store_and_mark）
+        self._repo.store_and_mark(
+            MemoryEntry(
+                task_type=task_type,
+                task_id=task_id,
+                run_id=run_id,
+                summary=summary,
+                full_text=response.content,  # 全文存 full_text（回溯用，不注入）
+                outcome=outcome,
+                tokens_used=tokens_used,
+            ),
+            record_ids=record_ids,
+        )
+        # 清理旧记忆（独立 best-effort 事务，失败不回滚上面的 run）
+        # L4：魔数收编——保留上限与 prune 上限同源（closeout §4 E3）
+        self._repo.prune(task_type, task_id, keep=1000)
+
+    async def _summarize(
+        self,
+        messages: list[Message],
+        response: ChatResponse,
+        job_name: str | None = None,
+    ) -> str:
+        """一行摘要：复用总结调用的完整对话上下文作前缀，命中 LLM prompt 缓存。
+
+        缓存利用：摘要调用紧跟总结调用（同一 execute_job 内，Anthropic 5 分钟
+        TTL / OpenAI 自动前缀缓存）——完整历史作前缀，输入 token 按缓存价格，
+        且无截断信息损失。job_name 使摘要调用 token 在 llm_usage 中归属任务
+        （与主调用同组，用量统计口径完整）。
+        """
+        if not response.content:
+            return ""
+        try:
+            summary_messages = list(messages)
+            summary_messages.append(Message(role="assistant", content=response.content))
+            summary_messages.append(Message(role="user", content=_SUMMARY_PROMPT))
+            llm = self._llm or get_llm_client()
+            resp = await llm.chat(summary_messages, job_name=job_name)
+            if resp.content:
+                return resp.content.strip()
+        except Exception as e:
+            # LLM 摘要失败：跳过不写记忆（与空响应同路径）——不保留截断兜底，
+            # 保证所有入库摘要均为 LLM 完整输出、零截断（见 closeout §4 修订）
+            logger.warning(f"摘要 LLM 调用失败，跳过记忆写入: {e}")
+        return ""

--- a/app/services/memory/extractor.py
+++ b/app/services/memory/extractor.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from app.core.database.agent_memory import AgentMemoryRepository
 from app.core.logging import logger
+from app.models.memory import MemoryEntry
 from app.services.llm import Message, get_llm_client
 from app.services.llm.models import ChatResponse
-
-from .models import MemoryEntry
 
 _SUMMARY_PROMPT = (
     "请用一句话总结以下追番总结的内容（50–100 字为宜，根据内容量自然把握），"

--- a/app/services/memory/models.py
+++ b/app/services/memory/models.py
@@ -1,33 +1,9 @@
-"""记忆数据模型。"""
+"""记忆数据模型（re-export）。
 
-from __future__ import annotations
+共享定义已迁移至 :mod:`app.models.memory`（供 core/database 与 services 共同引用，
+消除 core → services 的倒置依赖）。本模块保留 re-export 以兼容现有 import。
+"""
 
-from dataclasses import dataclass
+from app.models.memory import MemoryEntry  # noqa: F401
 
-
-@dataclass
-class MemoryEntry:
-    id: int | None = None
-    task_type: str = ""
-    task_id: str = ""
-    run_id: str = ""
-    summary: str = ""  # 一行摘要（注入粒度）
-    full_text: str = ""  # 本次总结全文（回溯/诊断用，随 prune/归档同生命周期）
-    outcome: str = "success"  # 取值：success | partial（用户反馈类取值由 phase3.x 反馈通道引入，见 specs/agent-phase3-summary-enhanced.md）
-    tokens_used: int = 0  # 总结调用的 token（response.usage.total_tokens）
-    created_at: str = ""
-
-    @classmethod
-    def from_row(cls, row) -> MemoryEntry:
-        """从 DB row 构造（列序：id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at）。"""
-        return cls(
-            id=row[0],
-            task_type=row[1],
-            task_id=row[2],
-            run_id=row[3],
-            summary=row[4],
-            full_text=row[5],
-            outcome=row[6],
-            tokens_used=row[7] or 0,
-            created_at=row[8],
-        )
+__all__ = ["MemoryEntry"]

--- a/app/services/memory/models.py
+++ b/app/services/memory/models.py
@@ -1,9 +1,0 @@
-"""记忆数据模型（re-export）。
-
-共享定义已迁移至 :mod:`app.models.memory`（供 core/database 与 services 共同引用，
-消除 core → services 的倒置依赖）。本模块保留 re-export 以兼容现有 import。
-"""
-
-from app.models.memory import MemoryEntry  # noqa: F401
-
-__all__ = ["MemoryEntry"]

--- a/app/services/memory/models.py
+++ b/app/services/memory/models.py
@@ -1,0 +1,33 @@
+"""记忆数据模型。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MemoryEntry:
+    id: int | None = None
+    task_type: str = ""
+    task_id: str = ""
+    run_id: str = ""
+    summary: str = ""  # 一行摘要（注入粒度）
+    full_text: str = ""  # 本次总结全文（回溯/诊断用，随 prune/归档同生命周期）
+    outcome: str = "success"  # 取值：success | partial（用户反馈类取值由 phase3.x 反馈通道引入，见 specs/agent-phase3-summary-enhanced.md）
+    tokens_used: int = 0  # 总结调用的 token（response.usage.total_tokens）
+    created_at: str = ""
+
+    @classmethod
+    def from_row(cls, row) -> MemoryEntry:
+        """从 DB row 构造（列序：id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at）。"""
+        return cls(
+            id=row[0],
+            task_type=row[1],
+            task_id=row[2],
+            run_id=row[3],
+            summary=row[4],
+            full_text=row[5],
+            outcome=row[6],
+            tokens_used=row[7] or 0,
+            created_at=row[8],
+        )

--- a/app/services/memory/retriever.py
+++ b/app/services/memory/retriever.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.core.database.agent_memory import AgentMemoryRepository
-
-from .models import MemoryEntry
+from app.models.memory import MemoryEntry
 
 if TYPE_CHECKING:
     # 仅类型注解用；运行时导入会经 summary 包 __init__ 回到 memory.retriever 形成环

--- a/app/services/memory/retriever.py
+++ b/app/services/memory/retriever.py
@@ -1,0 +1,100 @@
+"""记忆读取器：通用检索方法（业务合并/去重/排序在 SummaryService 层）。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.core.database.agent_memory import AgentMemoryRepository
+
+from .models import MemoryEntry
+
+if TYPE_CHECKING:
+    # 仅类型注解用；运行时导入会经 summary 包 __init__ 回到 memory.retriever 形成环
+    from app.services.summary.models import SummaryRecord
+
+
+class MemoryRetriever:
+    def __init__(self, repo: AgentMemoryRepository):
+        self._repo = repo
+
+    # ------------------------------------------------------------------
+    # 通用检索（业务层组合调用：summary service 自行合并/去重/排序）
+    # ------------------------------------------------------------------
+
+    def recent(self, task_type: str, task_id: str, limit: int = 5) -> list[MemoryEntry]:
+        """最近 N 次同任务执行摘要（连续性）。"""
+        return self._repo.get_recent(task_type, task_id, limit=limit)
+
+    def related(
+        self,
+        task_type: str,
+        task_id: str,
+        titles: list[str],
+        limit: int = 5,
+    ) -> list[MemoryEntry]:
+        """同剧关联：按剧名反查历史总结（含归档冷层，日期倒序）。"""
+        return self._repo.get_related_titles(task_type, task_id, titles, limit=limit)
+
+    # ------------------------------------------------------------------
+    # 旧组合检索（deprecated）
+    # ------------------------------------------------------------------
+
+    def retrieve(
+        self,
+        task_type: str,
+        task_id: str,
+        limit: int = 5,
+        keywords: list[str] | None = None,
+    ) -> list[MemoryEntry]:
+        """[deprecated] 旧组合检索：recent + FTS keywords。
+
+        FTS 检索已停用（相关回忆由 related 联表承担，见
+        specs/agent-phase2-closeout.md §FTS 停用决议）；本方法仅保留
+        keywords/FTS 通路供后续 Phase 5 混合检索评估，业务层不再调用。
+        """
+        entries: list[MemoryEntry] = []
+
+        # 1. 最近 N 次同任务执行
+        entries.extend(self._repo.get_recent(task_type, task_id, limit=limit))
+
+        # 2. 关键词搜索（FTS5，task_type 过滤；命中不占 limit 额度）
+        if keywords:
+            clean = [k for k in keywords if k and k.strip()]  # 过滤空字符串
+            if clean:
+                entries.extend(
+                    self._repo.search_fts(clean, task_type=task_type, limit=limit)
+                )
+
+        # 3. 去重（按 run_id，防双路径命中）；keywords 命中不占额度不收束
+        return self._deduplicate_and_rank(entries)
+
+    def _deduplicate_and_rank(self, entries: list[MemoryEntry]) -> list[MemoryEntry]:
+        """按 run_id 去重，保留顺序（recent 在前、keywords 命中随后）。
+
+        recent 条数已在 get_recent(limit) 源头受限；keywords 命中不占额度
+        全部保留（phase3.x 反馈通道的优先排序也在此扩展）。
+        """
+        seen: set[str] = set()
+        ranked: list[MemoryEntry] = []
+        for e in entries:
+            if e.run_id in seen:
+                continue
+            seen.add(e.run_id)
+            ranked.append(e)
+        return ranked
+
+    def format_memory_context(self, entries: list[MemoryEntry]) -> str:
+        """MemoryEntry 列表 → 注入文本（每条一行）。
+
+        phase3.x 引入用户反馈后，此处增加 `[用户反馈]` 前缀标记
+        （见 specs/agent-phase3-summary-enhanced.md）。
+        """
+        return "\n".join(f"- {e.summary}" for e in entries)
+
+    def find_overlaps(self, records: list[SummaryRecord]) -> list[SummaryRecord]:
+        """[deprecated] 返回已被任意任务消费的记录（consumed_run_ids 非空）。
+
+        v7 起业务方改为硬排除（execute_job 内过滤），本方法保留为通用工具；
+        overlap 软标注流程已移除（见 closeout §4 E3）。
+        """
+        return [r for r in records if r.consumed_run_ids]

--- a/app/services/memory/service.py
+++ b/app/services/memory/service.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.core.database.agent_memory import AgentMemoryRepository
+from app.models.memory import MemoryEntry
 from app.services.llm.models import ChatResponse
 
 from .extractor import MemoryExtractor
-from .models import MemoryEntry
 from .retriever import MemoryRetriever
 
 if TYPE_CHECKING:

--- a/app/services/memory/service.py
+++ b/app/services/memory/service.py
@@ -1,0 +1,120 @@
+"""记忆服务层：统一包装记忆操作，业务层只调此入口。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.core.database.agent_memory import AgentMemoryRepository
+from app.services.llm.models import ChatResponse
+
+from .extractor import MemoryExtractor
+from .models import MemoryEntry
+from .retriever import MemoryRetriever
+
+if TYPE_CHECKING:
+    # 仅类型注解用；运行时导入会经 summary 包 __init__ 回到 memory.service 形成环
+    from app.services.summary.models import SummaryRecord
+
+
+class MemoryService:
+    """记忆服务层：统一包装记忆操作，业务层只调此入口。
+
+    2.0.1/2.0.2 的底层能力（extract_and_store / retrieve）与 2.0.3 的
+    清理能力（rename_task / clear_task）统一经此暴露。
+    （mark_consumed 已折叠进 extract_and_store → store_and_mark，非独立入口）
+    """
+
+    def __init__(self, memory_repo: AgentMemoryRepository):
+        # 消费标记（sync_records 表）的写/清经共享 connection 在 store_and_mark /
+        # clear_task 事务内穿透式访问，不注入 sync repo（见 hy-review20260817 #7）。
+        self._memory = memory_repo
+        self._extractor = MemoryExtractor(memory_repo)
+        self._retriever = MemoryRetriever(memory_repo)
+
+    # ------------------------------------------------------------------
+    # 写入 / 读取（2.0.1/2.0.2 能力收口）
+    # ------------------------------------------------------------------
+
+    async def extract_and_store(
+        self,
+        task_type: str,
+        task_id: str,
+        run_id: str,
+        messages,
+        response: ChatResponse,
+        outcome: str,
+        tokens_used: int,
+        record_ids: list[int],
+        job_name: str | None = None,
+    ) -> None:
+        """总结执行成功后提炼摘要并写入记忆（含消费标记）。
+
+        job_name 透传给摘要 LLM 调用：摘要 token 在 llm_usage 中与主调用
+        归属同一任务，用量统计口径完整。
+        """
+        await self._extractor.extract_and_store(
+            task_type=task_type,
+            task_id=task_id,
+            run_id=run_id,
+            messages=messages,
+            response=response,
+            outcome=outcome,
+            tokens_used=tokens_used,
+            record_ids=record_ids,
+            job_name=job_name,
+        )
+
+    def recent(self, task_type: str, task_id: str, limit: int = 5) -> list[MemoryEntry]:
+        """最近 N 条同任务摘要（通用，不做业务合并）。"""
+        return self._retriever.recent(task_type, task_id, limit=limit)
+
+    def get_task_run_ids(self, task_type: str, task_id: str) -> set[str]:
+        """本任务全部 run_id 集合（含归档）。
+
+        供消费排除按任务隔离——判断记录的 consumed_run_ids 是否与当前任务
+        的 run_id 集合有交集。
+        """
+        return self._memory.get_task_run_ids(task_type, task_id)
+
+    def related(
+        self,
+        task_type: str,
+        task_id: str,
+        titles: list[str],
+        limit: int = 5,
+    ) -> list[MemoryEntry]:
+        """同剧关联摘要（含归档冷层，日期倒序）。"""
+        return self._retriever.related(task_type, task_id, titles, limit=limit)
+
+    def retrieve(
+        self,
+        task_type: str,
+        task_id: str,
+        limit: int = 5,
+        keywords: list[str] | None = None,
+    ) -> list[MemoryEntry]:
+        """[deprecated] 旧组合检索（recent + FTS keywords），业务层不再调用。"""
+        return self._retriever.retrieve(
+            task_type=task_type, task_id=task_id, limit=limit, keywords=keywords
+        )
+
+    def format_memory_context(self, entries: list[MemoryEntry]) -> str:
+        return self._retriever.format_memory_context(entries)
+
+    def find_overlaps(self, records: list[SummaryRecord]) -> list[SummaryRecord]:
+        return self._retriever.find_overlaps(records)
+
+    # ------------------------------------------------------------------
+    # 清理与重置（2.0.3）
+    # ------------------------------------------------------------------
+
+    def rename_task(self, task_type: str, old_task_id: str, new_task_id: str) -> int:
+        """改名迁移：同一事务 UPDATE 主表 + 归档表的 task_id（记忆跟随任务）。"""
+        return self._memory.rename_task(task_type, old_task_id, new_task_id)
+
+    def clear_task(self, task_type: str, task_id: str) -> int:
+        """显式清空（不可恢复，调用方二次确认）：记忆 + 归档 + 消费标记原子清空
+
+        （不筛 outcome，全部删除；想保留偏好重新开始的场景用"复制新 job"）。
+        """
+        return self._memory.clear_task(task_type, task_id)

--- a/app/services/summary/models.py
+++ b/app/services/summary/models.py
@@ -1,6 +1,8 @@
 """Summary job 配置数据类。"""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -20,18 +22,59 @@ class SummaryJobConfig:
         "5. 限制在 300 字以内"
     )
     max_records: int = -1  # -1 表示不限制
+    # 记忆特性（未发布，直接重构）：
+    # memory_limit=0 关闭记忆（不注入/不写入/不排除已消费记录）；
+    # >0 注入最近 N 条摘要 + 已消费记录排除（信息由摘要承继）。
+    memory_limit: int = 0  # 0=关；1–1000=注入最近 N 条摘要（对齐 prune 上限）
+    related_limit: int = 0  # 0=关；1–1000=同剧关联最近 N 条（日期倒序）
 
     @classmethod
-    def from_config_dict(cls, data: dict) -> "SummaryJobConfig":
+    def from_config_dict(cls, data: dict) -> SummaryJobConfig:
         """从 config_manager.get_summary_configs() 字典创建实例。"""
+
+        def _limit(key: str) -> int:
+            try:
+                # 0–1000，负值/非法回落 0
+                return max(0, min(1000, int(data.get(key, 0))))
+            except (TypeError, ValueError):
+                return 0
+
+        def _int(key: str, default: int) -> int:
+            """H2：非法值回落默认——单个坏配置不得拖垮调度注册（与 _limit 同款保护）。"""
+            try:
+                return int(data.get(key, default))
+            except (TypeError, ValueError):
+                return default
+
         return cls(
             name=str(data.get("name", "")),
             enabled=data.get("enabled", True)
             if isinstance(data.get("enabled"), bool)
             else str(data.get("enabled", "true")).lower() in ("true", "1"),
             cron=str(data.get("cron", "0 21 * * *")),
-            lookback_days=int(data.get("lookback_days", 1)),
+            lookback_days=_int("lookback_days", 1),
             user_name=str(data.get("user_name", "")),
             system_prompt=str(data.get("system_prompt", cls.system_prompt)),
-            max_records=int(data.get("max_records", -1)),
+            max_records=_int("max_records", -1),
+            memory_limit=_limit("memory_limit"),
+            related_limit=_limit("related_limit"),
         )
+
+
+@dataclass
+class SummaryRecord:
+    """summary 链路内部观影记录载体（_query_records 返回类型）。"""
+
+    id: int
+    timestamp: str
+    user_name: str
+    title: str
+    bgm_title: str
+    season: int
+    episode: int
+    media_type: str
+    source: str
+    status: str
+    consumed_run_ids: set[str] = field(
+        default_factory=set
+    )  # 消费标记（多对多，空集=未消费）

--- a/app/services/summary/service.py
+++ b/app/services/summary/service.py
@@ -33,12 +33,13 @@ class SummaryService:
         )
         date_to = now.strftime("%Y-%m-%d")
 
-        # 2. 查询记录
+        # 2. 查询记录（仅记忆开启时携带消费标记做排除，避免无条件加重查询）
         records = database_manager.get_records_in_date_range(
             date_from=date_from,
             date_to=date_to,
             limit=job_config.max_records,
             user_name=job_config.user_name.strip() or None,
+            include_consumed=(job_config.memory_limit > 0),
         )
         record_count = len(records)
 

--- a/tests/core/test_agent_memory.py
+++ b/tests/core/test_agent_memory.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.services.memory.models import MemoryEntry
+from app.models.memory import MemoryEntry
 
 MAIN_COLS = "id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at"
 
@@ -158,7 +158,9 @@ class TestStoreAndMark:
         assert rows[0][3] == "run-1"  # run_id
         assert rows[0][4] == "昨日看了芙莉莲"  # summary
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         by_id = {r["id"]: r for r in recs}
         assert by_id[r1]["consumed_run_ids"] == {"run-1"}
         assert by_id[r2]["consumed_run_ids"] == {"run-1"}
@@ -168,7 +170,9 @@ class TestStoreAndMark:
         db.memory.store_and_mark(_entry("run-2"), [])
 
         assert len(_main_rows(db)) == 1
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert all(r["consumed_run_ids"] == set() for r in recs)
 
     def test_duplicate_run_id_raises(self, temp_dir, reset_singletons):
@@ -402,9 +406,23 @@ class TestQueryConsumed:
         r1 = _log_record(db)
         db.memory.store_and_mark(_entry("run-1"), [r1])
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert recs and "consumed_run_ids" in recs[0]
         assert recs[0]["consumed_run_ids"] == {"run-1"}
+
+    def test_default_query_omits_consumed_and_returns_empty_set(
+        self, temp_dir, reset_singletons
+    ):
+        """P1：默认（轻量）查询返回空集合（无 JOIN/GROUP BY，记忆关闭场景）。"""
+        db = _make_db(temp_dir)
+        r1 = _log_record(db)
+        db.memory.store_and_mark(_entry("run-1"), [r1])
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs and "consumed_run_ids" in recs[0]
+        assert recs[0]["consumed_run_ids"] == set()
 
 
 # ── 2.0.3 清理与重置：rename_task / clear_task（C1-C12）──────────────────
@@ -489,7 +507,9 @@ class TestRenameTask:
         db.memory.store_and_mark(_entry("run-1", task_id="summary-daily"), [r1])
         db.memory.rename_task("summary", "summary-daily", "summary-daily2")
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert recs[0]["consumed_run_ids"] == {"run-1"}
 
     def test_rename_scoped_to_task_type_and_task(self, temp_dir, reset_singletons):
@@ -531,7 +551,9 @@ class TestClearTask:
         assert n == 6
         assert _main_rows(db) == []
         assert _archive_rows(db) == []
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert all(r["consumed_run_ids"] == set() for r in recs)
 
     def test_clear_task_isolation(self, temp_dir, reset_singletons):
@@ -578,7 +600,9 @@ class TestClearTask:
         # 与 C3 相同验证，此处显式断言 u1/u2/u3 三个标记（含归档 run_id）全清
         db.memory.clear_task("summary", "summary-daily")
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         marked = [r for r in recs if r["consumed_run_ids"]]
         assert marked == []
 
@@ -598,7 +622,9 @@ class TestClearTask:
 
         db.memory.clear_task("summary", "summary-daily")
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         by_id = {r["id"]: r for r in recs}
         assert by_id[r_daily]["consumed_run_ids"] == set()  # daily 标记被清
         assert by_id[r_yearly]["consumed_run_ids"] == {"y1"}  # yearly 标记保留
@@ -617,12 +643,16 @@ class TestClearTask:
         db.memory.store_and_mark(_entry("run-daily", task_id="summary-daily"), [r1])
         db.memory.store_and_mark(_entry("run-yearly", task_id="summary-yearly"), [r1])
 
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert recs[0]["consumed_run_ids"] == {"run-daily", "run-yearly"}
 
         # 清 daily → 只删 daily 的标记，yearly 保留
         db.memory.clear_task("summary", "summary-daily")
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert recs[0]["consumed_run_ids"] == {"run-yearly"}
 
 

--- a/tests/core/test_agent_memory.py
+++ b/tests/core/test_agent_memory.py
@@ -1,0 +1,701 @@
+"""AgentMemoryRepository 测试（Phase 2.0.1 写入侧）。
+
+覆盖 BDD 场景 W1/W4/W6/W8/W9/W10/W11。
+"""
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from app.services.memory.models import MemoryEntry
+
+MAIN_COLS = "id, task_type, task_id, run_id, summary, full_text, outcome, tokens_used, created_at"
+
+
+def _make_db(temp_dir, name="memory.db"):
+    """创建一个指向临时文件的 DatabaseManager 并返回。"""
+    db_path = temp_dir / name
+    with patch("app.core.database.logger"):
+        from app.core.database import DatabaseManager
+
+        db = DatabaseManager(str(db_path))
+    return db
+
+
+def _entry(run_id: str, summary: str = "昨日看了芙莉莲", **overrides) -> MemoryEntry:
+    defaults = {
+        "task_type": "summary",
+        "task_id": "summary-daily",
+        "run_id": run_id,
+        "summary": summary,
+        "full_text": f"{summary}（全文）",
+        "outcome": "success",
+        "tokens_used": 120,
+    }
+    defaults.update(overrides)
+    return MemoryEntry(**defaults)
+
+
+def _log_record(db, *, title="葬送的芙莉莲", episode=10, bgm_title="葬送的芙莉莲"):
+    return db.log_sync_record(
+        user_name="dad",
+        title=title,
+        ori_title=None,
+        season=1,
+        episode=episode,
+        subject_id="1",
+        status="success",
+        source="plex",
+        media_type="episode",
+        bgm_title=bgm_title,
+    )
+
+
+def _main_rows(db) -> list[tuple]:
+    conn = db._get_connection()
+    return conn.execute(
+        f"SELECT {MAIN_COLS} FROM agent_working_memory ORDER BY id"
+    ).fetchall()
+
+
+def _archive_rows(db) -> list[tuple]:
+    conn = db._get_connection()
+    return conn.execute(
+        f"SELECT {MAIN_COLS} FROM agent_working_memory_archive ORDER BY id"
+    ).fetchall()
+
+
+# ── 表结构（W4 数据基础）───────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_memory_tables_and_fts_created(self, temp_dir, reset_singletons):
+        _ = _make_db(temp_dir)
+
+        with sqlite3.connect(str(temp_dir / "memory.db")) as raw:
+            names = {
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type IN ('table','virtual table')"
+                )
+            }
+            assert "agent_working_memory" in names
+            assert "agent_working_memory_archive" in names
+            assert "agent_memory_fts" in names
+
+            triggers = {
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='trigger'"
+                )
+            }
+            assert {"agent_memory_ai", "agent_memory_ad", "agent_memory_au"} <= triggers
+
+    def test_memory_table_has_expected_columns(self, temp_dir, reset_singletons):
+        _ = _make_db(temp_dir)
+
+        with sqlite3.connect(str(temp_dir / "memory.db")) as raw:
+            rows = raw.execute("PRAGMA table_info(agent_working_memory)").fetchall()
+            cols = [r[1] for r in rows]
+            assert "task_type" in cols
+            assert "task_id" in cols
+            assert "run_id" in cols
+            assert "summary" in cols
+            assert "full_text" in cols
+            assert "outcome" in cols
+            assert "tokens_used" in cols
+            assert "created_at" in cols
+            # run_id 唯一索引（UNIQUE 列约束 → sqlite 自动索引，列名经 index_info 查）
+            indexes = raw.execute("PRAGMA index_list(agent_working_memory)").fetchall()
+            unique_cols: set[str] = set()
+            for idx in indexes:
+                if idx[2] == 1:  # unique=1
+                    cols = raw.execute(f"PRAGMA index_info({idx[1]})").fetchall()
+                    unique_cols.update(c[2] for c in cols)
+            assert "run_id" in unique_cols
+
+    def test_facade_exposes_memory_and_sync_records(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        from app.core.database.agent_memory import AgentMemoryRepository
+        from app.core.database.sync_records import SyncRecordsRepository
+
+        assert isinstance(db.memory, AgentMemoryRepository)
+        assert isinstance(db.sync_records, SyncRecordsRepository)
+
+    def test_sync_records_consumed_run_id_index_created(
+        self, temp_dir, reset_singletons
+    ):
+        """#8：关联表 run_id 建有索引（clear_task 清消费标记免全表扫）。"""
+        _ = _make_db(temp_dir)
+
+        with sqlite3.connect(str(temp_dir / "memory.db")) as raw:
+            indexes = {
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                )
+            }
+            assert "idx_sync_records_consumed_run_id" in indexes
+
+
+# ── W1 成功路径写入 ─────────────────────────────────────────────────────
+
+
+class TestStoreAndMark:
+    def test_inserts_memory_and_marks_consumed_in_same_transaction(
+        self, temp_dir, reset_singletons
+    ):
+        """W1：store_and_mark 写入记忆 + 标记消费（同一事务原子完成）。"""
+        db = _make_db(temp_dir)
+        r1 = _log_record(db, episode=10)
+        r2 = _log_record(db, title="鬼灭之刃", episode=5, bgm_title="鬼灭之刃")
+
+        db.memory.store_and_mark(_entry("run-1"), [r1, r2])
+
+        rows = _main_rows(db)
+        assert len(rows) == 1
+        assert rows[0][3] == "run-1"  # run_id
+        assert rows[0][4] == "昨日看了芙莉莲"  # summary
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        by_id = {r["id"]: r for r in recs}
+        assert by_id[r1]["consumed_run_ids"] == {"run-1"}
+        assert by_id[r2]["consumed_run_ids"] == {"run-1"}
+
+    def test_no_record_ids_skips_marking(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-2"), [])
+
+        assert len(_main_rows(db)) == 1
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert all(r["consumed_run_ids"] == set() for r in recs)
+
+    def test_duplicate_run_id_raises(self, temp_dir, reset_singletons):
+        """run_id UNIQUE：重复 run_id 抛异常（调用方 try/except 捕获）。"""
+        import sqlite3
+
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-x"), [])
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db.memory.store_and_mark(_entry("run-x"), [])
+
+
+# ── W4 FTS5 触发器同步 ──────────────────────────────────────────────────
+
+
+class TestFtsSearch:
+    def test_search_fts_finds_newly_inserted_row(self, temp_dir, reset_singletons):
+        """W4：插入后触发器同步 FTS，search_fts 命中。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            _entry("run-1", summary="昨日看了葬送的芙莉莲 S1E10"), []
+        )
+
+        hits = db.memory.search_fts(["芙莉莲"], task_type="summary")
+        assert len(hits) == 1
+        assert hits[0].run_id == "run-1"
+        assert hits[0].summary == "昨日看了葬送的芙莉莲 S1E10"
+
+    def test_search_fts_filters_by_task_type(self, temp_dir, reset_singletons):
+        """跨任务不命中：其他 task_type 的记忆不进 summary 检索结果。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            _entry(
+                "run-a",
+                summary="server 挂了 503",
+                task_type="diagnostic",
+                task_id="diag-x",
+            ),
+            [],
+        )
+        db.memory.store_and_mark(
+            _entry(
+                "run-b",
+                summary="server 挂了 503",
+                task_type="summary",
+                task_id="summary-daily",
+            ),
+            [],
+        )
+
+        hits = db.memory.search_fts(["503"], task_type="summary")
+        assert [h.run_id for h in hits] == ["run-b"]
+
+    def test_search_fts_multiple_keywords_or(self, temp_dir, reset_singletons):
+        """多关键词 OR：任一标题命中即相关（今日看的任一番剧都捞回）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", summary="芙莉莲 S1E10 鬼灭之刃"), [])
+        db.memory.store_and_mark(_entry("run-2", summary="只看了芙莉莲"), [])
+
+        hits = db.memory.search_fts(["芙莉莲", "鬼灭之刃"], task_type="summary")
+        # OR 语义：run-2 虽只含一词，仍是"与今日任一标题相关"的记忆
+        assert {h.run_id for h in hits} == {"run-1", "run-2"}
+
+    def test_search_fts_each_keyword_hits_independently(
+        self, temp_dir, reset_singletons
+    ):
+        """多关键词 OR 的核心场景：两条记忆各命中一个标题，均被捞回（AND 会 0 命中）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-a", summary="只看了芙莉莲"), [])
+        db.memory.store_and_mark(_entry("run-b", summary="只看了鬼灭之刃"), [])
+
+        hits = db.memory.search_fts(["芙莉莲", "鬼灭之刃"], task_type="summary")
+        assert {h.run_id for h in hits} == {"run-a", "run-b"}
+
+    def test_search_fts_multi_word_title_phrase_match(self, temp_dir, reset_singletons):
+        """#4：带空格标题按短语整体匹配——不把 'Spy x Family' 拆成 Spy/Family 独立 OR
+        （精确性：只命中含完整短语的记忆，而非'含任一单词'的记忆）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-a", summary="Spy x Family 剧场版"), [])
+        db.memory.store_and_mark(_entry("run-b", summary="Family Guy 新季开播"), [])
+
+        hits = db.memory.search_fts(["Spy x Family"], task_type="summary")
+        assert [h.run_id for h in hits] == ["run-a"]
+
+    def test_search_fts_returns_empty_for_no_match(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", summary="芙莉莲"), [])
+        assert db.memory.search_fts(["不存在的关键词"], task_type="summary") == []
+
+
+# ── W6 prune 归档 / W9 feedback 保留 ────────────────────────────────────
+
+
+class TestPrune:
+    def test_prune_archives_old_records(self, temp_dir, reset_singletons):
+        """W6：超出 keep 的旧记录先入归档再删主表（降级而非删除）。"""
+        db = _make_db(temp_dir)
+        for i in range(1005):
+            db.memory.store_and_mark(_entry(f"run-{i}", summary=f"第{i}次总结"), [])
+
+        db.memory.prune("summary", "summary-daily", keep=1000)
+
+        assert len(_main_rows(db)) == 1000
+        archive = _archive_rows(db)
+        assert len(archive) == 5
+        # 归档保留原 created_at/run_id
+        assert {r[3] for r in archive} == {f"run-{i}" for i in range(5)}
+        assert all(r[8] for r in archive)  # created_at 非空
+
+    def test_prune_archives_all_outcomes(self, temp_dir, reset_singletons):
+        """prune 不筛 outcome，超窗条目一律归档（feedback 优先保留属 phase3.x，
+        见 specs/agent-phase3-summary-enhanced.md）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            _entry("run-old", summary="早期总结", outcome="partial"), []
+        )
+        for i in range(1005):
+            db.memory.store_and_mark(_entry(f"run-{i}", summary=f"第{i}次总结"), [])
+
+        db.memory.prune("summary", "summary-daily", keep=1000)
+
+        rows = _main_rows(db)
+        assert all(r[3] != "run-old" for r in rows)
+        assert any(r[3] == "run-old" for r in _archive_rows(db))
+
+    def test_prune_scoped_to_task(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-a", task_id="summary-daily"), [])
+        db.memory.store_and_mark(_entry("run-b", task_id="summary-weekly"), [])
+
+        db.memory.prune("summary", "summary-daily", keep=0)
+
+        rows = _main_rows(db)
+        assert [r[3] for r in rows] == ["run-b"]
+
+
+# ── W8 归档可检索 ───────────────────────────────────────────────────────
+
+
+class TestSearchArchive:
+    def test_search_archive_finds_keyword(self, temp_dir, reset_singletons):
+        """W8：LIKE 检索冷记忆。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", summary="归档前的一次总结"), [])
+        db.memory.prune("summary", "summary-daily", keep=0)
+
+        hits = db.memory.search_archive("summary", "归档前")
+        assert len(hits) == 1
+        assert hits[0].run_id == "run-1"
+
+    def test_search_archive_task_type_filter(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            _entry(
+                "run-a",
+                summary="共享关键词内容",
+                task_type="summary",
+                task_id="summary-daily",
+            ),
+            [],
+        )
+        db.memory.store_and_mark(
+            _entry(
+                "run-b",
+                summary="共享关键词内容",
+                task_type="diagnostic",
+                task_id="diag-x",
+            ),
+            [],
+        )
+        db.memory.prune("summary", "summary-daily", keep=0)
+        db.memory.prune("diagnostic", "diag-x", keep=0)
+
+        hits = db.memory.search_archive("summary", "共享关键词")
+        assert [h.run_id for h in hits] == ["run-a"]
+
+
+# ── W10 老库补列幂等 ────────────────────────────────────────────────────
+
+
+class TestMigration:
+    def test_consumed_assoc_table_created_and_idempotent(
+        self, temp_dir, reset_singletons
+    ):
+        """W10：启动时建消费关联表（多对多）+ run_id 索引，幂等。"""
+        db = _make_db(temp_dir)
+
+        with sqlite3.connect(str(temp_dir / "memory.db")) as raw:
+            tables = [
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            ]
+            assert "sync_records_consumed" in tables
+            # 旧单列不存在（开发阶段直接建关联表，无迁移残留）
+            cols = [r[1] for r in raw.execute("PRAGMA table_info(sync_records)")]
+            assert "consumed_run_id" not in cols
+            # run_id 反查索引存在（P1-1：clear_task / get_related_titles 依赖）
+            indexes = {
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                )
+            }
+            assert "idx_sync_records_consumed_run_id" in indexes
+
+        # 再次执行迁移方法幂等（表已存在，不报错）
+        conn = db._get_connection()
+        db._connection._ensure_sync_records_consumed(conn.cursor())
+        with sqlite3.connect(str(temp_dir / "memory.db")) as raw:
+            tables = [
+                r[0]
+                for r in raw.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            ]
+            assert "sync_records_consumed" in tables
+
+
+# ── W11 查询返回 consumed_run_ids ───────────────────────────────────────
+
+
+class TestQueryConsumed:
+    def test_get_records_in_date_range_includes_consumed_run_ids(
+        self, temp_dir, reset_singletons
+    ):
+        """W11：summary 底层查询返回 consumed_run_ids（关联表多对多聚合）。"""
+        db = _make_db(temp_dir)
+        r1 = _log_record(db)
+        db.memory.store_and_mark(_entry("run-1"), [r1])
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs and "consumed_run_ids" in recs[0]
+        assert recs[0]["consumed_run_ids"] == {"run-1"}
+
+
+# ── 2.0.3 清理与重置：rename_task / clear_task（C1-C12）──────────────────
+
+
+class TestGetTaskRunIds:
+    """get_task_run_ids：按 (task_type, task_id) 取本任务全部 run_id 集合。
+
+    供消费排除按任务隔离使用——判断一条记录的 consumed_run_id 是否属于
+    「当前任务」而非全局（跨任务互斥解除，见 BDD 增量窗口场景）。
+    """
+
+    def test_returns_all_run_ids_of_task(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", task_id="summary-daily"), [])
+        db.memory.store_and_mark(_entry("run-2", task_id="summary-daily"), [])
+
+        assert db.memory.get_task_run_ids("summary", "summary-daily") == {
+            "run-1",
+            "run-2",
+        }
+
+    def test_excludes_other_tasks(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-a", task_id="summary-daily"), [])
+        db.memory.store_and_mark(
+            _entry("run-b", task_type="summary", task_id="summary-yearly"), []
+        )
+        db.memory.store_and_mark(
+            _entry("run-c", task_type="diagnostic", task_id="diag-x"), []
+        )
+
+        assert db.memory.get_task_run_ids("summary", "summary-daily") == {"run-a"}
+        assert db.memory.get_task_run_ids("summary", "summary-yearly") == {"run-b"}
+        assert db.memory.get_task_run_ids("diagnostic", "diag-x") == {"run-c"}
+
+    def test_includes_archived_runs(self, temp_dir, reset_singletons):
+        """prune 下沉归档后 run_id 仍归属本任务（消费标记不随归档失效）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", task_id="summary-daily"), [])
+        db.memory.store_and_mark(_entry("run-2", task_id="summary-daily"), [])
+        db.memory.prune("summary", "summary-daily", keep=1)  # run-1 入归档
+
+        assert db.memory.get_task_run_ids("summary", "summary-daily") == {
+            "run-1",
+            "run-2",
+        }
+
+    def test_no_memory_returns_empty_set(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        assert db.memory.get_task_run_ids("summary", "summary-empty") == set()
+
+
+class TestRenameTask:
+    def test_rename_migrates_main_and_archive(self, temp_dir, reset_singletons):
+        """C1：改名迁移主表 + 归档表的 task_id。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-1", task_id="summary-daily"), [])
+        db.memory.store_and_mark(_entry("run-2", task_id="summary-daily"), [])
+        db.memory.prune("summary", "summary-daily", keep=1)  # run-1 入归档，run-2 保留
+
+        n = db.memory.rename_task("summary", "summary-daily", "summary-daily2")
+
+        assert n == 2
+        main = [r[3] for r in _main_rows(db)]
+        archive = [r[3] for r in _archive_rows(db)]
+        assert set(main) == {"run-2"}
+        assert archive == ["run-1"]
+        assert all(r[2] == "summary-daily2" for r in _main_rows(db))
+        assert all(r[2] == "summary-daily2" for r in _archive_rows(db))
+
+    def test_rename_nonexistent_task_idempotent(self, temp_dir, reset_singletons):
+        """C6：改不存在的 task_id → 无操作，不报错。"""
+        db = _make_db(temp_dir)
+        n = db.memory.rename_task("summary", "summary-nonexist", "summary-new")
+        assert n == 0
+
+    def test_rename_keeps_consumed_marks(self, temp_dir, reset_singletons):
+        """C7：消费标记只关联 run_id，改名不破坏。"""
+        db = _make_db(temp_dir)
+        r1 = _log_record(db)
+        db.memory.store_and_mark(_entry("run-1", task_id="summary-daily"), [r1])
+        db.memory.rename_task("summary", "summary-daily", "summary-daily2")
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs[0]["consumed_run_ids"] == {"run-1"}
+
+    def test_rename_scoped_to_task_type_and_task(self, temp_dir, reset_singletons):
+        """rename 只影响目标 (task_type, task_id)。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("run-a", task_id="summary-daily"), [])
+        db.memory.store_and_mark(
+            _entry("run-b", task_type="diagnostic", task_id="diag-x"), []
+        )
+
+        db.memory.rename_task("summary", "summary-daily", "summary-daily2")
+
+        rows = _main_rows(db)
+        by_run = {r[3]: r[2] for r in rows}
+        assert by_run["run-a"] == "summary-daily2"
+        assert by_run["run-b"] == "diag-x"
+
+
+class TestClearTask:
+    def _seed(self, db):
+        """两条主表记忆 + 一条归档记忆 + 三条消费标记。"""
+        r1 = _log_record(db, episode=1)
+        r2 = _log_record(db, episode=2)
+        r3 = _log_record(db, episode=3)
+        db.memory.store_and_mark(_entry("u1", task_id="summary-daily"), [r1])
+        db.memory.store_and_mark(_entry("u2", task_id="summary-daily"), [r2])
+        db.memory.store_and_mark(_entry("u3", task_id="summary-daily"), [r3])
+        db.memory.prune("summary", "summary-daily", keep=1)  # u1/u2 入归档
+        return [r1, r2, r3]
+
+    def test_clear_task_removes_memory_and_marks(self, temp_dir, reset_singletons):
+        """C3：同一事务清主表 + 归档 + 消费标记（含归档 run_id）。"""
+        db = _make_db(temp_dir)
+        r1, r2, r3 = self._seed(db)
+
+        n = db.memory.clear_task("summary", "summary-daily")
+
+        # u3 主表 + u1/u2 归档 = 3 删除 + 3 消费标记清空
+        assert n == 6
+        assert _main_rows(db) == []
+        assert _archive_rows(db) == []
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert all(r["consumed_run_ids"] == set() for r in recs)
+
+    def test_clear_task_isolation(self, temp_dir, reset_singletons):
+        """C9：清 A 不影响 B。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("u1", task_id="summary-daily"), [])
+        db.memory.store_and_mark(_entry("v1", task_id="summary-weekly"), [])
+
+        db.memory.clear_task("summary", "summary-daily")
+
+        rows = _main_rows(db)
+        assert [r[3] for r in rows] == ["v1"]
+
+    def test_clear_task_includes_all_outcomes(self, temp_dir, reset_singletons):
+        """C10：彻底清空语义——不筛 outcome 全部删除。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            _entry("u-partial", task_id="summary-daily", outcome="partial"), []
+        )
+        db.memory.store_and_mark(_entry("u1", task_id="summary-daily"), [])
+
+        db.memory.clear_task("summary", "summary-daily")
+
+        assert _main_rows(db) == []
+
+    def test_clear_task_idempotent(self, temp_dir, reset_singletons):
+        """C11：再次清空不报错，影响行数 0。"""
+        db = _make_db(temp_dir)
+        db.memory.clear_task("summary", "summary-daily")
+        assert db.memory.clear_task("summary", "summary-daily") == 0
+
+    def test_clear_task_then_retrieve_empty(self, temp_dir, reset_singletons):
+        """C8：清空后 retrieve 返回空（新上下文从零开始）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(_entry("u1", task_id="summary-daily"), [])
+        db.memory.clear_task("summary", "summary-daily")
+
+        assert db.memory.get_recent("summary", "summary-daily") == []
+
+    def test_run_ids_collected_before_delete(self, temp_dir, reset_singletons):
+        """C12：run_id 收集先于删表——消费标记不因映射丢失而漏清。"""
+        db = _make_db(temp_dir)
+        r1, r2, r3 = self._seed(db)
+        # 与 C3 相同验证，此处显式断言 u1/u2/u3 三个标记（含归档 run_id）全清
+        db.memory.clear_task("summary", "summary-daily")
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        marked = [r for r in recs if r["consumed_run_ids"]]
+        assert marked == []
+
+    def test_clear_task_keeps_other_task_consumed_marks(
+        self, temp_dir, reset_singletons
+    ):
+        """C13（按任务隔离）：清 A 任务只清 A 的消费标记，B 任务的标记保留。
+
+        跨任务消费隔离的清理侧：每日总结清空记忆不应抹掉年度总结的消费标记
+        （否则年度总结会重复消费本已总结过的记录）。
+        """
+        db = _make_db(temp_dir)
+        r_daily = _log_record(db, episode=1)
+        r_yearly = _log_record(db, episode=2)
+        db.memory.store_and_mark(_entry("d1", task_id="summary-daily"), [r_daily])
+        db.memory.store_and_mark(_entry("y1", task_id="summary-yearly"), [r_yearly])
+
+        db.memory.clear_task("summary", "summary-daily")
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        by_id = {r["id"]: r for r in recs}
+        assert by_id[r_daily]["consumed_run_ids"] == set()  # daily 标记被清
+        assert by_id[r_yearly]["consumed_run_ids"] == {"y1"}  # yearly 标记保留
+
+    def test_same_record_consumed_by_two_tasks_both_kept(
+        self, temp_dir, reset_singletons
+    ):
+        """B（多对多）：同一条记录被每日 + 年度两个任务消费 → 两个标记共存。
+
+        这是关联表相对单列的核心差异：旧实现（单列 consumed_run_id）后写覆盖
+        先写；关联表 INSERT OR IGNORE 按 (record, run) 去重，互不覆盖。
+        """
+        db = _make_db(temp_dir)
+        r1 = _log_record(db, episode=1)
+        # daily 先消费 r1，yearly 后也消费 r1
+        db.memory.store_and_mark(_entry("run-daily", task_id="summary-daily"), [r1])
+        db.memory.store_and_mark(_entry("run-yearly", task_id="summary-yearly"), [r1])
+
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs[0]["consumed_run_ids"] == {"run-daily", "run-yearly"}
+
+        # 清 daily → 只删 daily 的标记，yearly 保留
+        db.memory.clear_task("summary", "summary-daily")
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs[0]["consumed_run_ids"] == {"run-yearly"}
+
+
+# ── 同剧关联联表（S5/S6/S7：get_related_titles）─────────────────────
+
+
+class TestGetRelatedTitles:
+    """按剧名反查历史总结：consumed_run_id 联表，主表+归档 UNION。"""
+
+    def test_empty_titles_short_circuits(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        assert (
+            db.memory.get_related_titles("summary", "summary-daily", [], limit=5) == []
+        )
+        assert (
+            db.memory.get_related_titles(
+                "summary", "summary-daily", ["", "  "], limit=5
+            )
+            == []
+        )
+
+    def test_hits_main_and_archive(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        # run-1 消费了《葬送的芙莉莲》记录（主表）
+        r1 = _log_record(db, bgm_title="葬送的芙莉莲")
+        db.memory.store_and_mark(_entry("run-1", summary="芙莉莲 S1E10"), [r1])
+        # run-2 消费《鬼灭之刃》记录后归档（冷层）
+        r2 = _log_record(db, title="鬼灭之刃", bgm_title="鬼灭之刃")
+        db.memory.store_and_mark(_entry("run-2", summary="鬼灭 S3E5"), [r2])
+        # prune run-2 到归档
+        db.memory.prune("summary", "summary-daily", keep=0)
+
+        hits = db.memory.get_related_titles(
+            "summary", "summary-daily", ["葬送的芙莉莲", "鬼灭之刃"], limit=5
+        )
+        run_ids = {h.run_id for h in hits}
+        assert run_ids == {"run-1", "run-2"}  # 主表 + 归档冷层都命中
+
+    def test_same_run_multi_episodes_deduped(self, temp_dir, reset_singletons):
+        """S6：同剧 12 集被同一次总结消费 → GROUP BY m.id 只返回一条。"""
+        db = _make_db(temp_dir)
+        ids = [
+            _log_record(db, bgm_title="葬送的芙莉莲", episode=i) for i in range(1, 4)
+        ]
+        db.memory.store_and_mark(_entry("run-1", summary="芙莉莲三集"), ids)
+
+        hits = db.memory.get_related_titles(
+            "summary", "summary-daily", ["葬送的芙莉莲"], limit=5
+        )
+        assert len(hits) == 1
+        assert hits[0].run_id == "run-1"
+
+    def test_task_isolation(self, temp_dir, reset_singletons):
+        """任务隔离：其他任务的记忆不命中。"""
+        db = _make_db(temp_dir)
+        r = _log_record(db, bgm_title="葬送的芙莉莲")
+        db.memory.store_and_mark(
+            _entry("run-1", summary="芙莉莲", task_id="summary-weekly"), [r]
+        )
+
+        hits = db.memory.get_related_titles(
+            "summary", "summary-daily", ["葬送的芙莉莲"], limit=5
+        )
+        assert hits == []
+
+    def test_order_desc_and_limit(self, temp_dir, reset_singletons):
+        """日期倒序 + LIMIT 生效。"""
+        db = _make_db(temp_dir)
+        for i in range(3):
+            r = _log_record(db, bgm_title="葬送的芙莉莲", episode=i + 1)
+            db.memory.store_and_mark(_entry(f"run-{i}", summary=f"第{i}次"), [r])
+
+        hits = db.memory.get_related_titles(
+            "summary", "summary-daily", ["葬送的芙莉莲"], limit=2
+        )
+        assert [h.run_id for h in hits] == ["run-2", "run-1"]  # 倒序取最近 2

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -1226,7 +1226,7 @@ class TestCleanupOldRecords:
             status="success",
             source="test",
         )
-        from app.services.memory.models import MemoryEntry
+        from app.models.memory import MemoryEntry
 
         db.memory.store_and_mark(
             MemoryEntry(

--- a/tests/core/test_database.py
+++ b/tests/core/test_database.py
@@ -1205,6 +1205,54 @@ class TestCleanupOldRecords:
         result = db.get_sync_records(limit=10)
         assert result["total"] == 1
 
+    def test_cleanup_removes_orphan_assoc_rows(self, temp_dir, reset_singletons):
+        """清理旧记录时，关联表 sync_records_consumed 孤儿行一并清除。
+
+        P2-1：DELETE sync_records 后关联表残留指向已删记录的消费标记，
+        表体积膨胀。级联清理避免孤儿行积累。
+        """
+        db_path = temp_dir / "cleanup_orphan.db"
+        with patch("app.core.database.logger"):
+            from app.core.database import DatabaseManager
+
+            db = DatabaseManager(str(db_path))
+
+        r1 = db.log_sync_record(
+            user_name="u",
+            title="旧记录",
+            ori_title=None,
+            season=1,
+            episode=1,
+            status="success",
+            source="test",
+        )
+        from app.services.memory.models import MemoryEntry
+
+        db.memory.store_and_mark(
+            MemoryEntry(
+                task_type="summary",
+                task_id="summary-daily",
+                run_id="run-1",
+                summary="s",
+            ),
+            [r1],
+        )
+        # 将记录改为 40 天前 → 触发清理
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "UPDATE sync_records SET timestamp = datetime('now', '-40 days')"
+            )
+            conn.commit()
+
+        db.cleanup_old_records(30)
+
+        # 关联表无孤儿行（记录已删，消费标记应一并清掉）
+        with sqlite3.connect(str(db_path)) as conn:
+            orphan = conn.execute(
+                "SELECT COUNT(*) FROM sync_records_consumed"
+            ).fetchone()[0]
+        assert orphan == 0
+
     def test_cleanup_facade_forwards(self, temp_dir, reset_singletons):
         """DatabaseManager facade 正确转发 cleanup_old_records"""
         db_path = temp_dir / "cleanup_facade.db"

--- a/tests/core/test_database_records_range.py
+++ b/tests/core/test_database_records_range.py
@@ -273,6 +273,7 @@ class TestGetRecordsInDateRange:
             "source",
             "media_type",
             "bgm_title",
+            "consumed_run_ids",
             "run_id",
             "batch_id",
         }
@@ -282,3 +283,59 @@ class TestGetRecordsInDateRange:
         assert r["source"] == "api"
         assert r["media_type"] == "episode"
         assert r["bgm_title"] == ""
+        assert r["consumed_run_ids"] == set()
+
+    def test_run_id_and_batch_id_columns_not_misindexed(
+        self, temp_dir, reset_singletons
+    ):
+        """F1：run_id/batch_id/consumed_run_ids 三列各自映射，不得错位。
+
+        历史 bug：dict 把 run_id 写成 row[14]（实为 consumed_run_id）、batch_id
+        写成 row[15]（实为 run_id），导致列错位。插入互不相同的值逐列断言；
+        消费标记走关联表（consumed_run_ids 集合聚合）。
+        """
+        db_path = temp_dir / "run_id_cols.db"
+        with patch("app.core.database.logger"):
+            from app.core.database import DatabaseManager
+
+            db = DatabaseManager(str(db_path))
+
+        with sqlite3.connect(str(db_path)) as raw:
+            cur = raw.execute(
+                """INSERT INTO sync_records
+                (timestamp, user_name, title, ori_title, season, episode,
+                 subject_id, episode_id, status, message, source, media_type,
+                 bgm_title, run_id, batch_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    "2025-02-01 10:00:00",
+                    "u",
+                    "T",
+                    None,
+                    1,
+                    1,
+                    None,
+                    None,
+                    "success",
+                    "",
+                    "api",
+                    "episode",
+                    "",
+                    "run-ABC",
+                    "batch-DEF",
+                ),
+            )
+            rec_id = cur.lastrowid
+            raw.execute(
+                "INSERT INTO sync_records_consumed (sync_record_id, run_id)"
+                " VALUES (?, ?)",
+                (rec_id, "consumed-XYZ"),
+            )
+            raw.commit()
+
+        records = db.get_records_in_date_range("2025-02-01", "2025-02-01")
+        assert len(records) == 1
+        r = records[0]
+        assert r["consumed_run_ids"] == {"consumed-XYZ"}
+        assert r["run_id"] == "run-ABC"
+        assert r["batch_id"] == "batch-DEF"

--- a/tests/core/test_database_records_range.py
+++ b/tests/core/test_database_records_range.py
@@ -333,9 +333,28 @@ class TestGetRecordsInDateRange:
             )
             raw.commit()
 
-        records = db.get_records_in_date_range("2025-02-01", "2025-02-01")
+        records = db.get_records_in_date_range(
+            "2025-02-01", "2025-02-01", include_consumed=True
+        )
         assert len(records) == 1
         r = records[0]
         assert r["consumed_run_ids"] == {"consumed-XYZ"}
         assert r["run_id"] == "run-ABC"
         assert r["batch_id"] == "batch-DEF"
+
+    def test_default_query_without_consumed_returns_empty_set(
+        self, temp_dir, reset_singletons
+    ):
+        """P1：默认查询（无 include_consumed）返回空 consumed_run_ids 集合。"""
+        db_path = temp_dir / "light.db"
+        with patch("app.core.database.logger"):
+            from app.core.database import DatabaseManager
+
+            db = DatabaseManager(str(db_path))
+
+        with sqlite3.connect(str(db_path)) as raw:
+            _insert_record(raw, "2025-03-01 10:00:00", title="T")
+            raw.commit()
+
+        records = db.get_records_in_date_range("2025-03-01", "2025-03-01")
+        assert records[0]["consumed_run_ids"] == set()

--- a/tests/services/memory/test_extractor.py
+++ b/tests/services/memory/test_extractor.py
@@ -7,9 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.memory import MemoryEntry
 from app.services.llm.models import ChatResponse, Message, Usage
 from app.services.memory.extractor import MemoryExtractor
-from app.services.memory.models import MemoryEntry
 
 
 def _response(content: str = "本次总结全文内容") -> ChatResponse:

--- a/tests/services/memory/test_extractor.py
+++ b/tests/services/memory/test_extractor.py
@@ -1,0 +1,211 @@
+"""MemoryExtractor 测试（Phase 2.0.1 摘要生成）。
+
+覆盖 BDD 场景 W1/W2/W3/W5。
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.llm.models import ChatResponse, Message, Usage
+from app.services.memory.extractor import MemoryExtractor
+from app.services.memory.models import MemoryEntry
+
+
+def _response(content: str = "本次总结全文内容") -> ChatResponse:
+    return ChatResponse(
+        content=content,
+        model="test-model",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+def _messages() -> list[Message]:
+    return [
+        Message(role="system", content="system prompt"),
+        Message(role="user", content="records..."),
+    ]
+
+
+def _make_extractor(
+    repo=None, llm=None
+) -> tuple[MemoryExtractor, MagicMock, MagicMock]:
+    repo = repo or MagicMock()
+    llm = llm or MagicMock()
+    llm.chat = AsyncMock(return_value=ChatResponse(content="一句话摘要", model="m"))
+    extractor = MemoryExtractor(repo, llm_client=llm)
+    return extractor, repo, llm
+
+
+# ── W1 成功路径写入 ─────────────────────────────────────────────────────
+
+
+class TestExtractAndStore:
+    @pytest.mark.asyncio
+    async def test_writes_summary_and_prunes(self):
+        """extract_and_store 用 LLM 摘要写入记忆并 prune。"""
+        extractor, repo, llm = _make_extractor()
+        response = _response("本次总结全文")
+
+        await extractor.extract_and_store(
+            task_type="summary",
+            task_id="summary-daily",
+            run_id="run-1",
+            messages=_messages(),
+            response=response,
+            outcome="success",
+            tokens_used=150,
+            record_ids=[1, 2],
+        )
+
+        # LLM 收到完整上下文（system+user）+ assistant 回复 + 摘要指令（缓存前缀复用）
+        args = llm.chat.await_args.args[0]
+        assert len(args) == 4
+        assert args[2].role == "assistant"
+        assert args[2].content == "本次总结全文"
+        assert args[3].role == "user"
+
+        repo.store_and_mark.assert_called_once()
+        entry: MemoryEntry = repo.store_and_mark.call_args.args[0]
+        assert entry.task_type == "summary"
+        assert entry.task_id == "summary-daily"
+        assert entry.run_id == "run-1"
+        assert entry.summary == "一句话摘要"
+        assert entry.full_text == "本次总结全文"
+        assert entry.outcome == "success"
+        assert entry.tokens_used == 150
+        assert repo.store_and_mark.call_args.kwargs["record_ids"] == [1, 2]
+
+        repo.prune.assert_called_once_with("summary", "summary-daily", keep=1000)
+
+
+# ── W2 摘要 LLM 失败规则兜底 ────────────────────────────────────────────
+
+
+class TestLazyLlmClient:
+    @pytest.mark.asyncio
+    async def test_no_injected_client_uses_global_singleton_per_call(self):
+        """未注入 llm_client 时，_summarize 每次现取 get_llm_client()（reset 后不滞留旧实例）。"""
+        mock_llm = MagicMock()
+        mock_llm.chat = AsyncMock(
+            return_value=ChatResponse(content="一句话", model="m")
+        )
+        extractor = MemoryExtractor(MagicMock(), llm_client=None)
+
+        with patch(
+            "app.services.memory.extractor.get_llm_client", return_value=mock_llm
+        ):
+            summary = await extractor._summarize(_messages(), _response())
+
+        assert summary == "一句话"
+        mock_llm.chat.assert_awaited_once()
+
+
+# ── 摘要失败跳过不写（S9：无截断兜底，所有入库摘要均为 LLM 完整输出）──────
+
+
+class TestSummarizeFailSkips:
+    @pytest.mark.asyncio
+    async def test_llm_exception_returns_empty_and_skips_write(self):
+        """S9：_summarize LLM 抛异常 → 返回空串（不写记忆，无截断兜底）。"""
+        extractor, repo, llm = _make_extractor()
+        llm.chat = AsyncMock(side_effect=RuntimeError("llm down"))
+        response = _response("很长的全文" * 100)
+
+        summary = await extractor._summarize(_messages(), response)
+
+        assert summary == ""
+        # extract_and_store 空摘要时跳过写入（同空响应路径）
+        await extractor.extract_and_store(
+            task_type="summary",
+            task_id="summary-daily",
+            run_id="run-1",
+            messages=_messages(),
+            response=response,
+            outcome="success",
+            tokens_used=0,
+            record_ids=[],
+        )
+        repo.store_and_mark.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_llm_summary_returns_empty(self):
+        """摘要 LLM 返回空内容 → 返回空串，不写记忆。"""
+        extractor, repo, llm = _make_extractor()
+        llm.chat = AsyncMock(return_value=ChatResponse(content="", model="m"))
+        response = _response("兜底全文" * 100)
+
+        summary = await extractor._summarize(_messages(), response)
+
+        assert summary == ""
+
+    @pytest.mark.asyncio
+    async def test_long_summary_kept_intact(self):
+        """S8：成功路径零截断——LLM 输出多长存多长（无 _SUMMARY_MAX_LEN）。"""
+        long_text = "长" * 500
+        extractor, repo, llm = _make_extractor()
+        llm.chat = AsyncMock(return_value=ChatResponse(content=long_text, model="m"))
+        response = _response("全文")
+
+        await extractor.extract_and_store(
+            task_type="summary",
+            task_id="summary-daily",
+            run_id="run-1",
+            messages=_messages(),
+            response=response,
+            outcome="success",
+            tokens_used=0,
+            record_ids=[],
+        )
+        entry: MemoryEntry = repo.store_and_mark.call_args.args[0]
+        assert entry.summary == long_text  # 500 字完整原文
+
+
+# ── 空响应不写记忆 ───────────────────────────────────────────────────
+
+
+class TestEmptyResponse:
+    @pytest.mark.asyncio
+    async def test_empty_response_skips_write(self):
+        """W3：LLM 重试耗尽返回空响应 → 不写记忆。"""
+        extractor, repo, llm = _make_extractor()
+        empty = ChatResponse(content="", model="", usage=None, latency=5)
+
+        await extractor.extract_and_store(
+            task_type="summary",
+            task_id="summary-daily",
+            run_id="run-1",
+            messages=_messages(),
+            response=empty,
+            outcome="success",
+            tokens_used=0,
+            record_ids=[],
+        )
+
+        repo.store_and_mark.assert_not_called()
+        repo.prune.assert_not_called()
+        llm.chat.assert_not_awaited()  # 空响应不触发摘要调用
+
+
+# ── W5 写入失败不影响调用方 ─────────────────────────────────────────────
+
+
+class TestFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_repo_failure_propagates_to_caller(self):
+        """W5：DB 写入异常向上传播（execute_job 外层 try/except 处理）。"""
+        repo = MagicMock()
+        repo.store_and_mark.side_effect = RuntimeError("db down")
+        extractor, _, _ = _make_extractor(repo=repo)
+
+        with pytest.raises(RuntimeError):
+            await extractor.extract_and_store(
+                task_type="summary",
+                task_id="summary-daily",
+                run_id="run-1",
+                messages=_messages(),
+                response=_response(),
+                outcome="success",
+                tokens_used=0,
+                record_ids=[],
+            )

--- a/tests/services/memory/test_retriever.py
+++ b/tests/services/memory/test_retriever.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from app.services.memory.models import MemoryEntry
+from app.models.memory import MemoryEntry
 from app.services.memory.retriever import MemoryRetriever
 from app.services.summary.models import SummaryRecord
 

--- a/tests/services/memory/test_retriever.py
+++ b/tests/services/memory/test_retriever.py
@@ -1,0 +1,194 @@
+"""MemoryRetriever 测试（Phase 2.0.2 读取侧）。
+
+覆盖 BDD 场景 R2/R3/R5/R9/D2/D5 与 format_memory_context。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.services.memory.models import MemoryEntry
+from app.services.memory.retriever import MemoryRetriever
+from app.services.summary.models import SummaryRecord
+
+
+def _entry(run_id: str, summary: str = "昨日看了芙莉莲") -> MemoryEntry:
+    return MemoryEntry(
+        task_type="summary", task_id="summary-daily", run_id=run_id, summary=summary
+    )
+
+
+def _record(consumed_run_ids: set[str] | None = None, **overrides) -> SummaryRecord:
+    defaults = {
+        "id": 1,
+        "timestamp": "2026-08-13 20:00:00",
+        "user_name": "dad",
+        "title": "葬送的芙莉莲",
+        "bgm_title": "葬送的芙莉莲",
+        "season": 1,
+        "episode": 10,
+        "media_type": "episode",
+        "source": "plex",
+        "status": "success",
+        "consumed_run_ids": consumed_run_ids or set(),
+    }
+    defaults.update(overrides)
+    return SummaryRecord(**defaults)
+
+
+def _make_retriever(**repo_mocks) -> tuple[MemoryRetriever, MagicMock]:
+    repo = MagicMock()
+    for k, v in repo_mocks.items():
+        setattr(repo, k, MagicMock(return_value=v))
+    return MemoryRetriever(repo), repo
+
+
+# ── R2 task_type 过滤 / R3 双路径去重 / R9 不占额度 / R5 空关键词 ──────────
+
+
+class TestRetrieve:
+    def test_search_fts_called_with_task_type_filter(self):
+        """R2：FTS 检索必须带 task_type 过滤（跨任务不污染上下文）。"""
+        retriever, repo = _make_retriever(get_recent=[], search_fts=[])
+
+        retriever.retrieve("summary", "summary-daily", keywords=["芙莉莲"])
+
+        repo.search_fts.assert_called_once_with(
+            ["芙莉莲"], task_type="summary", limit=5
+        )
+
+    def test_multi_word_keyword_passed_as_single_phrase(self):
+        """#4 修复：带空格的标题作为整体短语传递（不被空白切碎）。"""
+        retriever, repo = _make_retriever(get_recent=[], search_fts=[])
+
+        retriever.retrieve(
+            "summary", "summary-daily", keywords=["Spy x Family", "芙莉莲"]
+        )
+
+        repo.search_fts.assert_called_once_with(
+            ["Spy x Family", "芙莉莲"], task_type="summary", limit=5
+        )
+
+    def test_deduplicate_by_run_id(self):
+        """R3：同记忆双路径命中（recent + keywords）只注入一次，recent 优先。"""
+        retriever, _ = _make_retriever(
+            get_recent=[_entry("run-a"), _entry("run-b")],
+            search_fts=[_entry("run-b"), _entry("run-c")],
+        )
+
+        result = retriever.retrieve("summary", "summary-daily", keywords=["x"])
+
+        assert [e.run_id for e in result] == ["run-a", "run-b", "run-c"]
+
+    def test_keywords_hits_not_capped_by_limit(self):
+        """R9：keywords 命中不占 memory_limit 额度（recent 5 + 命中 3 = 8）。"""
+        retriever, _ = _make_retriever(
+            get_recent=[_entry(f"r{i}") for i in range(5)],
+            search_fts=[_entry(f"k{i}") for i in range(3)],
+        )
+
+        result = retriever.retrieve("summary", "summary-daily", limit=5, keywords=["x"])
+
+        assert len(result) == 8
+
+    def test_empty_keywords_skips_fts(self):
+        """R5：keywords 含空字符串/None → 过滤掉，FTS 不查空串。"""
+        retriever, repo = _make_retriever(get_recent=[], search_fts=[])
+
+        result = retriever.retrieve(
+            "summary", "summary-daily", keywords=["", None, "  "]
+        )
+
+        assert result == []
+        repo.search_fts.assert_not_called()
+
+    def test_no_keywords_skips_fts(self):
+        retriever, repo = _make_retriever(get_recent=[_entry("run-a")])
+
+        result = retriever.retrieve("summary", "summary-daily")
+
+        assert [e.run_id for e in result] == ["run-a"]
+        repo.search_fts.assert_not_called()
+
+    def test_recent_capped_by_limit(self):
+        """recent 路径受 memory_limit 约束（limit 传给 repo）。"""
+        retriever, repo = _make_retriever(get_recent=[_entry("r1"), _entry("r2")])
+
+        result = retriever.retrieve("summary", "summary-daily", limit=2)
+
+        repo.get_recent.assert_called_once_with("summary", "summary-daily", limit=2)
+        assert len(result) == 2
+
+
+# ── format_memory_context ──────────────────────────────────────────────
+
+
+class TestFormatMemoryContext:
+    def test_each_entry_one_line(self):
+        retriever, _ = _make_retriever()
+        text = retriever.format_memory_context(
+            [_entry("a", "看了芙莉莲"), _entry("b", "用户反馈：不要太啰嗦")]
+        )
+        assert text == "- 看了芙莉莲\n- 用户反馈：不要太啰嗦"
+
+    def test_empty_entries(self):
+        retriever, _ = _make_retriever()
+        assert retriever.format_memory_context([]) == ""
+
+
+# ── D2 重叠识别 / D5 无窗口限制 ────────────────────────────────────────
+
+
+class TestFindOverlaps:
+    def test_returns_only_consumed_records(self):
+        """D2：只返回 consumed_run_ids 非空的记录。"""
+        retriever, _ = _make_retriever()
+        records = [
+            _record(consumed_run_ids={"run-1"}),
+            _record(consumed_run_ids=set(), id=2),
+            _record(consumed_run_ids={"run-3"}, id=3),
+        ]
+
+        overlaps = retriever.find_overlaps(records)
+
+        assert [r.id for r in overlaps] == [1, 3]
+
+    def test_any_old_consumed_record_hits(self):
+        """D5：无窗口限制——任意久远被消费都命中（精确到集）。"""
+        retriever, _ = _make_retriever()
+        records = [_record(consumed_run_ids={"very-old-run-id"}, id=99)]
+
+        overlaps = retriever.find_overlaps(records)
+
+        assert [r.id for r in overlaps] == [99]
+
+    def test_all_new_records_no_overlap(self):
+        retriever, _ = _make_retriever()
+        records = [
+            _record(consumed_run_ids=set()),
+            _record(consumed_run_ids=set(), id=2),
+        ]
+
+        assert retriever.find_overlaps(records) == []
+
+
+class TestGenericMethods:
+    """通用方法 recent/related（retrieve 保留 deprecated，业务合并上移 service）。"""
+
+    def test_recent_delegates_to_repo(self):
+        retriever, repo = _make_retriever()
+        repo.get_recent.return_value = [_entry("run-1")]
+        assert retriever.recent("summary", "summary-daily", limit=3) == [
+            _entry("run-1")
+        ]
+        repo.get_recent.assert_called_once_with("summary", "summary-daily", limit=3)
+
+    def test_related_delegates_to_repo(self):
+        retriever, repo = _make_retriever()
+        repo.get_related_titles.return_value = [_entry("run-9")]
+        assert retriever.related(
+            "summary", "summary-daily", ["葬送的芙莉莲"], limit=2
+        ) == [_entry("run-9")]
+        repo.get_related_titles.assert_called_once_with(
+            "summary", "summary-daily", ["葬送的芙莉莲"], limit=2
+        )

--- a/tests/services/memory/test_service.py
+++ b/tests/services/memory/test_service.py
@@ -1,0 +1,159 @@
+"""MemoryService 测试（Phase 2.0.3 统一入口）。
+
+覆盖：rename_task / clear_task 委托（C1/C3 语义）+ 读写能力收口。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.llm.models import ChatResponse
+from app.services.memory.models import MemoryEntry
+from app.services.memory.service import MemoryService
+from app.services.summary.models import SummaryRecord
+
+
+def _make_db(temp_dir, name="svc.db"):
+    db_path = temp_dir / name
+    with patch("app.core.database.logger"):
+        from app.core.database import DatabaseManager
+
+        return DatabaseManager(str(db_path))
+
+
+def _make_service(db) -> MemoryService:
+    return MemoryService(db.memory)
+
+
+class TestRenameTask:
+    def test_rename_migrates_memory(self, temp_dir, reset_singletons):
+        """C1：经 MemoryService 改名迁移记忆（主表）。"""
+        db = _make_db(temp_dir)
+        db.memory.store_and_mark(
+            MemoryEntry(
+                task_type="summary",
+                task_id="summary-daily",
+                run_id="run-1",
+                summary="s",
+            ),
+            [],
+        )
+        svc = _make_service(db)
+
+        n = svc.rename_task("summary", "summary-daily", "summary-daily2")
+
+        assert n == 1
+        rows = db.memory.get_recent("summary", "summary-daily2")
+        assert [r.run_id for r in rows] == ["run-1"]
+        assert db.memory.get_recent("summary", "summary-daily") == []
+
+
+class TestClearTask:
+    def test_clear_removes_memory_and_marks(self, temp_dir, reset_singletons):
+        """C3：经 MemoryService 清空记忆 + 消费标记。"""
+        db = _make_db(temp_dir)
+        r1 = db.log_sync_record(
+            "dad",
+            "芙莉莲",
+            "",
+            1,
+            1,
+            status="success",
+            source="plex",
+            bgm_title="芙莉莲",
+        )
+        db.memory.store_and_mark(
+            MemoryEntry(
+                task_type="summary",
+                task_id="summary-daily",
+                run_id="run-1",
+                summary="s",
+            ),
+            [r1],
+        )
+        svc = _make_service(db)
+
+        n = svc.clear_task("summary", "summary-daily")
+
+        assert n == 2  # 1 记忆 + 1 消费标记
+        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        assert recs[0]["consumed_run_ids"] == set()
+
+    def test_clear_idempotent(self, temp_dir, reset_singletons):
+        db = _make_db(temp_dir)
+        svc = _make_service(db)
+        assert svc.clear_task("summary", "summary-daily") == 0
+
+
+class TestReadWriteDelegation:
+    @pytest.mark.asyncio
+    async def test_extract_and_store_delegates(self):
+        repo = MagicMock()
+        svc = MemoryService(repo)
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=ChatResponse(content="一句话", model="m"))
+        svc._extractor._llm = llm
+
+        await svc.extract_and_store(
+            task_type="summary",
+            task_id="summary-daily",
+            run_id="run-1",
+            messages=[],
+            response=ChatResponse(content="全文"),
+            outcome="success",
+            tokens_used=10,
+            record_ids=[1],
+        )
+
+        repo.store_and_mark.assert_called_once()
+
+    def test_retrieve_delegates(self):
+        repo = MagicMock()
+        repo.get_recent.return_value = [MemoryEntry(run_id="run-1", summary="s")]
+        svc = MemoryService(repo)
+
+        entries = svc.retrieve("summary", "summary-daily", limit=3, keywords=["芙莉莲"])
+
+        repo.get_recent.assert_called_once_with("summary", "summary-daily", limit=3)
+        assert [e.run_id for e in entries] == ["run-1"]
+
+    def test_format_memory_context(self):
+        svc = MemoryService(MagicMock())
+        text = svc.format_memory_context(
+            [MemoryEntry(run_id="a", summary="看了芙莉莲")]
+        )
+        assert text == "- 看了芙莉莲"
+
+    def test_find_overlaps(self):
+        svc = MemoryService(MagicMock())
+        records = [
+            SummaryRecord(
+                id=1,
+                timestamp="t",
+                user_name="u",
+                title="t",
+                bgm_title="b",
+                season=1,
+                episode=1,
+                media_type="episode",
+                source="s",
+                status="success",
+                consumed_run_ids={"run-1"},
+            ),
+            SummaryRecord(
+                id=2,
+                timestamp="t",
+                user_name="u",
+                title="t",
+                bgm_title="b",
+                season=1,
+                episode=2,
+                media_type="episode",
+                source="s",
+                status="success",
+                consumed_run_ids=set(),
+            ),
+        ]
+        assert [r.id for r in svc.find_overlaps(records)] == [1]

--- a/tests/services/memory/test_service.py
+++ b/tests/services/memory/test_service.py
@@ -9,8 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.memory import MemoryEntry
 from app.services.llm.models import ChatResponse
-from app.services.memory.models import MemoryEntry
 from app.services.memory.service import MemoryService
 from app.services.summary.models import SummaryRecord
 
@@ -78,7 +78,9 @@ class TestClearTask:
         n = svc.clear_task("summary", "summary-daily")
 
         assert n == 2  # 1 记忆 + 1 消费标记
-        recs = db.get_records_in_date_range("2000-01-01", "2100-01-01")
+        recs = db.get_records_in_date_range(
+            "2000-01-01", "2100-01-01", include_consumed=True
+        )
         assert recs[0]["consumed_run_ids"] == set()
 
     def test_clear_idempotent(self, temp_dir, reset_singletons):

--- a/tests/services/summary/test_models.py
+++ b/tests/services/summary/test_models.py
@@ -36,6 +36,8 @@ def test_from_config_dict_defaults_empty():
     assert cfg.user_name == ""
     assert cfg.system_prompt == SummaryJobConfig.system_prompt
     assert cfg.max_records == -1
+    assert cfg.memory_limit == 0  # 默认关闭（0=关）
+    assert cfg.related_limit == 0
 
 
 def test_from_config_dict_defaults_minimal():
@@ -71,6 +73,74 @@ def test_enabled_already_bool():
     assert cfg_true.enabled is True
     cfg_false = SummaryJobConfig.from_config_dict({"name": "t", "enabled": False})
     assert cfg_false.enabled is False
+
+
+# ── memory_limit / related_limit（R6 配置透传，0=关）────────────────────
+
+
+def test_memory_config_parsed():
+    """R6：[summary-xxx] memory_limit=3、related_limit=2 → 透传。"""
+    cfg = SummaryJobConfig.from_config_dict(
+        {"name": "daily", "memory_limit": "3", "related_limit": "2"}
+    )
+    assert cfg.memory_limit == 3
+    assert cfg.related_limit == 2
+
+
+def test_memory_defaults_closed():
+    """缺省 = 0（记忆特性关闭），不隐式开启。"""
+    cfg = SummaryJobConfig.from_config_dict({"name": "t"})
+    assert cfg.memory_limit == 0
+    assert cfg.related_limit == 0
+
+
+def test_memory_limit_scale_0_to_1000():
+    """0=关、1–1000 生效；负值/超 1000/非法回落 0。"""
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "memory_limit": "0"}
+        ).memory_limit
+        == 0
+    )
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "memory_limit": "1000"}
+        ).memory_limit
+        == 1000
+    )
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "memory_limit": "1001"}
+        ).memory_limit
+        == 1000
+    )
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "memory_limit": "-5"}
+        ).memory_limit
+        == 0
+    )
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "memory_limit": "abc"}
+        ).memory_limit
+        == 0
+    )
+
+
+def test_related_limit_scale_0_to_1000():
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "related_limit": "1001"}
+        ).related_limit
+        == 1000
+    )
+    assert (
+        SummaryJobConfig.from_config_dict(
+            {"name": "t", "related_limit": "-1"}
+        ).related_limit
+        == 0
+    )
 
 
 # ── int coercion ──────────────────────────────────────────────────────
@@ -112,3 +182,20 @@ def test_no_user_prompt_template_attribute():
     """user_prompt_template 不应该是 dataclass 的属性。"""
     cfg = SummaryJobConfig.from_config_dict({"name": "t"})
     assert not hasattr(cfg, "user_prompt_template")
+
+
+def test_bad_lookback_days_does_not_crash():
+    """H2：非法 lookback_days/max_records 不抛异常（坏配置不拖垮调度注册）。"""
+    cfg = SummaryJobConfig.from_config_dict(
+        {"name": "t", "lookback_days": "abc", "max_records": "1.5"}
+    )
+    assert cfg.lookback_days == 1  # 回落默认
+    assert cfg.max_records == -1  # 回落默认
+
+
+def test_bad_max_records_negative_ok():
+    """max_records=-1 合法；'abc' 回落 -1。"""
+    cfg = SummaryJobConfig.from_config_dict({"name": "t", "max_records": "-1"})
+    assert cfg.max_records == -1
+    cfg = SummaryJobConfig.from_config_dict({"name": "t", "max_records": "abc"})
+    assert cfg.max_records == -1

--- a/tests/services/summary/test_service.py
+++ b/tests/services/summary/test_service.py
@@ -157,6 +157,56 @@ class TestGenerateSummary:
         assert call_kwargs["user_name"] is None
 
     @pytest.mark.asyncio
+    async def test_include_consumed_true_when_memory_on(self):
+        """P1：memory_limit>0 时传 include_consumed=True（消费排除所需）。"""
+        from app.services.summary.service import SummaryService
+
+        svc = SummaryService()
+        config = _make_config(user_name="dad", memory_limit=5)
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.chat = AsyncMock(return_value=_mock_chat_response())
+
+        with (
+            patch("app.services.summary.service.database_manager") as mock_db,
+            patch(
+                "app.services.summary.service.get_llm_client",
+                return_value=mock_llm_client,
+            ),
+        ):
+            mock_db.get_records_in_date_range.return_value = []
+
+            await svc.generate_summary(config)
+
+        call_kwargs = mock_db.get_records_in_date_range.call_args.kwargs
+        assert call_kwargs["include_consumed"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_consumed_false_when_memory_off(self):
+        """P1：memory_limit=0（默认）时传 include_consumed=False（轻量查询）。"""
+        from app.services.summary.service import SummaryService
+
+        svc = SummaryService()
+        config = _make_config(user_name="dad")  # memory_limit 默认 0
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.chat = AsyncMock(return_value=_mock_chat_response())
+
+        with (
+            patch("app.services.summary.service.database_manager") as mock_db,
+            patch(
+                "app.services.summary.service.get_llm_client",
+                return_value=mock_llm_client,
+            ),
+        ):
+            mock_db.get_records_in_date_range.return_value = []
+
+            await svc.generate_summary(config)
+
+        call_kwargs = mock_db.get_records_in_date_range.call_args.kwargs
+        assert call_kwargs["include_consumed"] is False
+
+    @pytest.mark.asyncio
     async def test_system_prompt_in_messages(self):
         """LLM 被调用时 messages[0].content 为 system_prompt（role='system'）。"""
         from app.services.summary.service import SummaryService


### PR DESCRIPTION
## 📝 PR 描述

### 变更类型
✨ 新功能 (feature)

### 变更内容
本次 PR 为「AI 追番总结」任务新增**记忆上下文核心能力**（写入 → 读取 → 清理闭环），使总结可引用历史结论、避免重复叙述。消费标记采用**多对多关联表**，一条记录可被多个任务的多次总结消费。

**1. 存储层（`agent_working_memory` + 归档 + FTS5）**
- 主表 + 归档冷表（prune 下沉）+ FTS5 虚表 + 同步触发器（tokenizer 优先 trigram，SQLite <3.34 自动降级 unicode61）。
- **多对多消费标记 `sync_records_consumed`**（`sync_record_id, run_id` 复合主键）：一条记录可被多个任务的 run 消费，互不覆盖（INSERT OR IGNORE 幂等）——修复原单列 `consumed_run_id`「记录只能被一个 summary 消费」的限制。
- `store_and_mark`：记忆条目与消费标记**同一事务原子写入**，消除「记忆已写但标记未写」的中间态。

**2. 读取**
- `get_recent`：最近 N 条摘要（连续性）。
- `get_related_titles`：主表+归档 UNION 联表反查，跨窗口同剧回忆。
- `get_task_run_ids`：按任务取全部 run_id（消费排除按任务隔离）。

**3. 清理与生命周期**
- `prune`（保留 1000 条下沉归档）/ `rename_task`（改名迁移记忆）/ `clear_task`（主表+归档+关联表同一事务清空，跨任务隔离，不留孤儿数据）。

**4. 服务层 + 类型**
- `MemoryExtractor`（LLM 提炼一行摘要 + 全文留档，摘要失败/空响应跳过不写，零截断）。
- `MemoryRetriever` / `MemoryService` 门面。
- `SummaryRecord` 类型化（summary 链路观影记录载体，含 `consumed_run_ids: set`）；`SummaryJobConfig` 增加 `memory_limit`/`related_limit`（0=关，0–1000 钳制）与 H2 坏配置回落。

### 相关 Issue
无（与 PR #244  `feat/llm-resilience` 为同系列，本 PR 依赖其基础）

## 🔍 额外说明
- 无运行时依赖变更；`sqlite3` 为标准库（SQLite 版本仅影响 trigram 物理索引健康，降级分支有 warning 日志）。
- 全量测试：**3568 passed**（`tests/core/test_agent_memory.py` + `tests/services/memory/*` + `tests/core/test_database*.py` + `tests/services/summary/test_models.py`）；Ruff check + format 全绿。
- 本分支基于最新 `main`，行为由 `memory_limit`/`related_limit` 门控（默认 0=关），存量行为零变化。

## Checklist
- [x] 行为由 `memory_limit`/`related_limit` 门控（默认关闭）——无破坏性变更
- [x] 测试通过（3568 passed）+ Ruff 全绿
- [x] `requirements.txt` 未动
