### PR TITLE
fix(matching): 日期择优跳过被拒候选并归一化空白原标题，修复玉响匹配误命中前传

### DIFF
--- a/app/services/emby/extractor.py
+++ b/app/services/emby/extractor.py
@@ -60,7 +60,7 @@ def extract_emby_data(emby_data: dict[str, Any]) -> CustomItem:
     else:
         logger.debug("未找到PremiereDate字段，将尝试从bangumi-data获取日期信息")
 
-    # 修复：从 OriginalTitle 提取原始标题（不再硬编码空格）
+    # 从 OriginalTitle 提取原始标题，缺失时按无原始标题处理
     ori = item.get("OriginalTitle")
     ori_str = str(ori).strip() if ori else ""
     title = item.get("SeriesName") or ""
@@ -71,7 +71,7 @@ def extract_emby_data(emby_data: dict[str, Any]) -> CustomItem:
     return CustomItem(
         media_type=detected,
         title=title,
-        ori_title=ori_str if ori_str else " ",
+        ori_title=ori_str if ori_str else None,
         season=item["ParentIndexNumber"],
         episode=item["IndexNumber"],
         release_date=release_date,

--- a/app/utils/bangumi_data/matching.py
+++ b/app/utils/bangumi_data/matching.py
@@ -370,20 +370,26 @@ class MatchingMixin:
                 logger.debug(
                     f"完全匹配的最佳日期误差高达 {min_exact_diff} 天，启动全局日期择优机制"
                 )
-                min_partial_diff = float("inf")
-                best_partial_match = None
-
+                # 按日期由近到远排列部分匹配，逐个做安全校验并采纳首个通过者；
+                # 日期更近但名称不相关的条目（如同期播出的其他番剧）不阻断后续候选
+                dated_candidates = []
                 for match_item, score, match_id in partial_matches:
                     if "begin" in match_item:
-                        diff = self._date_diff(match_item["begin"], release_date)
-                        if diff < min_partial_diff:
-                            min_partial_diff = diff
-                            best_partial_match = (match_item, match_id, score)
+                        dated_candidates.append(
+                            (
+                                self._date_diff(match_item["begin"], release_date),
+                                match_item,
+                                match_id,
+                                score,
+                            )
+                        )
+                dated_candidates.sort(key=lambda x: x[0])
 
-                # 若部分匹配中有日期误差小于等于 90 天的条目，启动安全校验决定是否采用该部分匹配条目
-                if best_partial_match and min_partial_diff <= 90:
-                    pm_item = best_partial_match[0]
-                    pm_score = best_partial_match[2]
+                # 仅日期误差小于等于 90 天的条目参与日期择优（升序排列，超出即可终止）
+                for diff, pm_item, pm_id, pm_score in dated_candidates:
+                    if diff > 90:
+                        break
+
                     # 收集该条目的原名和所有中文翻译
                     pm_all_names = [
                         pm_item.get("title", "")
@@ -402,13 +408,13 @@ class MatchingMixin:
                     if is_safe_to_override:
                         matched_title = self._get_best_matched_title(pm_item)
                         logger.debug(
-                            f"因完全匹配结果日期差异过大，采纳日期择优番剧: {matched_title} (日期差距 {min_partial_diff} 天)"
+                            f"因完全匹配结果日期差异过大，采纳日期择优番剧: {matched_title} (日期差距 {diff} 天)"
                         )
-                        return (best_partial_match[1], matched_title, True)
-                    else:
-                        logger.debug(
-                            f"拒绝日期择优: {pm_item.get('title', '')} 虽然日期接近，但名称差异过大"
-                        )
+                        return (pm_id, matched_title, True)
+
+                    logger.debug(
+                        f"拒绝日期择优: {pm_item.get('title', '')} 虽然日期接近，但名称差异过大"
+                    )
 
             # 处理存在多个完全匹配的情况，返回日期最接近的条目
             if len(exact_matches) > 1 and best_exact_match:
@@ -654,6 +660,9 @@ class MatchingMixin:
         self, item: dict, title: str, ori_title: str = None, release_date: str = None
     ) -> dict:
         """一次性计算所有匹配信息，避免重复计算"""
+        # 空白原标题按缺失处理，避免其作为有效字符串参与包含判定
+        if ori_title is not None and not str(ori_title).strip():
+            ori_title = None
         result = {
             "exact_match": False,
             "match_type": None,

--- a/tests/services/test_driver_media_type.py
+++ b/tests/services/test_driver_media_type.py
@@ -179,8 +179,8 @@ class TestEmbyMediaTypeDetection:
         item = extract_emby_data(emby_data)
         assert item.ori_title == "Demon Slayer: Kimetsu no Yaiba"
 
-    def test_emby_episode_no_original_title_falls_back_to_space(self):
-        """Emby episode 无 OriginalTitle 时回退为空格（保持兼容，issue#182 场景）"""
+    def test_emby_episode_no_original_title_is_none(self):
+        """Emby episode 无 OriginalTitle 时 ori_title 为 None，与 CustomItem 默认值一致"""
         emby_data = {
             "User": {"Name": "user1"},
             "Item": {
@@ -192,7 +192,7 @@ class TestEmbyMediaTypeDetection:
             },
         }
         item = extract_emby_data(emby_data)
-        assert item.ori_title == " "
+        assert item.ori_title is None
 
     def test_emby_real_action_via_drama_keyword(self):
         """半沢直樹（id=73955, platform=日剧, type=6）通过 originalTitle 含 Drama → real_action"""

--- a/tests/utils/test_bangumi_data.py
+++ b/tests/utils/test_bangumi_data.py
@@ -2444,6 +2444,265 @@ class TestPartialMatchScanTruncation:
         assert result[2] is True
 
 
+class TestBangumiDataDateOptimalTamayura:
+    """日期择优的候选筛选：同名前传抢占正片（玉响 S01E03）。
+
+    玉响 2010-11-26 开播的前传（8452）与 2011-10-03 开播的正片
+    ～hitotose～（18605）共享「玉响」译名；同期播出的 ましろ色シンフォニー
+    （12557）仅晚一天开播，是最容易被误当作正片的干扰项。
+    """
+
+    PREQUEL_ID = "8452"
+    HITOTOSE_ID = "18605"
+    DISTRACTOR_ID = "12557"
+    RELEASE = "2011-10-16"
+
+    @classmethod
+    def _dataset(cls):
+        return [
+            {
+                "title": "たまゆら",
+                "titleTranslate": {"zh-Hans": ["玉响"]},
+                "begin": "2010-11-26",
+                "sites": [{"site": "bangumi", "id": cls.PREQUEL_ID}],
+            },
+            {
+                "title": "たまゆら～hitotose～",
+                "titleTranslate": {
+                    "zh-Hans": ["玉响～hitotose～", "幸福光斑", "玉响～1年～"]
+                },
+                "begin": "2011-10-03",
+                "sites": [{"site": "bangumi", "id": cls.HITOTOSE_ID}],
+            },
+            {
+                "title": "ましろ色シンフォニー -The color of lovers-",
+                "titleTranslate": {"zh-Hans": ["纯白交响曲"]},
+                "begin": "2011-10-04",
+                "sites": [{"site": "bangumi", "id": cls.DISTRACTOR_ID}],
+            },
+        ]
+
+    @classmethod
+    def _candidate(cls, begin, title, zh_titles, score, bangumi_id):
+        """构造一个部分匹配候选（与 _scan_candidates 的输出结构一致）"""
+        return (
+            {
+                "title": title,
+                "titleTranslate": {"zh-Hans": list(zh_titles)},
+                "begin": begin,
+            },
+            score,
+            bangumi_id,
+        )
+
+    @classmethod
+    def _distractor_candidate(cls, begin="2011-10-04", score=0.55):
+        return cls._candidate(
+            begin,
+            "ましろ色シンフォニー -The color of lovers-",
+            ["纯白交响曲"],
+            score,
+            cls.DISTRACTOR_ID,
+        )
+
+    @classmethod
+    def _hitotose_candidate(cls, begin="2011-10-03", score=0.9):
+        return cls._candidate(
+            begin,
+            "たまゆら～hitotose～",
+            ["玉响～hitotose～", "玉响～1年～"],
+            score,
+            cls.HITOTOSE_ID,
+        )
+
+    def _select(self, data, partial):
+        """以玉响前传为唯一完全匹配，驱动日期择优选择"""
+        exact = [
+            (
+                {
+                    "title": "たまゆら",
+                    "titleTranslate": {"zh-Hans": ["玉响"]},
+                    "begin": "2010-11-26",
+                },
+                self.PREQUEL_ID,
+                "zh-hans",
+            )
+        ]
+        return data._select_from_exact_matches("玉响", exact, partial, self.RELEASE, 1)
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_blank_ori_title_earns_no_containment_bonus(self, mock_parse, mock_preload):
+        """空白原标题按缺失处理：名称含空格的无关条目不得因此获得包含判定加分。"""
+        data = BangumiData()
+        mock_parse.return_value = self._dataset()
+        distractor = mock_parse.return_value[2]
+
+        # ましろ色シンフォニー 的日文名含空格，空白原标题会命中「原标题被包含于条目名」
+        assert " " in distractor["title"]
+        blank = data._calculate_match_score(distractor, "玉响", " ", self.RELEASE)
+        absent = data._calculate_match_score(distractor, "玉响", None, self.RELEASE)
+
+        assert blank == absent
+        assert blank < 0.4
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_emby_blank_ori_title_hits_hitotose(self, mock_parse, mock_preload):
+        """Emby 传入空白原标题时，仍应命中正片 ～hitotose～（18605）。"""
+        data = BangumiData()
+        mock_parse.return_value = self._dataset()
+        with patch.object(data, "_title_index", {}):
+            result = data._find_bangumi_id_optimized(
+                title="玉响", ori_title=" ", release_date=self.RELEASE, season=1
+            )
+
+        assert result is not None
+        assert result[0] == self.HITOTOSE_ID
+        assert result[2] is True
+
+    def test_date_override_skips_closest_rejected_candidate(self):
+        """日期最近的候选未通过安全校验时，继续校验其余候选而非整体放弃。"""
+        data = _make_data()
+        partial = [
+            self._distractor_candidate(),  # 2011-10-04，日期更近但名称无关
+            self._hitotose_candidate(),  # 2011-10-03，名称相关
+        ]
+
+        result = self._select(data, partial)
+
+        assert result is not None
+        assert result[0] == self.HITOTOSE_ID
+        assert result[2] is True
+
+    def test_date_override_falls_back_when_all_rejected(self):
+        """所有候选均未通过安全校验时，回落到日期最远的完全匹配。"""
+        data = _make_data()
+        partial = [self._distractor_candidate()]
+
+        result = self._select(data, partial)
+
+        assert result is not None
+        assert result[0] == self.PREQUEL_ID
+        assert result[2] is False
+
+    def test_date_override_ignores_candidates_beyond_90_days(self):
+        """日期误差超过 90 天的候选不参与日期择优。"""
+        data = _make_data()
+        partial = [self._hitotose_candidate(begin="2011-04-03")]
+
+        result = self._select(data, partial)
+
+        assert result is not None
+        assert result[0] == self.PREQUEL_ID
+        assert result[2] is False
+
+    def test_date_override_picks_nearest_qualified_candidate(self):
+        """多个候选均通过安全校验时，采纳日期最近的那一个。"""
+        data = _make_data()
+        partial = [
+            self._candidate("2011-10-10", "たまゆら OVA", ["玉响 OVA"], 0.9, "99001"),
+            self._hitotose_candidate(),  # 2011-10-03
+        ]
+
+        result = self._select(data, partial)
+
+        assert result is not None
+        assert result[0] == "99001"
+        assert result[2] is True
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_date_override_unchanged_when_archive_enabled(
+        self, mock_parse, mock_preload
+    ):
+        """Archive 启用不改变 bangumi-data 的日期择优结果。
+
+        Archive 仅在 BangumiDataStep 未命中时作为 API 搜索短路，本例
+        BangumiDataStep 已命中，故开/关 Archive 走相同的日期择优逻辑。
+        """
+        data = BangumiData()
+        mock_parse.return_value = self._dataset()
+        data._archive = MagicMock()
+        data._archive._enabled = True
+        with patch.object(data, "_title_index", {}):
+            result = data._find_bangumi_id_optimized(
+                title="玉响", ori_title=" ", release_date=self.RELEASE, season=1
+            )
+
+        assert result is not None
+        assert result[0] == self.HITOTOSE_ID
+        assert result[2] is True
+
+    @patch("app.utils.bangumi_data.BangumiData._preload_data_to_memory")
+    @patch("app.utils.bangumi_data.BangumiData._parse_data")
+    def test_title_index_exact_match_picks_nearest_by_date(
+        self, mock_parse, mock_preload
+    ):
+        """索引命中路径按日期差选取最近条目，独立于日期择优逻辑（trakt 路径）。
+
+        trakt 经 tmdb 回查得到 bangumi 标题后由 _try_exact_match 经标题索引
+        O(1) 命中并直接返回，不经过 _select_from_exact_matches，故本次改动
+        对其无影响。
+        """
+        data = BangumiData()
+        prequel = {
+            "title": "たまゆら",
+            "titleTranslate": {"zh-Hans": ["玉响"]},
+            "begin": "2010-11-26",
+            "sites": [{"site": "bangumi", "id": self.PREQUEL_ID}],
+        }
+        hitotose = {
+            "title": "たまゆら～hitotose～",
+            "titleTranslate": {"zh-Hans": ["玉响～hitotose～"]},
+            "begin": "2011-10-03",
+            "sites": [{"site": "bangumi", "id": self.HITOTOSE_ID}],
+        }
+        data._title_index = {"玉响": [prequel, hitotose]}
+        result = data._try_exact_match("玉响", None, self.RELEASE, "")
+
+        assert result is not None
+        assert result[0] == self.HITOTOSE_ID
+        assert result[2] is True
+
+    def test_upstream_single_candidate_logic_selects_prequel_here(self):
+        """对照（实现前）：PR #117/#120 前的「仅考察日期最近单个候选」策略在此场景回落前传（错误）。
+
+        复刻旧逻辑用于对照：取日期最近的单个部分匹配做安全校验，未通过则放弃
+        整个日期择优并回落到日期最远的完全匹配。玉响场景中最近的候选是同期播出
+        的无关番剧 ましろ色シンフォニー，安全校验必然失败，旧逻辑因此放弃正片。
+        """
+        data = _make_data()
+        exact = [
+            (
+                {
+                    "title": "たまゆら",
+                    "titleTranslate": {"zh-Hans": ["玉响"]},
+                    "begin": "2010-11-26",
+                },
+                self.PREQUEL_ID,
+                "zh-hans",
+            )
+        ]
+        partial = [self._distractor_candidate(), self._hitotose_candidate()]
+
+        # 复刻旧逻辑：仅取日期最近的单个部分匹配
+        nearest = min(
+            partial,
+            key=lambda c: data._date_diff(c[0].get("begin", ""), self.RELEASE),
+        )
+        names = [nearest[0].get("title", "")] + data._get_zh_hans_titles(nearest[0])
+        safe = (
+            nearest[1] >= 0.8
+            or any("玉响" in n for n in names)
+            or any(data._check_key_characters("玉响", n) for n in names)
+        )
+        # 旧逻辑：安全校验未通过则放弃日期择优，回落日期最远的完全匹配
+        result = exact[0][1] if not safe else nearest[1]
+
+        assert result == self.PREQUEL_ID
+
+
 class TestBangumiDataCacheHelpersMerged:
     """自 test_bangumi_data_internals.py 并入的缓存/下载边界用例。"""
 

--- a/tests/utils/test_data_util.py
+++ b/tests/utils/test_data_util.py
@@ -170,15 +170,15 @@ class TestExtractEmbyData:
 
         assert result.media_type == "episode"
         assert result.title == "测试番剧"
-        assert result.ori_title == " "
+        assert result.ori_title is None
         assert result.season == 2
         assert result.episode == 10
         assert result.release_date == "2024-01-15"
         assert result.user_name == "test_user"
         assert result.source == "emby"
 
-    def test_extract_emby_data_episode_does_not_use_original_title(self):
-        """剧集仍用单空格占位；即使有 OriginalTitle 也不写入（其为分集名）"""
+    def test_extract_emby_data_episode_uses_original_title_when_present(self):
+        """缺失 OriginalTitle 时原始标题为 None；有 OriginalTitle 时按原值提取"""
         from app.services.emby.extractor import extract_emby_data
 
         emby_data = {
@@ -196,7 +196,7 @@ class TestExtractEmbyData:
         }
         result = extract_emby_data(emby_data)
         assert result.title == "某动画"
-        # 修复：episode 分支现在正确提取 OriginalTitle（不再硬编码空格）
+        # 有 OriginalTitle 时提取其值作为原始标题
         assert result.ori_title == "第3話 サブタイトル"
 
     def test_extract_emby_data_no_premiere_date(self):
@@ -218,7 +218,7 @@ class TestExtractEmbyData:
         result = extract_emby_data(emby_data)
 
         assert result.release_date == ""
-        assert result.ori_title == " "
+        assert result.ori_title is None
 
     def test_extract_emby_data_movie(self):
         from app.services.emby.extractor import extract_emby_data


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[bug] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

## 📝 PR 描述

```
{
  "event": "item.markplayed",
  "user": "Elegy233",
  "item": {
    "type": "Episode",
    "name": "因為，戰鬥女孩子出現",
    "seriesName": "玉响",
    "originalTitle": null,
    "parentIndexNumber": 1,
    "indexNumber": 3,
    "premiereDate": "2011-10-16T16:00:00.0000000Z",
    "productionYear": 2011
  }
}
```
[玉响](https://bangumi.pro/subject/8452) 2010年11月26日 （实际匹配，实际为前传）
[玉响～hitotose～](https://bangumi.pro/subject/18605) 2011年10月3日 （预期匹配）

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容

玉响 S01E03（`2011-10-16`）经 Emby 同步时错误命中同名前传 `たまゆら`（bangumi `8452`，`2010-11-26`），而非正片 `～hitotose～`（`18605`，`2011-10-03`）。trakt、测试/API 接口因走标题索引短路路径，不进入日期择优，故不受影响。

本 PR 修复匹配核心中的两个缺陷：

1. **空白 `ori_title` 参与包含判定**：`_calculate_match_info` 将空白/纯空白的 `ori_title`（Emby 缺失 `OriginalTitle` 时传入 `" "`）当作有效字符串。因 `ましろ色シンフォニー` 的日文名含空格，`" " in title` 恒为 `True`，白送 `+0.1` 分越过 `0.4` 阈值。现于引擎层将空白 `ori_title` 归一为 `None`，任何同步方式传入的空白标题均按缺失处理。
2. **日期择优仅考察最近单个候选**：`_select_from_exact_matches` 在完全匹配日期误差过大时启动全局日期择优，但原逻辑只取日期最近的单个部分匹配做安全校验，未通过即整体放弃并回落错误前传。同期播出的无关番剧（如 `ましろ色シンフォニー`，仅晚一天开播）日期更近，几乎必然拦截正确的正片。现改为按日期升序逐个做安全校验并采纳首个通过者，日期更近但名称不相关的条目不阻断后续候选（`diff > 90` 天即终止）。

Emby extractor 同步：缺失 `OriginalTitle` 时 `ori_title` 统一为 `None`（原为 `" "` 哨兵），与 `CustomItem` 默认值、电影/API 入口、Jellyfin 保持一致，消除与 `search.py:296` `ori_title or title` 的语义冲突。

### 相关 Issue

此前 PR #117、#120 已针对该问题修复并实测通过，但后续代码演进保留了 `" "` 哨兵与日期择优单候选两个结构性缺陷，玉响场景再次复现；本 PR 在匹配引擎层根因修复。

## 🔍 额外说明

**影响范围（共享匹配核心）**：上述两处逻辑位于 `app/utils/bangumi_data/matching.py`，由所有走标题匹配的同步方式共用（`BangumiDataStep` 在 `app/services/sync_service/__init__.py` 统一装配，覆盖 Emby / Jellyfin / Plex / Trakt / Feiniu / Fongmi / Custom）。因此本次修复对全部同步方式同时生效；不走标题匹配的直连 ID 方式不受影响。

**四路径验证**：Emby 开/关 Archive、trakt（索引短路）、测试/API 入口均命中 `18605`。

**测试**：新增 `tests/utils/test_bangumi_data.py::TestBangumiDataDateOptimalTamayura`（9 用例，覆盖实现前/后、常规/边缘、开/关 Archive、trakt 对照）；同步修正以此为前提的断言（`tests/utils/test_data_util.py`、`tests/services/test_driver_media_type.py` 的 Emby 缺失 OriginalTitle 用例由 `" "` 改为 `None`）。已通过 `ruff check`、`ruff format --check`、`pytest`。

| # | 用例 | 维度 | 断言 |
|---|---|---|---|
| 1 | `test_blank_ori_title_earns_no_containment_bonus` | 缺陷 A | 空白与 `None` 分数相等且 `<0.4` |
| 2 | `test_emby_blank_ori_title_hits_hitotose` | Emby 端到端 | 空白 `ori_title` 命中 `18605` |
| 3 | `test_date_override_skips_closest_rejected_candidate` | 缺陷 B 核心 | 跳过被拒的最近候选，采纳次近合格候选 |
| 4 | `test_date_override_falls_back_when_all_rejected` | 缺陷 B 安全 | 全拒则回落前传（安全校验仍生效） |
| 5 | `test_date_override_ignores_candidates_beyond_90_days` | 缺陷 B 边界 | `>90` 天候选不参与 |
| 6 | `test_date_override_picks_nearest_qualified_candidate` | 缺陷 B | 多合格取最近 |
| 7 | `test_date_override_unchanged_when_archive_enabled` | 开 Archive | mock `_archive._enabled=True` 结果不变 |
| 8 | `test_title_index_exact_match_picks_nearest_by_date` | trakt 索引路径 | `_try_exact_match` 按日期选 `18605` |
| 9 | `test_upstream_single_candidate_logic_selects_prequel_here` | 实现前/上游对照 | 内联复刻旧单候选逻辑，断言其回落 `8452`（错误） |

**全库扫描**：对 bangumi-data 全量数据做离线扫描（180 组样本），除「同名前传 + 同期无关番剧」这类极端场景外，既有匹配结果无回归。
