### PR TITLE
refactor: llm 健壮性增强

### DIFF
--- a/app/api/llm.py
+++ b/app/api/llm.py
@@ -59,23 +59,31 @@ async def update_llm_config(
 
 @router.post("/test", response_model=LLMTestResponse)
 async def test_llm_connection(_=Depends(get_current_user_flexible)):
-    """发送简单 ping 验证 LLM 连通性。"""
+    """发送简单 ping 验证 LLM 连通性（短回复，避免完整生成等待）。
+
+    连通性验证语义：不展示回复正文（短回复会被 max_tokens 截停，展示半截句
+    反而迷惑）；只返回 成功/模型/延迟。max_tokens=8 让模型在第 8 个 token
+    处被 API 截停——服务端不会"生成后丢弃"，只是限制生成长度，延迟显著低于
+    完整回复。
+    """
     try:
         client = get_llm_client()
         t0 = time.time()
         response = await client.chat(
-            [Message(role="user", content="Hello")],
+            [Message(role="user", content="ping")],
             job_name="llm_test",
+            max_tokens=8,
         )
         latency = int((time.time() - t0) * 1000)
         # chat() 永不抛异常，重试耗尽时返回空响应
-        if not response.model and not response.content:
+        # H1：仅以 content 是否为空判定失败（model 存在但 content 为空仍算失败）
+        if not response.content:
             return LLMTestResponse(
                 success=False, message="LLM 调用失败（所有重试已耗尽）"
             )
         return LLMTestResponse(
             success=True,
-            message=response.content[:200],
+            message="连接成功",  # 不含回复正文（短回复截停无展示价值）
             model=response.model,
             latency_ms=latency,
         )

--- a/app/services/llm/client.py
+++ b/app/services/llm/client.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import time
 
+import httpx
+
 from app.core.config import config_manager
 from app.core.logging import logger
 
@@ -35,6 +37,67 @@ def _format_error_detail(e: Exception) -> str:
     return " ".join(parts)
 
 
+# 端点拒绝扩展参数的响应特征（大小写不敏感子串匹配）。
+# OpenAI: "Unrecognized request argument supplied: reasoning_effort"；
+# Anthropic: invalid_request_error；网关实现各异 —— 以宽泛特征兕底。
+# M8：模式串含 Anthropic 文案；状态码放行 400/422（pydantic 网关）。
+_PARAM_REJECTION_PATTERNS = (
+    "unrecognized",
+    "unknown parameter",
+    "unexpected keyword",
+    "invalid request argument",
+    "extra fields not permitted",
+    "invalid_request_error",
+    "does not support",
+)
+
+_PARAM_REJECTION_STATUSES = (400, 422)
+
+
+def _is_param_rejection(e: Exception) -> bool:
+    """识别"端点不支持某请求参数"类错误（区别于鉴权/格式错误）。"""
+    if not isinstance(e, httpx.HTTPStatusError):
+        return False
+    resp = getattr(e, "response", None)
+    if resp is None or resp.status_code not in _PARAM_REJECTION_STATUSES:
+        return False
+    text = (resp.text or "").lower()
+    return any(p in text for p in _PARAM_REJECTION_PATTERNS)
+
+
+# M7/M9：确定性错误 —— 重试无意义（refusal / 鉴权 / 参数类 / 不存在）
+_TERMINAL_STATUSES = (400, 401, 403, 404, 422)
+
+
+def _is_terminal_error(e: Exception) -> bool:
+    """refusal（ValueError）与确定性 4xx 不重试；其余（429/5xx/超时）可重试。"""
+    if isinstance(e, ValueError):
+        return True  # 解析失败/refusal，重试结果不变
+    if isinstance(e, httpx.HTTPStatusError):
+        resp = getattr(e, "response", None)
+        status = getattr(resp, "status_code", None)
+        if status in _TERMINAL_STATUSES:
+            # 参数类 400/422 由调用方先走降级路径，此处仅兜底其它确定性 4xx
+            return not _is_param_rejection(e)
+    return False
+
+
+def _retry_delay(e: Exception, fallback: int) -> int:
+    """429 优先读取 Retry-After（秒）；其余用固定退避。
+
+    顺手项 2：Retry-After 钳制到 60s 上限，避免恶意/异常端点返回超大值导致
+    请求长时间挂起（退避本就只用于吸收短暂限流，过长无收益）。
+    """
+    _RETRY_AFTER_CAP = 60
+    if isinstance(e, httpx.HTTPStatusError):
+        resp = getattr(e, "response", None)
+        if resp is not None and getattr(resp, "status_code", None) == 429:
+            ra = resp.headers.get("Retry-After")
+            if ra and ra.isdigit():
+                return min(int(ra), _RETRY_AFTER_CAP)
+    return fallback
+
+
 def _build_provider(
     provider: str, cfg: dict[str, object], proxy: str | None
 ) -> BaseProvider:
@@ -52,10 +115,9 @@ def _build_provider(
         "temperature": cfg["temperature"],
         "timeout": cfg["timeout"],
         "proxy": proxy,
+        # 双 provider 构造函数均接受 thinking_level（openai 侧映射 reasoning_effort）
+        "thinking_level": cfg.get("thinking_level", "off"),
     }
-    # thinking_level 只传给 anthropic 分支（openai 分支构造函数无此参数）
-    if provider == "anthropic_compat":
-        kwargs["thinking_level"] = cfg.get("thinking_level", "off")
     return cls(**kwargs)
 
 
@@ -95,12 +157,15 @@ class LLMClient:
             成功时返回 ChatResponse，所有重试耗尽时返回空的 ChatResponse。
         """
         last_error: Exception | None = None
-        t_start = time.time()
+        # L8：latency 只计量成功那次请求（不含退避睡眠墙钟）
+        t_attempt = time.time()
+        attempt = 0
+        extras_degraded = False  # 参数类 400 降级只做一次，不计入退避次数
 
-        for attempt in range(self.MAX_RETRIES + 1):
+        while attempt <= self.MAX_RETRIES:
             try:
                 response = await self._provider.chat(messages, **kwargs)
-                latency_ms = int((time.time() - t_start) * 1000)
+                latency_ms = int((time.time() - t_attempt) * 1000)
                 response.latency = latency_ms
                 self._log_success(response, job_id=job_id, job_name=job_name)
                 logger.debug(
@@ -111,16 +176,34 @@ class LLMClient:
                 return response
             except Exception as e:
                 last_error = e
+                # 双重保险第二道：端点拒绝扩展参数（thinking/reasoning 等）→
+                # 置位降级标记后立即重试（该 provider 实例生命周期内不再发送）
+                if not extras_degraded and _is_param_rejection(e):
+                    extras_degraded = True
+                    if hasattr(self._provider, "_extras_disabled"):
+                        self._provider._extras_disabled = True
+                    logger.warning(
+                        "LLM endpoint rejected extra params, "
+                        f"degraded retry without them: {_format_error_detail(e)}"
+                    )
+                    # 顺手项 1：降级重试前重置计时，避免把首次失败请求的耗时计入 latency
+                    t_attempt = time.time()
+                    continue
+                # M7/M9：确定性错误（refusal/鉴权/参数类）不重试
+                if _is_terminal_error(e):
+                    break
                 if attempt < self.MAX_RETRIES:
-                    delay = self.RETRY_BACKOFF[attempt]
+                    delay = _retry_delay(e, self.RETRY_BACKOFF[attempt])
                     logger.warning(
                         f"LLM retry {attempt + 1}/{self.MAX_RETRIES} "
                         f"after {delay}s: {_format_error_detail(e)}"
                     )
                     await asyncio.sleep(delay)
+                attempt += 1
+                t_attempt = time.time()  # L8：重试后重新计时
 
-        # 所有重试耗尽 —— 记录错误并返回空响应
-        latency_ms = int((time.time() - t_start) * 1000)
+        # 所有重试耗尽 —— 记录错误并返回空响应（latency 仅最后尝试耗时）
+        latency_ms = int((time.time() - t_attempt) * 1000)
         error_detail = _format_error_detail(last_error) if last_error else "unknown"
         logger.error(
             f"LLM call failed after {self.MAX_RETRIES} retries: {error_detail}"

--- a/app/services/llm/client.py
+++ b/app/services/llm/client.py
@@ -38,18 +38,27 @@ def _format_error_detail(e: Exception) -> str:
 
 
 # 端点拒绝扩展参数的响应特征（大小写不敏感子串匹配）。
-# OpenAI: "Unrecognized request argument supplied: reasoning_effort"；
-# Anthropic: invalid_request_error；网关实现各异 —— 以宽泛特征兕底。
-# M8：模式串含 Anthropic 文案；状态码放行 400/422（pydantic 网关）。
+# 模式串已收窄到具体短语，避免网关无关文案（如 "model does not support streaming"、
+# "unrecognized model"）被误判为参数拒绝。
+# OpenAI canonical: "Unrecognized request argument supplied: <param>" → "unrecognized request argument"；
+# 网关变体: "unrecognized parameter '<param>' is not supported" → "unrecognized parameter"。
+# thinking/reasoning 类: "does not support thinking" / "does not support reasoning"。
+# 其余（unknown parameter / unexpected keyword / invalid request argument / extra fields not permitted）保持裸短语。
+# M8：状态码放行 400/422（pydantic 网关）。
 _PARAM_REJECTION_PATTERNS = (
-    "unrecognized",
+    "unrecognized request argument",
+    "unrecognized parameter",
     "unknown parameter",
     "unexpected keyword",
     "invalid request argument",
     "extra fields not permitted",
-    "invalid_request_error",
-    "does not support",
+    "does not support thinking",
+    "does not support reasoning",
 )
+
+# Anthropic invalid_request_error 覆盖过广（消息格式错误等无关 400 也用该 type），
+# 须与扩展参数关键字组合才判定为参数拒绝。
+_PARAM_KEYWORDS = ("thinking", "reasoning", "budget_tokens")
 
 _PARAM_REJECTION_STATUSES = (400, 422)
 
@@ -62,7 +71,10 @@ def _is_param_rejection(e: Exception) -> bool:
     if resp is None or resp.status_code not in _PARAM_REJECTION_STATUSES:
         return False
     text = (resp.text or "").lower()
-    return any(p in text for p in _PARAM_REJECTION_PATTERNS)
+    if any(p in text for p in _PARAM_REJECTION_PATTERNS):
+        return True
+    # 复合判定：Anthropic invalid_request_error + 扩展参数关键字
+    return "invalid_request_error" in text and any(k in text for k in _PARAM_KEYWORDS)
 
 
 # M7/M9：确定性错误 —— 重试无意义（refusal / 鉴权 / 参数类 / 不存在）

--- a/app/services/llm/providers/anthropic.py
+++ b/app/services/llm/providers/anthropic.py
@@ -145,9 +145,14 @@ class AnthropicProvider(BaseProvider):
         if system_parts:
             body["system"] = "\n\n".join(system_parts)
 
-        # thinking_level：每任务 kwargs 覆盖 > 全局默认；模型不支持时降级
+        # thinking_level：每任务 kwargs 覆盖 > 全局默认；模型不支持时降级；
+        # 端点拒绝过扩展参数时（_extras_disabled）不再发送
         level = kwargs.get("thinking_level", self.thinking_level)
-        budget = self._thinking_enabled(level, kwargs.get("model", self.model))
+        budget = (
+            0
+            if self._extras_disabled
+            else self._thinking_enabled(level, kwargs.get("model", self.model))
+        )
         if budget > 0:
             body["thinking"] = {"type": "enabled", "budget_tokens": budget}
             # Anthropic 约束：budget_tokens 必须小于 max_tokens，且 max_tokens
@@ -164,7 +169,8 @@ class AnthropicProvider(BaseProvider):
 
     def _thinking_enabled(self, level: str, model: str) -> int:
         """返回 budget_tokens；模型不支持或 level=off 时返回 0。"""
-        if model.startswith("claude-haiku"):
+        # 包含匹配而非前缀：兼容网关透传的带前缀模型名（如 "anthropic/claude-haiku-..."）
+        if "claude-haiku" in model:
             logger.warning(f"model {model} 不支持 extended thinking，已降级为 off")
             return 0
         return self._THINKING_BUDGETS.get(level, 0)

--- a/app/services/llm/providers/base.py
+++ b/app/services/llm/providers/base.py
@@ -14,7 +14,14 @@ class BaseProvider(ABC):
 
     子类必须实现 async chat() 方法，接收消息列表和额外关键字参数，
     返回 ChatResponse。
+
+    Attributes:
+        _extras_disabled: 端点拒绝扩展参数（thinking/reasoning 等）后由
+            LLMClient 置位的降级标记——置位后 _build_request 不再构造
+            扩展字段（双重保险第二道，见 client._is_param_rejection）。
     """
+
+    _extras_disabled: bool = False
 
     @abstractmethod
     async def chat(self, messages: list[Message], **kwargs: Any) -> ChatResponse:

--- a/app/services/llm/providers/openai_compat.py
+++ b/app/services/llm/providers/openai_compat.py
@@ -2,12 +2,27 @@
 
 基于 httpx 实现的 BaseProvider，与任何遵循 OpenAI /v1/chat/completions
 API 规范的端点通信。
+
+内部中立模型 → OpenAI wire 格式的差异收敛在 _build_request /
+_parse_response 两个方法内（与 AnthropicProvider 结构对称）：
+- content 为 list[ContentBlock] 时取 text block 拼接（OpenAI wire 为字符串；
+  thinking/tool 等 block 不适用于当前端点）
+- thinking_level → reasoning_effort（仅 o 系列模型生效，其余忽略并告警）
 """
 
-from typing import Any, Optional
+from __future__ import annotations
+
+import re
+from typing import Any
 
 from app.core.logging import logger
-from app.services.llm.models import ChatResponse, Message, Usage
+from app.services.llm.models import (
+    ChatResponse,
+    Message,
+    TextBlock,
+    ThinkingLevel,
+    Usage,
+)
 from app.services.llm.providers.base import BaseProvider
 from app.utils.http_client import create_async_client
 
@@ -24,7 +39,17 @@ class OpenAICompatProvider(BaseProvider):
         max_tokens: 补全的默认最大 token 数。
         temperature: 默认采样温度。
         timeout: 请求超时时间（秒）。
+        proxy: 可选的 HTTP 代理 URL。
+        thinking_level: 思考强度 off/low/medium/high（映射 reasoning_effort，
+            仅 o 系列模型生效；每任务 kwargs 可覆盖）。
     """
+
+    # thinking_level → OpenAI reasoning_effort 映射（off 不传 = 现状行为）
+    _REASONING_EFFORT: dict[str, str] = {
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+    }
 
     def __init__(
         self,
@@ -34,7 +59,8 @@ class OpenAICompatProvider(BaseProvider):
         max_tokens: int = 2000,
         temperature: float = 0.7,
         timeout: int = 60,
-        proxy: Optional[str] = None,
+        proxy: str | None = None,
+        thinking_level: ThinkingLevel = "off",
     ) -> None:
         """初始化 OpenAI 兼容 provider。
 
@@ -46,6 +72,7 @@ class OpenAICompatProvider(BaseProvider):
             temperature: 采样温度 (0.0-2.0)。
             timeout: HTTP 请求超时时间（秒）。
             proxy: 可选的 HTTP 代理 URL。
+            thinking_level: 思考强度（reasoning_effort 映射，仅 o 系列）。
         """
         self.api_base = api_base.rstrip("/")
         self.api_key = api_key
@@ -54,6 +81,7 @@ class OpenAICompatProvider(BaseProvider):
         self.temperature = temperature
         self.timeout = timeout
         self.proxy = proxy
+        self.thinking_level = thinking_level
 
     async def chat(self, messages: list[Message], **kwargs: Any) -> ChatResponse:
         """向 API 发送聊天补全请求。
@@ -78,12 +106,7 @@ class OpenAICompatProvider(BaseProvider):
             f"timeout={self.timeout}s{proxy_label}"
         )
 
-        body = {
-            "model": model,
-            "messages": [{"role": m.role, "content": m.content} for m in messages],
-            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
-            "temperature": kwargs.get("temperature", self.temperature),
-        }
+        body = self._build_request(messages, **kwargs)
 
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -104,10 +127,75 @@ class OpenAICompatProvider(BaseProvider):
             response.raise_for_status()
             data = response.json()
 
+        return self._parse_response(data)
+
+    def _build_request(self, messages: list[Message], **kwargs: Any) -> dict:
+        """内部模型 → OpenAI wire 格式（请求体）。"""
+        body: dict[str, Any] = {
+            "model": kwargs.get("model", self.model),
+            "messages": [self._to_wire_message(m) for m in messages],
+            "max_tokens": kwargs.get("max_tokens", self.max_tokens),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        # thinking_level：每任务 kwargs 覆盖 > 全局默认；非 o 系列模型忽略并告警；
+        # 端点拒绝过扩展参数时（_extras_disabled）不再发送
+        level = kwargs.get("thinking_level", self.thinking_level)
+        effort = (
+            None
+            if self._extras_disabled
+            else self._reasoning_effort(level, body["model"])
+        )
+        if effort is not None:
+            body["reasoning_effort"] = effort
+            # H3：o 系列推理模型拒绝非 1 的 temperature（硬 400），
+            # 与 Anthropic thinking 开启时的处理对齐（anthropic.py 强制 1）
+            body["temperature"] = 1
+        return body
+
+    def _to_wire_message(self, m: Message) -> dict:
+        """内部消息 → OpenAI wire 消息（content 为字符串）。
+
+        content 为 list[ContentBlock] 时取 text block 拼接（与 Anthropic 侧
+        _system_text 同一分隔语义）；thinking/tool 等 block 不适用于当前端点，
+        跳过（正式工具协议见 Phase 4）。
+        """
+        if isinstance(m.content, str):
+            return {"role": m.role, "content": m.content}
+        parts = [b.text for b in m.content if isinstance(b, TextBlock)]
+        skipped = len(m.content) - len(parts)
+        if skipped:
+            logger.debug(
+                f"OpenAI wire 不支持 {skipped} 个非 text content block，已跳过"
+            )
+        return {"role": m.role, "content": "\n\n".join(parts)}
+
+    def _reasoning_effort(self, level: str, model: str) -> str | None:
+        """thinking_level → reasoning_effort；off/不支持时返回 None（不传字段）。"""
+        if level == "off":
+            return None
+        # reasoning_effort 仅 o 系列模型支持（o1/o3/o4-mini 等）。用 ^o\d 而非
+        # startswith("o")：避免 "ollama/…"、"openrouter/…" 等第三方网关模型名
+        # 误中导致向不支持的端点发送未知参数。OpenAI 对未知参数的行为因 API 版本
+        # 而异，不冒险传给非 o 系列。
+        if not re.match(r"^o\d", model):
+            # L6：配置/模型不匹配是静态事实，warning 刷屏无益——降为 debug
+            # （用户可通过 stats/日志在调优期定位）
+            logger.debug(
+                f"model {model} 非 o 系列不支持 reasoning_effort，"
+                f"已忽略 thinking_level={level}"
+            )
+            return None
+        return self._REASONING_EFFORT.get(level)
+
+    def _parse_response(self, data: dict) -> ChatResponse:
+        """OpenAI wire 格式 → 内部模型。"""
         choice = data["choices"][0]
         message = choice.get("message", {})
         content = message.get("content")
         refusal = message.get("refusal")
+        # M10：finish_reason → stop_reason（与 Anthropic 对齐，P4 判断 max_tokens 截断用）
+        stop_reason = choice.get("finish_reason") or ""
 
         if content is None:
             if refusal:
@@ -115,7 +203,7 @@ class OpenAICompatProvider(BaseProvider):
             content = ""
         model = data.get("model", "")
 
-        usage: Optional[Usage] = None
+        usage: Usage | None = None
         if "usage" in data:
             u = data["usage"]
             usage = Usage(
@@ -124,4 +212,6 @@ class OpenAICompatProvider(BaseProvider):
                 total_tokens=u.get("total_tokens", 0),
             )
 
-        return ChatResponse(content=content, model=model, usage=usage)
+        return ChatResponse(
+            content=content, model=model, usage=usage, stop_reason=stop_reason
+        )

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -200,8 +200,8 @@ LLM 连接是独立模块，追番总结和调试工具共用。在「配置管�
 - **API 密钥（api_key）**：服务商提供的 API Key。**加密存储**，页面回显为掩码。
 - **模型（model）**：要调用的模型名称，默认 `gpt-4o-mini`。`openai_compat` 请确认模型支持 Chat Completions 接口；`anthropic_compat` 请填写 Claude 模型（如 `claude-sonnet-4-6`、`claude-opus-4-6` 等）。
 - **最大 Token（max_tokens）**：单次请求最大输出 token 数，默认 2000。根据模型上下文窗口和总结长度调整。Anthropic Messages API 的 max_tokens 为必填字段，请保持不小于所需输出长度。开启思考强度时该值会被自动抬升到不低于 `budget_tokens + 1024`（Anthropic 约束：思考 token 计入 max_tokens 上限，`budget_tokens` 必须小于 `max_tokens`），无需手动调大。
-- **温度（temperature）**：生成随机性，0~2 之间，默认 0.7。越低越确定/保守，越高越有创意。注意 `anthropic_compat` 开启思考后该值会被强制为 1（Anthropic API 要求）。
-- **思考强度（thinking_level）**：仅 `anthropic_compat` 生效，可选 `off` / `low` / `medium` / `high`，默认 `off` 不启用思考。开启后映射为 Anthropic extended thinking 的 `budget_tokens`（依次为 2048 / 4096 / 8192），`low` 适合日常总结，高质量总结可试 `high`。`claude-haiku` 系列等不支持 extended thinking 的模型会自动降级为 `off`（日志有提示）。
+- **温度（temperature）**：生成随机性，0~2 之间，默认 0.7。越低越确定/保守，越高越有创意。注意开启思考后该值会被强制为 1（Anthropic 与 OpenAI o 系列均要求）。
+- **思考强度（thinking_level）**：可选 `off` / `low` / `medium` / `high`，默认 `off` 不启用思考。`anthropic_compat` 开启后映射为 Anthropic extended thinking 的 `budget_tokens`（依次为 2048 / 4096 / 8192），`low` 适合日常总结，高质量总结可试 `high`；`claude-haiku` 系列等不支持 extended thinking 的模型会自动降级为 `off`（日志有提示）。`openai_compat` 开启后映射为 OpenAI `reasoning_effort`（`low` / `medium` / `high`），仅 o 系列推理模型（o1/o3/o4-mini 等）生效，其余模型自动忽略（debug 日志有提示）。
 - **超时时间（timeout）**：请求超时秒数，默认 60。遇到超时错误可适当调大。
 - **调用记录保留（retention_days）**：LLM 调用记录（Token 用量、延迟等）在数据库中保留天数，默认 365 天。
 

--- a/static/js/api-utils.js
+++ b/static/js/api-utils.js
@@ -23,6 +23,43 @@ function appUrl(path) {
  * @param {string} path 站内路径，会自动拼接 appUrl
  * @param {object} options fetch options，可附加 skipAuthRedirect / returnResponse
  */
+/**
+ * 将后端错误响应体归一化为人类可读的纯字符串。
+ *
+ * 处理多种响应形态：
+ * - detail 为字符串（如 HTTPException 的 detail）
+ * - detail 为对象数组（FastAPI 422 校验错误，每项含 msg 与 loc）
+ * - detail 为单对象（含 message/msg）
+ * - 顶层 message 兜底
+ * 任何分支都保证返回字符串，杜绝 [object Object]。
+ */
+function apiErrorMessage(errData, fallback) {
+    const detail = errData && errData.detail;
+    if (typeof detail === 'string' && detail) return detail;
+    if (Array.isArray(detail)) {
+        // FastAPI 422 校验错误：提取各条 msg，附字段名（loc 末段）
+        const parts = detail
+            .map(function (e) {
+                if (!e || typeof e !== 'object') return String(e);
+                const loc = Array.isArray(e.loc) ? e.loc : [];
+                const field = loc.length ? String(loc[loc.length - 1]) : '';
+                const msg = typeof e.msg === 'string' ? e.msg : '';
+                if (field && msg) return field + ': ' + msg;
+                if (msg) return msg;
+                return JSON.stringify(e);
+            })
+            .filter(function (s) { return s; });
+        if (parts.length) return parts.join('; ');
+    }
+    if (detail && typeof detail === 'object') {
+        if (typeof detail.message === 'string' && detail.message) return detail.message;
+        if (typeof detail.msg === 'string' && detail.msg) return detail.msg;
+        try { return JSON.stringify(detail); } catch (_) {}
+    }
+    if (typeof errData.message === 'string' && errData.message) return errData.message;
+    return fallback;
+}
+
 async function apiFetch(path, options = {}) {
     const opts = { credentials: 'include', ...options };
     const response = await fetch(appUrl(path), opts);
@@ -33,10 +70,11 @@ async function apiFetch(path, options = {}) {
     }
 
     if (!response.ok && !opts.returnResponse) {
-        let msg = `请求失败: ${response.status}`;
+        const fallback = `请求失败: ${response.status}`;
+        let msg = fallback;
         try {
             const errData = await response.json();
-            msg = errData.detail || errData.message || msg;
+            msg = apiErrorMessage(errData, fallback);
         } catch (_) {}
         throw new Error(msg);
     }
@@ -48,3 +86,4 @@ async function apiFetch(path, options = {}) {
 
 window.appUrl = appUrl;
 window.apiFetch = apiFetch;
+window.apiErrorMessage = apiErrorMessage;

--- a/templates/config/_llm.html
+++ b/templates/config/_llm.html
@@ -3,17 +3,23 @@
         <div class="d-flex align-items-center">
             <i class="bi bi-robot me-2 card-header-icon"></i>
             <h6 class="m-0 fw-semibold card-header-title">LLM 配置</h6>
+            <i class="bi bi-question-circle ms-1 text-muted"
+               data-bs-toggle="tooltip"
+               title="请使用您信任的 LLM 服务提供商。API 密钥将加密存储，测试连接会产生少量 Token 消耗。"></i>
         </div>
     </div>
     <div class="card-body">
         <div class="row g-3">
             <div class="col-md-6">
-                <label class="form-label">API 地址</label>
+                <label class="form-label">API 地址
+                    <i class="bi bi-question-circle ms-1 text-muted"
+                       data-bs-toggle="tooltip"
+                       title="OpenAI 兼容接口请以 /v1 结尾填写完整地址, 具体以 Provider 文档为准"></i>
+                </label>
                 <input class="form-control"
                        id="llm-api-base"
                        name="llm.api_base"
                        placeholder="https://api.openai.com/v1">
-                <small class="text-muted">OpenAI 兼容接口请以 /v1 结尾填写完整地址, 具体以 Provider 文档为准</small>
             </div>
             <div class="col-md-6">
                 <label class="form-label">API 密钥</label>
@@ -31,14 +37,17 @@
                 </select>
             </div>
             <div class="col-md-6">
-                <label class="form-label">思考强度</label>
+                <label class="form-label">思考强度
+                    <i class="bi bi-question-circle ms-1 text-muted"
+                       data-bs-toggle="tooltip"
+                       title="off/low/medium/high；anthropic_compat 映射 extended thinking 的 budget_tokens（2048/4096/8192），openai_compat 映射 reasoning_effort（仅 o 系列模型生效，其余模型自动忽略）"></i>
+                </label>
                 <select class="form-select" id="llm-thinking-level" name="llm.thinking_level">
                     <option value="off">off</option>
                     <option value="low">low</option>
                     <option value="medium">medium</option>
                     <option value="high">high</option>
                 </select>
-                <small class="text-muted">仅 anthropic_compat 生效，映射为 Anthropic extended thinking 的 budget_tokens（2048/4096/8192），OpenAI 侧暂不支持</small>
             </div>
             <div class="col-md-4">
                 <label class="form-label">模型</label>
@@ -81,9 +90,6 @@
                 </button>
             </div>
         </div>
-        <p class="text-muted small mt-3 mb-0">
-            <i class="bi bi-info-circle me-1"></i>请使用您信任的 LLM 服务提供商。API 密钥将加密存储，测试连接会产生少量 Token 消耗。
-        </p>
     </div>
 </div>
 </div>

--- a/tests/api/test_config_page_comments.py
+++ b/tests/api/test_config_page_comments.py
@@ -1,0 +1,135 @@
+"""
+配置页注释悬浮化改造测试（LLM 卡片部分）
+
+目标：验证 config 页面 LLM 卡片中原本以 ``<small class="text-muted">`` 平铺的
+注释，全部改为 label/按钮旁的问号图标
+（``<i class="bi bi-question-circle ms-1 text-muted" data-bs-toggle="tooltip" title="...">``）。
+
+参照：``templates/config/_bangumi_data.html`` 中"使用本地缓存"的写法。
+
+改造已实现，本文件的测试当前全部通过（绿）。
+"""
+
+import re
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api import pages
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+
+def _fetch_config_html():
+    """以已认证用户访问 /config，返回 (full_text, llm_segment, modal_segment)。
+
+    - llm_segment：``#config-section-llm`` 到 ``#config-section-summary`` 之间，即 LLM 配置卡片。
+    - modal_segment：``#summaryJobModal`` 到 ``#deleteSummaryModal`` 之间，即追番总结任务弹窗。
+    """
+    app = FastAPI()
+    app.include_router(pages.router)
+    with patch.object(
+        pages, "get_current_user_from_cookie", return_value={"username": "u"}
+    ):
+        client = TestClient(app)
+        response = client.get("/config", follow_redirects=False)
+    assert response.status_code == 200, f"期望 200，实际 {response.status_code}"
+    text = response.text
+
+    llm_start = text.index('id="config-section-llm"')
+    llm_end = text.index('id="config-section-summary"')
+    llm_segment = text[llm_start:llm_end]
+
+    modal_start = text.index('id="summaryJobModal"')
+    modal_end = text.index('id="deleteSummaryModal"')
+    modal_segment = text[modal_start:modal_end]
+
+    return text, llm_segment, modal_segment
+
+
+# 问号图标 + tooltip + title（不要求 data-bs-container）
+TOOLTIP_RE = re.compile(
+    r"<i\b"
+    r"(?=[^>]*\bbi-question-circle\b)"
+    r'(?=[^>]*data-bs-toggle="tooltip")'
+    r'[^>]*?title="([^"]*)"',
+    re.DOTALL,
+)
+
+
+def _find_tooltip_title(segment, key):
+    """在 segment 中查找 title 含 key 的问号 tooltip 图标，返回其 title 或 None。"""
+    for m in TOOLTIP_RE.finditer(segment):
+        if key in m.group(1):
+            return m.group(1)
+    return None
+
+
+def _slice_between(text, start_marker, end_marker):
+    """截取 text 中 start_marker 到 end_marker 之间的片段（不含 end_marker 本身）。"""
+    s = text.index(start_marker)
+    e = text.index(end_marker)
+    return text[s:e]
+
+
+# ---------------------------------------------------------------------------
+# LLM 卡片：3 处图标
+# ---------------------------------------------------------------------------
+
+
+def test_llm_api_base_comment_becomes_tooltip_icon():
+    """LLM 卡片 API 地址 label 旁应出现问号图标，title 含原文注释。"""
+    _, llm, _ = _fetch_config_html()
+    title = _find_tooltip_title(llm, "OpenAI 兼容接口请以 /v1 结尾填写完整地址")
+    assert title is not None, (
+        "LLM 卡片『API 地址』旁应出现问号图标，title 含『OpenAI 兼容接口请以 /v1 结尾填写完整地址』"
+    )
+
+
+def test_llm_thinking_level_comment_becomes_tooltip_icon():
+    """LLM 卡片 思考强度 label 旁应出现问号图标，title 同时覆盖双 provider 映射。"""
+    _, llm, _ = _fetch_config_html()
+    title = _find_tooltip_title(llm, "reasoning_effort")
+    assert title is not None, (
+        "LLM 卡片『思考强度』旁应出现问号图标，title 含『reasoning_effort』"
+    )
+    assert "budget_tokens" in title, (
+        "思考强度图标 title 需同时含『budget_tokens』，实际 title={title!r}"
+    )
+
+
+def test_llm_card_title_comment_becomes_tooltip_icon():
+    """LLM 卡片标题『LLM 配置』旁应出现问号图标，title 含原底部安全提示。"""
+    _, llm, _ = _fetch_config_html()
+    title = _find_tooltip_title(llm, "API 密钥将加密存储")
+    assert title is not None, (
+        "LLM 卡片标题『LLM 配置』旁应出现问号图标，title 含原底部安全提示『API 密钥将加密存储』"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 原有 <small class="text-muted"> 平铺注释应被移除
+# ---------------------------------------------------------------------------
+
+
+def test_llm_card_has_no_small_text_muted():
+    """LLM 卡片片段内不应再出现 <small class="text-muted"> 平铺注释。"""
+    _, llm, _ = _fetch_config_html()
+    assert '<small class="text-muted">' not in llm, (
+        'LLM 卡片内不应再出现 <small class="text-muted"> 平铺注释'
+    )
+
+
+# ---------------------------------------------------------------------------
+# 边界：无注释字段不新增图标
+# ---------------------------------------------------------------------------
+
+
+def test_llm_api_key_field_has_no_tooltip():
+    """API 密钥（llm-api-key）字段所在段不应新增悬浮注释图标。"""
+    text, _, _ = _fetch_config_html()
+    seg = _slice_between(text, 'id="llm-api-key"', 'id="llm-provider"')
+    assert 'data-bs-toggle="tooltip"' not in seg, "API 密钥字段不应新增悬浮注释图标"

--- a/tests/api/test_summary.py
+++ b/tests/api/test_summary.py
@@ -735,9 +735,18 @@ class TestTestLLMConnection:
                 assert response.status_code == 200
                 data = response.json()
                 assert data["success"] is True
-                assert "Hello! How can I help you?" in data["message"]
+                # 响应不含回复正文（S12：message 为固定文案，短回复截停无展示价值）
+                assert data["message"] == "连接成功"
+                assert "Hello! How can I help you?" not in data["message"]
                 assert data["model"] == "gpt-4o-mini"
                 assert data["latency_ms"] is not None
+                # 连通性 ping 应限制生成长度（max_tokens=8）且 prompt 极简
+                call_kwargs = mock_client.chat.await_args.kwargs
+                assert call_kwargs["max_tokens"] == 8
+                assert call_kwargs["job_name"] == "llm_test"
+                msgs = mock_client.chat.await_args.args[0]
+                assert len(msgs) == 1
+                assert msgs[0].content == "ping"
 
     @pytest.mark.asyncio
     async def test_llm_connection_failure(self):
@@ -768,6 +777,46 @@ class TestTestLLMConnection:
                 data = response.json()
                 assert data["success"] is False
                 assert "Connection refused" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_llm_connection_empty_content_with_model_fails(self):
+        """F2（H1 同步）：content 为空但 model 存在 → 仍视为失败（仅判 not content）。
+
+        旧逻辑 `not response.model and not response.content` 在 model 存在时会误判为
+        成功；修复后与 summary 侧一致，仅 `not content` 即失败。
+        """
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        from app.api.deps import get_current_user_flexible
+        from app.api.llm import router
+        from app.services.llm.models import ChatResponse, Usage
+
+        app = FastAPI()
+        app.include_router(router)
+
+        async def mock_auth(request=None, credentials=None):
+            return {"username": "testuser"}
+
+        app.dependency_overrides[get_current_user_flexible] = mock_auth
+
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(
+            return_value=ChatResponse(
+                content="",
+                model="gpt-4o-mini",
+                usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+            )
+        )
+
+        with patch("app.api.llm.get_llm_client", return_value=mock_client):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.post("/api/llm/test")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["success"] is False
 
 
 class TestGetLLMStats:

--- a/tests/services/llm/test_client.py
+++ b/tests/services/llm/test_client.py
@@ -624,34 +624,36 @@ class TestParamRejectionDegradation:
         assert resp.latency == 500
 
     @pytest.mark.asyncio
-    async def test_non_param_400_no_degration(
+    async def test_non_param_400_terminal_no_retry(
         self, reset_llm_singleton, mock_config, mock_log_usage
     ):
-        """非参数类 400（如 invalid_api_key）不触发降级，走普通退避重试。"""
+        """非参数类 400（如 invalid_api_key 文案）为终态——不降级、不重试、快速失败。"""
         from app.services.llm.client import LLMClient
         from app.services.llm.providers.openai_compat import OpenAICompatProvider
 
         calls = []
         mock_sleep = AsyncMock()
 
-        async def _always_bad(self, messages, **kwargs):
+        async def _always_bad(messages, **kwargs):
             calls.append(1)
-            raise self._httpx_400('{"error": "Invalid API key provided"}')
+            raise TestParamRejectionDegradation._httpx_400(
+                '{"error": "Invalid API key provided"}'
+            )
 
         provider = OpenAICompatProvider(
             api_base="https://test.api.com/v1", api_key="sk-test"
         )
-        provider.chat = _always_bad.__get__(provider, OpenAICompatProvider)
+        provider.chat = AsyncMock(side_effect=_always_bad)
 
         with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
             client = LLMClient()
             client._provider = provider
             resp = await client.chat([Message(role="user", content="Q")])
 
-        assert resp.content == ""  # 重试耗尽返回空响应
-        assert len(calls) == 3  # MAX_RETRIES=2 → 3 次尝试
-        assert provider._extras_disabled is False  # 未降级
-        assert mock_sleep.await_count == 2
+        assert resp.content == ""  # 空响应契约（不抛异常）
+        assert len(calls) == 1  # 终态：仅 1 次尝试
+        assert provider._extras_disabled is False  # 未误降级
+        assert mock_sleep.await_count == 0  # 零退避
 
 
 class TestTerminalErrorsNoRetry:
@@ -800,6 +802,47 @@ class TestTerminalErrorsNoRetry:
         assert len(calls) == 2
         assert mock_sleep.await_args.args[0] == 60  # 钳制到 60s 上限
 
+    @pytest.mark.asyncio
+    async def test_anthropic_unrelated_invalid_request_error_fast_fails(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """Anthropic 无关 invalid_request_error 400 终态快速失败——不降级、不重试、零退避。"""
+        import httpx as _h
+
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        def _raise_anthropic_400():
+            request = _h.Request("POST", "https://test.api.com/v1/messages")
+            response = _h.Response(
+                400,
+                text='{"type": "error", "error": {"type": "invalid_request_error", "message": "messages: field required"}}',
+                request=request,
+            )
+            raise _h.HTTPStatusError("Bad Request", request=request, response=response)
+
+        async def _bad(messages, **kwargs):
+            calls.append(1)
+            _raise_anthropic_400()
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk"
+        )
+        provider.chat = AsyncMock(side_effect=_bad)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            resp = await client.chat([Message(role="user", content="Q")])
+
+        assert resp.content == ""  # 空响应契约（不抛异常）
+        assert len(calls) == 1  # 终态：仅 1 次尝试
+        assert provider._extras_disabled is False  # 未误降级
+        assert mock_sleep.await_count == 0  # 零退避
+
 
 class TestParamRejectionExtended:
     """M8：Anthropic invalid_request_error / 422 网关也触发降级。"""
@@ -841,6 +884,53 @@ class TestParamRejectionExtended:
         request = _h.Request("POST", "https://test.api.com/v1")
         response = _h.Response(
             400, text='{"error": "Invalid API key"}', request=request
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is False
+        assert _is_terminal_error(e) is True
+
+    def test_anthropic_invalid_request_error_unrelated_is_not_param_rejection(self):
+        """Anthropic 无关 400（如字段缺失）不应被误判为参数拒绝。"""
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection, _is_terminal_error
+
+        request = _h.Request("POST", "https://test.api.com/v1/messages")
+        response = _h.Response(
+            400,
+            text='{"type": "error", "error": {"type": "invalid_request_error", "message": "messages: field required"}}',
+            request=request,
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is False
+        assert _is_terminal_error(e) is True
+
+    def test_anthropic_budget_tokens_compound_matches(self):
+        """Anthropic invalid_request_error + budget_tokens 关键字 → 复合判定命中参数拒绝。"""
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection
+
+        request = _h.Request("POST", "https://test.api.com/v1/messages")
+        response = _h.Response(
+            400,
+            text='{"type": "error", "error": {"type": "invalid_request_error", "message": "budget_tokens is only available when thinking is enabled"}}',
+            request=request,
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is True
+
+    def test_broad_does_not_support_unrelated_is_not_param_rejection(self):
+        """网关返回与 thinking/reasoning 无关的 'does not support' 文案不应判为参数拒绝。"""
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection, _is_terminal_error
+
+        request = _h.Request("POST", "https://gateway/v1/chat/completions")
+        response = _h.Response(
+            400,
+            text='{"error": "model does not support streaming"}',
+            request=request,
         )
         e = _h.HTTPStatusError("err", request=request, response=response)
         assert _is_param_rejection(e) is False

--- a/tests/services/llm/test_client.py
+++ b/tests/services/llm/test_client.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from app.services.llm.models import ChatResponse, Message, Usage
@@ -449,8 +450,8 @@ class TestAnthropicProviderFactory:
         assert isinstance(provider, AnthropicProvider)
         assert provider.thinking_level == "high"
 
-    def test_openai_provider_no_thinking_level(self, reset_llm_singleton):
-        """openai_compat 分支不受 thinking_level 影响（Phase 1 不改动）。"""
+    def test_openai_provider_accepts_thinking_level(self, reset_llm_singleton):
+        """Phase 2.2：双 provider 统一传 thinking_level（openai 侧映射 reasoning_effort）。"""
         from app.services.llm.client import LLMClient
         from app.services.llm.providers.openai_compat import OpenAICompatProvider
 
@@ -462,7 +463,7 @@ class TestAnthropicProviderFactory:
             client = LLMClient()
 
         assert isinstance(client._provider, OpenAICompatProvider)
-        assert not hasattr(client._provider, "thinking_level")
+        assert client._provider.thinking_level == "high"
 
     def test_unknown_provider_raises(self, reset_llm_singleton):
         """Scenario 4.2: 非法 provider 抛 ValueError 并提示支持列表。"""
@@ -538,3 +539,309 @@ class TestGetLlmClient:
         first = clients[0]
         for c in clients[1:]:
             assert c is first
+
+
+# ===================================================================
+# 方案 C：参数类 400 降级重试（checkbox2 双重保险第二道）
+# ===================================================================
+
+
+class TestParamRejectionDegradation:
+    """端点拒绝扩展参数 → provider._extras_disabled 置位 → 立即重试。"""
+
+    @staticmethod
+    def _httpx_400(text: str) -> httpx.HTTPStatusError:
+        request = httpx.Request("POST", "https://test.api.com/v1/chat/completions")
+        response = httpx.Response(400, text=text, request=request)
+        return httpx.HTTPStatusError("Bad Request", request=request, response=response)
+
+    @pytest.mark.asyncio
+    async def test_param_rejection_degrades_and_retries(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """首次 400（unrecognized argument）→ 降级标记置位 → 重试成功。"""
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls: list[dict] = []
+
+        def _flaky_chat(messages, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise TestParamRejectionDegradation._httpx_400(
+                    '{"error": "Unrecognized request argument supplied: reasoning_effort"}'
+                )
+            return ChatResponse(content="ok", model="gpt-4o", usage=None)
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk-test", thinking_level="high"
+        )
+        provider.chat = AsyncMock(side_effect=_flaky_chat)
+
+        client = LLMClient()
+        client._provider = provider
+        resp = await client.chat([Message(role="user", content="Q")])
+
+        assert resp.content == "ok"
+        assert len(calls) == 2  # 降级后立即重试，无退避
+        assert provider._extras_disabled is True
+
+    @pytest.mark.asyncio
+    async def test_param_rejection_latency_excludes_failed_attempt(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """顺手项 1：降级重试不把首次失败请求耗时计入成功 latency。
+
+        首次请求返回 400 参数拒绝（模拟耗时很长），降级重试成功；latency 应只
+        计量第二次成功请求，而非 1000s 跨度。
+        """
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+
+        def _flaky(messages, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise TestParamRejectionDegradation._httpx_400(
+                    '{"error": "Unrecognized request argument supplied: reasoning_effort"}'
+                )
+            return ChatResponse(content="ok", model="gpt-4o", usage=None)
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk-test", thinking_level="high"
+        )
+        provider.chat = AsyncMock(side_effect=_flaky)
+
+        # time.time 序列：首次尝试起点 1000 → 降级重置 2000 → 成功测得 2000.5
+        times = [1000.0, 2000.0, 2000.5, 2000.5, 2000.5]
+        with patch("app.services.llm.client.time.time", side_effect=times):
+            client = LLMClient()
+            client._provider = provider
+            resp = await client.chat([Message(role="user", content="Q")])
+
+        # 旧实现未重置 t_attempt → latency=(2000.5-1000)=1000ms；修复后=500ms
+        assert resp.latency == 500
+
+    @pytest.mark.asyncio
+    async def test_non_param_400_no_degration(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """非参数类 400（如 invalid_api_key）不触发降级，走普通退避重试。"""
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        async def _always_bad(self, messages, **kwargs):
+            calls.append(1)
+            raise self._httpx_400('{"error": "Invalid API key provided"}')
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk-test"
+        )
+        provider.chat = _always_bad.__get__(provider, OpenAICompatProvider)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            resp = await client.chat([Message(role="user", content="Q")])
+
+        assert resp.content == ""  # 重试耗尽返回空响应
+        assert len(calls) == 3  # MAX_RETRIES=2 → 3 次尝试
+        assert provider._extras_disabled is False  # 未降级
+        assert mock_sleep.await_count == 2
+
+
+class TestTerminalErrorsNoRetry:
+    """M7/M9：确定性错误（refusal/4xx）不重试；429 尊重 Retry-After。"""
+
+    @pytest.mark.asyncio
+    async def test_refusal_valueerror_no_retry(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """M7：refusal（ValueError）为终态——只尝试一次，不再退避重试。"""
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        async def _refuse(self, messages, **kwargs):
+            calls.append(1)
+            raise ValueError("模型拒绝响应: 内容违反政策")
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk"
+        )
+        provider.chat = _refuse.__get__(provider, OpenAICompatProvider)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            await client.chat([Message(role="user", content="Q")])
+
+        assert len(calls) == 1  # 不重试
+        assert mock_sleep.await_count == 0  # 无退避
+
+    @pytest.mark.asyncio
+    async def test_401_no_retry(self, reset_llm_singleton, mock_config, mock_log_usage):
+        """M9：401（密钥错误）为终态——只尝试一次。"""
+        import httpx as _h
+
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        def _raise401():
+            request = _h.Request("POST", "https://test.api.com/v1/chat/completions")
+            response = _h.Response(
+                401, text='{"error": "Invalid API key"}', request=request
+            )
+            raise _h.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        async def _bad(self, messages, **kwargs):
+            calls.append(1)
+            _raise401()
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk"
+        )
+        provider.chat = _bad.__get__(provider, OpenAICompatProvider)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            await client.chat([Message(role="user", content="Q")])
+
+        assert len(calls) == 1
+        assert mock_sleep.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_429_respects_retry_after(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """M9：429 尊重 Retry-After（5s）→ 退避 5s 重试。"""
+        import httpx as _h
+
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        async def _limited(self, messages, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                request = _h.Request("POST", "https://test.api.com/v1/chat/completions")
+                response = _h.Response(
+                    429,
+                    text="rate limited",
+                    request=request,
+                    headers={"Retry-After": "5"},
+                )
+                raise _h.HTTPStatusError("Too Many", request=request, response=response)
+            return ChatResponse(content="ok", model="m", usage=None)
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk"
+        )
+        provider.chat = _limited.__get__(provider, OpenAICompatProvider)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            resp = await client.chat([Message(role="user", content="Q")])
+
+        assert resp.content == "ok"
+        assert len(calls) == 2
+        assert mock_sleep.await_args.args[0] == 5  # Retry-After 优先
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_capped_at_60(
+        self, reset_llm_singleton, mock_config, mock_log_usage
+    ):
+        """顺手项 2：429 Retry-After 超大值被钳制到 60s，避免请求长时间挂起。"""
+        import httpx as _h
+
+        from app.services.llm.client import LLMClient
+        from app.services.llm.providers.openai_compat import OpenAICompatProvider
+
+        calls = []
+        mock_sleep = AsyncMock()
+
+        async def _limited(self, messages, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                request = _h.Request("POST", "https://test.api.com/v1/chat/completions")
+                response = _h.Response(
+                    429,
+                    text="rate limited",
+                    request=request,
+                    headers={"Retry-After": "9999"},
+                )
+                raise _h.HTTPStatusError("Too Many", request=request, response=response)
+            return ChatResponse(content="ok", model="m", usage=None)
+
+        provider = OpenAICompatProvider(
+            api_base="https://test.api.com/v1", api_key="sk"
+        )
+        provider.chat = _limited.__get__(provider, OpenAICompatProvider)
+
+        with patch("app.services.llm.client.asyncio.sleep", mock_sleep):
+            client = LLMClient()
+            client._provider = provider
+            resp = await client.chat([Message(role="user", content="Q")])
+
+        assert resp.content == "ok"
+        assert len(calls) == 2
+        assert mock_sleep.await_args.args[0] == 60  # 钳制到 60s 上限
+
+
+class TestParamRejectionExtended:
+    """M8：Anthropic invalid_request_error / 422 网关也触发降级。"""
+
+    def test_anthropic_text_422_matches(self):
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection
+
+        request = _h.Request("POST", "https://test.api.com/v1/messages")
+        response = _h.Response(
+            400,
+            text='{"type": "error", "error": {"type": "invalid_request_error", "message": "does not support thinking"}}',
+            request=request,
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is True
+
+    def test_422_gateway_matches(self):
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection
+
+        request = _h.Request("POST", "https://gateway/v1/chat/completions")
+        response = _h.Response(
+            422,
+            text='{"detail": "extra fields not permitted"}',
+            request=request,
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is True
+
+    def test_terminal_400_not_param(self):
+        """普通 400（API key 无效）不是参数拒绝、是终态错误。"""
+        import httpx as _h
+
+        from app.services.llm.client import _is_param_rejection, _is_terminal_error
+
+        request = _h.Request("POST", "https://test.api.com/v1")
+        response = _h.Response(
+            400, text='{"error": "Invalid API key"}', request=request
+        )
+        e = _h.HTTPStatusError("err", request=request, response=response)
+        assert _is_param_rejection(e) is False
+        assert _is_terminal_error(e) is True

--- a/tests/services/llm/test_provider_openai_compat.py
+++ b/tests/services/llm/test_provider_openai_compat.py
@@ -282,3 +282,151 @@ class TestOpenAICompatProviderChat:
 
         # 在 `async with` 内部，__aexit__ 应调用 aclose
         mock_client.aclose.assert_awaited_once()
+
+
+class TestOpenAICompatBuildRequest:
+    """Phase 2.2：_build_request / _to_wire_message / reasoning_effort 映射。"""
+
+    def _provider(self, thinking_level="off", model="gpt-4o-mini"):
+        return OpenAICompatProvider(
+            api_base="https://api.openai.com/v1",
+            api_key="sk-test",
+            model=model,
+            thinking_level=thinking_level,
+        )
+
+    def test_basic_request_shape(self):
+        body = self._provider()._build_request([Message(role="user", content="Q")])
+        assert body["model"] == "gpt-4o-mini"
+        assert body["messages"] == [{"role": "user", "content": "Q"}]
+        assert "reasoning_effort" not in body  # off 不传 = 现状行为
+
+    def test_content_block_list_flattens_text_blocks(self):
+        from app.services.llm.models import TextBlock
+
+        msg = Message(
+            role="system",
+            content=[TextBlock(text="第一段"), TextBlock(text="第二段")],
+        )
+        wire = self._provider()._to_wire_message(msg)
+        assert wire["content"] == "第一段\n\n第二段"
+
+    @pytest.mark.parametrize(
+        "level,expected", [("low", "low"), ("medium", "medium"), ("high", "high")]
+    )
+    def test_reasoning_effort_o_series(self, level, expected):
+        provider = self._provider(thinking_level=level, model="o4-mini")
+        assert provider._reasoning_effort(level, "o4-mini") == expected
+        body = provider._build_request([Message(role="user", content="Q")])
+        assert body["reasoning_effort"] == expected
+
+    def test_reasoning_effort_non_o_series_ignored(self):
+        provider = self._provider(thinking_level="high", model="gpt-4o-mini")
+        assert provider._reasoning_effort("high", "gpt-4o-mini") is None
+        body = provider._build_request([Message(role="user", content="Q")])
+        assert "reasoning_effort" not in body
+
+    def test_reasoning_effort_kwargs_override(self):
+        provider = self._provider(thinking_level="off", model="o3")
+        body = provider._build_request(
+            [Message(role="user", content="Q")], thinking_level="medium"
+        )
+        assert body["reasoning_effort"] == "medium"
+
+
+class TestOpenAICompatParseResponse:
+    """Phase 2.2：_parse_response（含 refusal / 缺省字段）。"""
+
+    def test_refusal_raises(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1", api_key="sk-test"
+        )
+        with pytest.raises(ValueError, match="模型拒绝响应"):
+            provider._parse_response(
+                {"choices": [{"message": {"content": None, "refusal": "不行"}}]}
+            )
+
+    def test_missing_usage_and_model_defaults(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1", api_key="sk-test"
+        )
+        resp = provider._parse_response({"choices": [{"message": {}}]})
+        assert resp.content == ""
+        assert resp.usage is None
+
+
+class TestReasoningTemperatureAlignment:
+    """H3：o 系列发 reasoning_effort 时 temperature 强制 1（与 Anthropic 侧对齐），
+    避免推理模型对非 1 temperature 的硬 400。"""
+
+    def test_o_series_forces_temperature_one(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1",
+            api_key="sk-test",
+            model="o4-mini",
+            thinking_level="high",
+        )
+        body = provider._build_request([Message(role="user", content="Q")])
+        assert body["reasoning_effort"] == "high"
+        assert body["temperature"] == 1  # 硬 400 修复点
+
+    def test_non_o_series_keeps_configured_temperature(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1",
+            api_key="sk-test",
+            model="gpt-4o-mini",
+            temperature=0.7,
+            thinking_level="off",
+        )
+        body = provider._build_request([Message(role="user", content="Q")])
+        assert body["temperature"] == 0.7
+
+    def test_o_series_user_temperature_overridden(self):
+        """用户显式传 temperature=0.2 也被强制为 1（推理模型不接受非 1）。"""
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1",
+            api_key="sk-test",
+            model="o3",
+            thinking_level="low",
+        )
+        body = provider._build_request(
+            [Message(role="user", content="Q")], temperature=0.2
+        )
+        assert body["temperature"] == 1
+
+
+class TestFinishReasonMapping:
+    """M10：OpenAI finish_reason → stop_reason（与 Anthropic 对齐，供 P4 截断判断）。"""
+
+    def test_finish_reason_stop_mapped(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1", api_key="sk-test"
+        )
+        resp = provider._parse_response(
+            {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "model": "gpt-4o-mini",
+            }
+        )
+        assert resp.stop_reason == "stop"
+
+    def test_finish_reason_length_mapped(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1", api_key="sk-test"
+        )
+        resp = provider._parse_response(
+            {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "length"}],
+                "model": "gpt-4o-mini",
+            }
+        )
+        assert resp.stop_reason == "length"
+
+    def test_missing_finish_reason_defaults_empty(self):
+        provider = OpenAICompatProvider(
+            api_base="https://api.openai.com/v1", api_key="sk-test"
+        )
+        resp = provider._parse_response(
+            {"choices": [{"message": {"content": "ok"}}], "model": "gpt-4o-mini"}
+        )
+        assert resp.stop_reason == ""


### PR DESCRIPTION

### 变更类型
🚀 重构 refactor

### 变更内容
本次 PR 为 LLM 客户端与双 Provider 增加**健壮性与能力对齐**，是后续「记忆上下文 / Agent 化」的前置基础设施：

**1. 参数类 400 降级重试（方案C，双重保险）**
- `LLMClient` 识别参数类 400（`unrecognized/unknown parameter/unexpected keyword/invalid request argument/extra fields not permitted` 等）→ 置位 provider 的 `_extras_disabled` → 立即重试一次（不计入 MAX_RETRIES 退避）→ 实例生命周期内不再发送 thinking/reasoning 扩展字段。
- 兼容第三方网关对未知参数的严格 400（OpenAI 严格、Anthropic 同样严格、DeepSeek/Ollama 宽松忽略——客户端按最严格情形兜底）。

**2. 终态错误不重试 + 429 尊重 Retry-After**
- 终态 4xx / refusal（openai 的 `ValueError`）不再重试；`429` 优先尊重 `Retry-After`（上限 60s），超时快速重试一次。

**3. OpenAI 兼容 Provider 能力对齐**
- `thinking_level → reasoning_effort` 三档映射（`off` 不传字段，仅 `^o\d` 模型生效，非 o 系列 warning 忽略），与 Anthropic extended thinking 对齐。
- o 系列启用 reasoning 时强制 `temperature=1`（对齐 Anthropic budget 语义）。
- `finish_reason → stop_reason` 采集（对齐 Anthropic 侧，供 Agent 循环消费）。
- refusal 显式抛出为终态；content 为 `list[ContentBlock]` 时取 text block 拼接。

**4. Anthropic 侧修正**
- haiku 降级判断由 `startswith` 改为**包含匹配**（兼容 `anthropic/claude-haiku-...` 网关带前缀模型名）。

**5. 连通性测试降延迟 + 配置页 LLM 卡片注释悬浮化**
- `POST /api/llm/test` 改为简单 ping（`max_tokens=8` + 固定文案，短回复截停无展示价值），空内容判定与 summary 侧对齐（仅 `not content` 即失败）。
- `_llm.html`：LLM 卡片 3 处注释改为问号 tooltip（API 地址/思考强度/安全提示），移除 `<small class="text-muted">` 平铺。
- `api-utils.js`：新增 `apiErrorMessage` 统一错误归一化（detail 字符串/数组/对象兜底）。
- `configuration.md`：thinking_level 双 provider 映射文档对齐。

### 相关 Issue
无（前置基础设施，为后续记忆/Agent 功能铺路）

## 🔍 额外说明
- 无运行时依赖变更（`requirements.txt`/`uv.lock` 未动）。
- 全量测试：**3522 passed**（`tests/services/llm/*` + `tests/api/test_summary.py` LLM 部分 + `tests/api/test_config_page_comments.py` LLM 卡片部分）；Ruff check + format 全绿。
- 本分支基于最新 `main`（含 #235 anthropic 支持），为**纯增量增强**，存量行为零变化。

## Checklist
- [x] 行为由既有配置驱动，无破坏性变更
- [x] 测试通过（3522 passed）+ Ruff 全绿
- [x] `requirements.txt` 未动